### PR TITLE
Configure Ethernet management interfaces using static IP "up"

### DIFF
--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -172,6 +172,13 @@ if [ "$1" = "start" ] ; then
         fi
         intf_counter=$(( $intf_counter + 1))
     done
+
+    # Configure all interfaces using static IP up.
+    if [ -n "$onie_ip" ] ; then
+        for intf in $intf_list ; do
+            cmd_run ifconfig $intf up
+        done
+    fi
 fi
 
 config_ethmgmt "$*"


### PR DESCRIPTION
The static IP passed from u-boot is not working in ONIE because
all interfaces are "down" after setting MAC addr.
