### PR TITLE
Revise times of polling mgmt port link status to 100

### DIFF
--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -104,7 +104,7 @@ check_link_up()
 
     _log_info_msg "Info: ${intf}:  Checking link... "
     local i=0
-    [ -r $operstate ] && while [ $i -lt 50 ] ; do
+    [ -r $operstate ] && while [ $i -lt 100 ] ; do
         if [ "$(cat $operstate)" = "up" ] ; then
             _log_info_msg "up.\n"
             return 0


### PR DESCRIPTION
The polling loop of checking link status is a total 5 seconds in the
worst case. It may be timeout eventually if the link partner has
capibility of 1000 full duplex.

We ran test of booting on Accton AS5710_54x repeatedly and found the
polling loop has probability over 50 times. The test result are:
- 40 times (55%)
- 50 times (45%)
- 69 times (8%)
- 79 times (2%)
