### PR TITLE
Allow platform specific Busybox customizations

### DIFF
--- a/build-config/make/busybox.make
+++ b/build-config/make/busybox.make
@@ -14,6 +14,7 @@ BUSYBOX_DIR		= $(BUSYBOX_BUILD_DIR)/busybox-$(BUSYBOX_VERSION)
 BUSYBOX_CONFIG		= conf/busybox.config
 
 BUSYBOX_SRCPATCHDIR	= $(PATCHDIR)/busybox
+MACHINE_BUSYBOX_PATCHDIR ?= $(MACHINEDIR)/busybox
 BUSYBOX_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/busybox-download
 BUSYBOX_SOURCE_STAMP	= $(STAMPDIR)/busybox-source
 BUSYBOX_PATCH_STAMP	= $(STAMPDIR)/busybox-patch
@@ -56,6 +57,7 @@ $(BUSYBOX_PATCH_STAMP): $(BUSYBOX_SRCPATCHDIR)/* $(BUSYBOX_SOURCE_STAMP)
 $(BUSYBOX_DIR)/.config: $(BUSYBOX_CONFIG) $(BUSYBOX_PATCH_STAMP)
 	$(Q) echo "==== Copying $(BUSYBOX_CONFIG) to $(BUSYBOX_DIR)/.config ===="
 	$(Q) cp -v $< $@
+	$(Q) $(SCRIPTDIR)/apply-config-patch $@ $(MACHINE_BUSYBOX_PATCHDIR)/config
 
 busybox-config: $(BUSYBOX_DIR)/.config
 	PATH='$(CROSSBIN):$(PATH)' \

--- a/build-config/scripts/apply-config-patch
+++ b/build-config/scripts/apply-config-patch
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+CONFIG="$1"
+CONFIGOPTS="$2"
+
+if [ -z "$CONFIG" -o ! -f "$CONFIG" ]; then
+    echo "ERROR: $CONFIG not found!"
+    echo "Usage: $0 /path/to/config-file /path/to/extra-config-options-file"
+    exit 100
+fi
+
+# If the config options file is not present, do a successful exit
+[ -r $CONFIGOPTS ] || exit 0
+
+# Iterate through all the config options in $CONFIGOPTS and replace their
+# existence in $CONFIG with corresponding lines from $CONFIGOPTS
+
+while read bbopt; do
+    optname=${bbopt%%=*}
+    sed -i "/$optname/c\\$bbopt" $CONFIG
+done <$CONFIGOPTS


### PR DESCRIPTION
Issue #37 - This commit adds support for customizing busybox
config on a per platform basis.

We're currently supporting only config customizations similar to
how its done for the kernel.

Custom configs can be placed uner: machine/<platform>/busybox/config
and the build system will pick it from there.

The customizations are optional and the build system will use
existing defaults if its not defined by a platform.
