### PR TITLE
Accton AS4600_54t: Disable BCM54616 PHY interrupt in kernel driver

### DIFF
--- a/machine/accton/accton_as4600_54t/kernel/driver-bcm54616-disable-phy-interrupt.patch
+++ b/machine/accton/accton_as4600_54t/kernel/driver-bcm54616-disable-phy-interrupt.patch
@@ -1,0 +1,17 @@
+Disable the BCM54616 PHY interrupt to support R01E machine
+
+This patch is backward compatible with old machines.
+
+diff --git a/drivers/net/phy/broadcom.c b/drivers/net/phy/broadcom.c
+index 85559f6..1904704 100644
+--- a/drivers/net/phy/broadcom.c
++++ b/drivers/net/phy/broadcom.c
+@@ -919,7 +919,7 @@ static struct phy_driver bcm54616_driver = {
+ 	.name		= "Broadcom BCM54616",
+ 	.features	= PHY_GBIT_FEATURES |
+ 			  SUPPORTED_Pause | SUPPORTED_Asym_Pause,
+-	.flags		= PHY_HAS_MAGICANEG | PHY_HAS_INTERRUPT,
++	.flags		= PHY_HAS_MAGICANEG,
+ 	.config_init	= bcm54616_config_init,
+ 	.config_aneg	= genphy_config_aneg,
+ 	.read_status	= bcm54616_read_status,

--- a/machine/accton/accton_as4600_54t/kernel/series
+++ b/machine/accton/accton_as4600_54t/kernel/series
@@ -1,1 +1,2 @@
+driver-bcm54616-disable-phy-interrupt.patch
 platform-as4600_54t.patch


### PR DESCRIPTION
This patch is backward compatible with old machines.
