### PR TITLE
udhcp: Option 150(TFTP server IP) does not work properly. (updated)

### DIFF
--- a/patches/busybox/dhcp-additional-options.patch
+++ b/patches/busybox/dhcp-additional-options.patch
@@ -7,7 +7,7 @@ Enable the send/receive of additional DHCP options:
   DHCP_DEFAULT_URL
 
 diff --git a/networking/udhcp/common.c b/networking/udhcp/common.c
-index ae0e0d3..328897b 100644
+index ae0e0d3..552dbe1 100644
 --- a/networking/udhcp/common.c
 +++ b/networking/udhcp/common.c
 @@ -26,7 +26,7 @@ const struct dhcp_optflag dhcp_optflags[] = {
@@ -27,7 +27,7 @@ index ae0e0d3..328897b 100644
  	{ OPTION_IP | OPTION_LIST                 , 0x2c }, /* DHCP_WINS_SERVER   */
  	{ OPTION_U32                              , 0x33 }, /* DHCP_LEASE_TIME    */
  	{ OPTION_IP                               , 0x36 }, /* DHCP_SERVER_ID     */
-@@ -51,13 +52,16 @@ const struct dhcp_optflag dhcp_optflags[] = {
+@@ -51,18 +52,22 @@ const struct dhcp_optflag dhcp_optflags[] = {
  //TODO: must be combined with 'sname' and 'file' handling:
  	{ OPTION_STRING_HOST                      , 0x42 }, /* DHCP_TFTP_SERVER_NAME */
  	{ OPTION_STRING                           , 0x43 }, /* DHCP_BOOT_FILE     */
@@ -44,7 +44,13 @@ index ae0e0d3..328897b 100644
  #if ENABLE_FEATURE_UDHCP_8021Q
  	{ OPTION_U16                              , 0x84 }, /* DHCP_VLAN_ID       */
  	{ OPTION_U8                               , 0x85 }, /* DHCP_VLAN_PRIORITY */
-@@ -95,7 +99,7 @@ const char dhcp_option_strings[] ALIGN1 =
+ #endif
+ 	{ OPTION_6RD                              , 0xd4 }, /* DHCP_6RD           */
++	{ OPTION_IP                               , 0x96 }, /* DHCP_TFTP_SERVER_IP */
+ 	{ OPTION_STATIC_ROUTES | OPTION_LIST      , 0xf9 }, /* DHCP_MS_STATIC_ROUTES */
+ 	{ OPTION_STRING                           , 0xfc }, /* DHCP_WPAD          */
+ 
+@@ -95,7 +100,7 @@ const char dhcp_option_strings[] ALIGN1 =
  //	"timesrv" "\0"     /* DHCP_TIME_SERVER    */
  //	"namesrv" "\0"     /* DHCP_NAME_SERVER    */
  	"dns" "\0"         /* DHCP_DNS_SERVER     */
@@ -53,7 +59,7 @@ index ae0e0d3..328897b 100644
  //	"cookiesrv" "\0"   /* DHCP_COOKIE_SERVER  */
  	"lprsrv" "\0"      /* DHCP_LPR_SERVER     */
  	"hostname" "\0"    /* DHCP_HOST_NAME      */
-@@ -110,13 +114,16 @@ const char dhcp_option_strings[] ALIGN1 =
+@@ -110,13 +115,16 @@ const char dhcp_option_strings[] ALIGN1 =
  	"nisdomain" "\0"   /* DHCP_NIS_DOMAIN     */
  	"nissrv" "\0"      /* DHCP_NIS_SERVER     */
  	"ntpsrv" "\0"      /* DHCP_NTP_SERVER     */
@@ -70,7 +76,7 @@ index ae0e0d3..328897b 100644
  #if ENABLE_FEATURE_UDHCP_RFC3397
  	"search" "\0"      /* DHCP_DOMAIN_SEARCH  */
  // doesn't work in udhcpd.conf since OPTION_SIP_SERVERS
-@@ -124,6 +131,7 @@ const char dhcp_option_strings[] ALIGN1 =
+@@ -124,11 +132,13 @@ const char dhcp_option_strings[] ALIGN1 =
  	"sipsrv" "\0"      /* DHCP_SIP_SERVERS    */
  #endif
  	"staticroutes" "\0"/* DHCP_STATIC_ROUTES  */
@@ -78,7 +84,13 @@ index ae0e0d3..328897b 100644
  #if ENABLE_FEATURE_UDHCP_8021Q
  	"vlanid" "\0"      /* DHCP_VLAN_ID        */
  	"vlanpriority" "\0"/* DHCP_VLAN_PRIORITY  */
-@@ -145,6 +153,7 @@ const uint8_t dhcp_option_lengths[] ALIGN1 = {
+ #endif
+ 	"ip6rd" "\0"       /* DHCP_6RD            */
++	"tftpsiaddr" "\0"  /* DHCP_TFTP_SERVER_IP */
+ 	"msstaticroutes""\0"/* DHCP_MS_STATIC_ROUTES */
+ 	"wpad" "\0"        /* DHCP_WPAD           */
+ 	;
+@@ -145,6 +155,7 @@ const uint8_t dhcp_option_lengths[] ALIGN1 = {
  	[OPTION_IP] =      4,
  	[OPTION_IP_PAIR] = 8,
  //	[OPTION_BOOLEAN] = 1,

--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -227,6 +227,11 @@ tftp_download()
         url_run "tftp://$onie_disco_tftp/$onie_disco_bootfile" && return 0
     fi
 
+    # Try DHCP TFTP server IP address (opt 150) and bootfile (opt 67)
+    if [ -n "$onie_disco_tftpsiaddr" ] && [ -n "$onie_disco_bootfile" ] ; then
+        url_run "tftp://$onie_disco_tftpsiaddr/$onie_disco_bootfile" && return 0
+    fi
+
     return 1
 }
 
@@ -254,7 +259,7 @@ waterfall()
     wf_paths="$wf_paths $onie_default_filenames"
 
     # TFTP waterfall
-    tftp_servers="$onie_disco_siaddr $onie_disco_tftp"
+    tftp_servers="$onie_disco_siaddr $onie_disco_tftp $onie_disco_tftpsiaddr"
     for s in $tftp_servers ; do
         for p in $wf_paths ; do
             url_run "tftp://$s/$p" && return 0


### PR DESCRIPTION
Problem:
Setting Option 150(TFTP server IP) and 67(TFTP bootfile) in DHCP
server, ONIE does not fetch the installer from the exact URL of
DHCP option 150 and 67.
Please note ONIE certification also has this test.

Procedures:
1. Setting DHCP server to provide DHCP Option 150 and 67.
2. Setting TFTP server to host the related NOS installer image file.
3. Start ONIE at Install mode
4. Execute "tail -f /var/log/onie.log" at ONIE prompt for checking
   which file is fetching.
