### PR TITLE
Accton AS6700_32X: Add to support the r01c machine

### DIFF
--- a/machine/accton/accton_as6700_32x/INSTALL
+++ b/machine/accton/accton_as6700_32x/INSTALL
@@ -2,22 +2,41 @@
 Installing ONIE on Accton AS6700_32X
 ====================================
 
+Accton AS6700_32X has several revisions such as ``r01b`` and ``r01c``.  The
+``r0`` ONIE images are suitable for the machines till ``r01b`` revision.  And
+the ``r1`` ONIE images are suitable for the ``r01c`` machine.
+
 Cross-Compiling ONIE
 ====================
+
+Compiling the r0 ONIE
+---------------------
 
 Change directories to ``build-config`` to compile ONIE.
 
 To compile ONIE first change directories to ``build-config`` and then
-type ``"make MACHINEROOT=../machine/accton MACHINE=accton_as6700_32x all"``.
+type ``"make MACHINEROOT=../machine/accton MACHINE=accton_as6700_32x VENDOR_REV=r01b all"``.
 For example::
 
   $ cd build-config
-  $ make -j4 MACHINEROOT=../machine/accton MACHINE=accton_as6700_32x all
+  $ make -j4 MACHINEROOT=../machine/accton MACHINE=accton_as6700_32x VENDOR_REV=r01b all
 
 When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 May  7 11:38 onie-accton_as6700_32x-r0.bin
+
+Compiling the r1 ONIE
+---------------------
+
+To compile the ``r1`` ONIE type
+``"make MACHINEROOT=../machine/accton MACHINE=accton_as6700_32x VENDOR_REV=r01c all"``.
+
+When complete, the ONIE binaries are located in
+``build/images``::
+
+  -rw-r--r-- 3604480 May  7 11:38 onie-accton_as6700_32x-r1.bin
+
 
 Installing the ONIE binaries
 ============================
@@ -28,14 +47,25 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install ONIE kernel (onie-accton_as6700_32x-r0.bin)
------------------------------------------------
+Step 2 -- Install ONIE kernel
+-----------------------------
 
-Copying the image down using TFTP and flash to the NOR flash::
+Copying the image (onie-accton_as6700_32x-r0.bin) down using TFTP and flash to
+the NOR flash on the machines till ``r01b`` revision::
+
+  => setenv q1start 0x00130000
+  => setenv q1sz.b 0x800000
+  => tftp onie-accton_as6700_32x-r0.bin
+  => sf probe
+  => sf erase $q1start ${q1sz.b}
+  => sf write $fileaddr $q1start ${q1sz.b}
+
+For the ``r01c`` machine, it has to assign another address to ``q1start`` to
+flash the image (onie-accton_as6700_32x-r1.bin) to the NOR flash::
 
   => setenv q1start 0x001c0000
   => setenv q1sz.b 0x800000
-  => tftp onie-accton_as6700_32x-r0.bin
+  => tftp onie-accton_as6700_32x-r1.bin
   => sf probe
   => sf erase $q1start ${q1sz.b}
   => sf write $fileaddr $q1start ${q1sz.b}

--- a/machine/accton/accton_as6700_32x/kernel/platform-accton-as6700_32x.patch
+++ b/machine/accton/accton_as6700_32x/kernel/platform-accton-as6700_32x.patch
@@ -2,11 +2,11 @@ platform accton as6700_32x patch
 
 Support for the Accton AS6700_32X networking platform.
 
-diff --git a/arch/powerpc/boot/dts/as6700_32x.dts b/arch/powerpc/boot/dts/as6700_32x.dts
+diff --git a/arch/powerpc/boot/dts/accton_as6700_32x-r0.dts b/arch/powerpc/boot/dts/accton_as6700_32x-r0.dts
 new file mode 100644
-index 0000000..00a750f
+index 0000000..1923fe5
 --- /dev/null
-+++ b/arch/powerpc/boot/dts/as6700_32x.dts
++++ b/arch/powerpc/boot/dts/accton_as6700_32x-r0.dts
 @@ -0,0 +1,1498 @@
 +/*
 + * Accton Technology AS6700_32X Device Tree Source
@@ -442,7 +442,1511 @@ index 0000000..00a750f
 +			flash@0 {
 +				#address-cells = <0x1>;
 +				#size-cells = <0x1>;
-+				compatible = "numonyx,n25q512a13", "s25fl512s";
++				compatible = "numonyx,n25q512a13";
++
++				reg = <0x0>;
++				spi-max-frequency = <0xb71b00>;
++
++				partition@uboot {
++					label = "uboot";
++					reg = <0x0 0x100000>;
++				};
++
++				partition@uboot-env {
++					label = "uboot-env";
++					reg = <0x100000 0x10000>;
++					env_size = <0x2000>;
++				};
++
++				partition@Fman-FW {
++					label = "Fman-FW";
++					reg = <0x110000 0x10000>;
++				};
++
++				partition@hw-info {
++					label = "hw-info";
++					reg = <0x120000 0x10000>;
++				};
++
++				partition@onie {
++					label = "onie";
++					reg = <0x130000 0x800000>;
++				};
++
++				partition@diag {
++					label = "diag";
++					reg = <0x930000 0x2000000>;
++				};
++
++				partition@reserved {
++					label = "reserved";
++					reg = <0x2930000 0x16d0000>;
++				};
++			};
++		};
++
++		i2c@118000 {
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			cell-index = <0x0>;
++			compatible = "fsl-i2c";
++			reg = <0x118000 0x100>;
++			interrupts = <0x26 0x2 0x0 0x0>;
++			dfsrr;
++
++			rtc@68 {
++				compatible = "dallas,ds1672";
++				reg = <0x68>;
++			};
++		};
++
++		i2c@118100 {
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			cell-index = <0x1>;
++			compatible = "fsl-i2c";
++			reg = <0x118100 0x100>;
++			interrupts = <0x26 0x2 0x0 0x0>;
++			dfsrr;
++
++			eeprom@50 {
++				compatible = "at24,24c256";
++				reg = <0x50>;
++			};
++		};
++
++		usb@211000 {
++			dr_mode = "host";
++			reg = <0x211000 0x1000>;
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			interrupts = <0x2d 0x2 0x0 0x0>;
++			compatible = "fsl-usb2-dr-v1.6", "fsl,mpc85xx-usb2-dr", "fsl-usb2-dr";
++			fsl,iommu-parent = <0x10>;
++			fsl,liodn-reg = <0x11 0x524>;
++			phy_type = "utmi";
++		};
++
++		fman@400000 {
++			#address-cells = <0x1>;
++			#size-cells = <0x1>;
++			cell-index = <0x0>;
++			compatible = "fsl,fman", "simple-bus";
++			ranges = <0x0 0x400000 0x100000>;
++			reg = <0x400000 0x100000>;
++			clock-frequency = <0x0>;
++			interrupts = <0x60 0x2 0x0 0x0 0x10 0x2 0x1 0x1>;
++
++			mdio@e1120 {
++				#address-cells = <0x1>;
++				#size-cells = <0x0>;
++				compatible = "fsl,fman-mdio";
++				reg = <0xe1120 0xee0>;
++				interrupts = <0x64 0x1 0x0 0x0>;
++
++				ethernet-phy@1e {
++					reg = <0x1e>;
++					linux,phandle = <0x13>;
++					phandle = <0x13>;
++				};
++
++				ethernet-phy@1 {
++					reg = <0x1>;
++					linux,phandle = <0x18>;
++					phandle = <0x18>;
++				};
++			};
++
++			ethernet@e4000 {
++				tbi-handle = <0x12>;
++				phy-handle = <0x13>;
++				phy-connection-type = "sgmii";
++				cell-index = <0x2>;
++				compatible = "fsl,fman-1g-mac";
++				reg = <0xe4000 0x1000>;
++				fsl,port-handles = <0x14 0x15>;
++				ptimer-handle = <0x16>;
++				linux,phandle = <0x26>;
++				phandle = <0x26>;
++			};
++
++			mdio@e5120 {
++				#address-cells = <0x1>;
++				#size-cells = <0x0>;
++				compatible = "fsl,fman-tbi";
++				reg = <0xe5120 0xee0>;
++				interrupts = <0x64 0x1 0x0 0x0>;
++
++				tbi-phy@8 {
++					reg = <0x8>;
++					device_type = "tbi-phy";
++					linux,phandle = <0x12>;
++					phandle = <0x12>;
++				};
++			};
++
++			ethernet@e6000 {
++				tbi-handle = <0x17>;
++				phy-handle = <0x18>;
++				phy-connection-type = "sgmii";
++				cell-index = <0x3>;
++				compatible = "fsl,fman-1g-mac";
++				reg = <0xe6000 0x1000>;
++				fsl,port-handles = <0x19 0x1a>;
++				ptimer-handle = <0x16>;
++				linux,phandle = <0x25>;
++				phandle = <0x25>;
++			};
++
++			mdio@e7120 {
++				#address-cells = <0x1>;
++				#size-cells = <0x0>;
++				compatible = "fsl,fman-tbi";
++				reg = <0xe7120 0xee0>;
++				interrupts = <0x64 0x1 0x0 0x0>;
++
++				tbi-phy@8 {
++					reg = <0x8>;
++					device_type = "tbi-phy";
++					linux,phandle = <0x17>;
++					phandle = <0x17>;
++				};
++			};
++
++			cc {
++				compatible = "fsl,fman-cc";
++			};
++
++			muram@0 {
++				compatible = "fsl,fman-muram";
++				reg = <0x0 0x28000>;
++			};
++
++			bmi@80000 {
++				compatible = "fsl,fman-bmi";
++				reg = <0x80000 0x400>;
++			};
++
++			qmi@80400 {
++				compatible = "fsl,fman-qmi";
++				reg = <0x80400 0x400>;
++			};
++
++			port@81000 {
++				cell-index = <0x0>;
++				compatible = "fsl,fman-port-oh";
++				reg = <0x81000 0x1000>;
++				fsl,qman-channel-id = <0x46>;
++			};
++
++			port@82000 {
++				cell-index = <0x1>;
++				compatible = "fsl,fman-port-oh";
++				reg = <0x82000 0x1000>;
++				fsl,qman-channel-id = <0x47>;
++			};
++
++			port@83000 {
++				cell-index = <0x2>;
++				compatible = "fsl,fman-port-oh";
++				reg = <0x83000 0x1000>;
++				fsl,qman-channel-id = <0x48>;
++			};
++
++			port@84000 {
++				cell-index = <0x3>;
++				compatible = "fsl,fman-port-oh";
++				reg = <0x84000 0x1000>;
++				fsl,qman-channel-id = <0x49>;
++			};
++
++			port@85000 {
++				cell-index = <0x4>;
++				compatible = "fsl,fman-port-oh";
++				reg = <0x85000 0x1000>;
++				status = "disabled";
++				fsl,qman-channel-id = <0x4a>;
++			};
++
++			port@86000 {
++				cell-index = <0x5>;
++				compatible = "fsl,fman-port-oh";
++				reg = <0x86000 0x1000>;
++				status = "disabled";
++				fsl,qman-channel-id = <0x4b>;
++			};
++
++			port@87000 {
++				cell-index = <0x6>;
++				compatible = "fsl,fman-port-oh";
++				reg = <0x87000 0x1000>;
++				status = "disabled";
++			};
++
++			policer@c0000 {
++				compatible = "fsl,fman-policer";
++				reg = <0xc0000 0x1000>;
++			};
++
++			keygen@c1000 {
++				compatible = "fsl,fman-keygen";
++				reg = <0xc1000 0x1000>;
++			};
++
++			dma@c2000 {
++				compatible = "fsl,fman-dma";
++				reg = <0xc2000 0x1000>;
++			};
++
++			fpm@c3000 {
++				compatible = "fsl,fman-fpm";
++				reg = <0xc3000 0x1000>;
++			};
++
++			parser@c7000 {
++				compatible = "fsl,fman-parser";
++				reg = <0xc7000 0x1000>;
++			};
++
++			rtc@fe000 {
++				compatible = "fsl,fman-rtc";
++				reg = <0xfe000 0x1000>;
++				linux,phandle = <0x16>;
++				phandle = <0x16>;
++			};
++
++			port@89000 {
++				cell-index = <0x1>;
++				compatible = "fsl,fman-port-1g-rx";
++				reg = <0x89000 0x1000>;
++				linux,phandle = <0x1b>;
++				phandle = <0x1b>;
++			};
++
++			port@a9000 {
++				cell-index = <0x1>;
++				compatible = "fsl,fman-port-1g-tx";
++				reg = <0xa9000 0x1000>;
++				fsl,qman-channel-id = <0x42>;
++				linux,phandle = <0x1c>;
++				phandle = <0x1c>;
++			};
++
++			ethernet@e2000 {
++				cell-index = <0x1>;
++				compatible = "fsl,fman-1g-mac";
++				reg = <0xe2000 0x1000>;
++				fsl,port-handles = <0x1b 0x1c>;
++				ptimer-handle = <0x16>;
++			};
++
++			mdio@e3120 {
++				#address-cells = <0x1>;
++				#size-cells = <0x0>;
++				compatible = "fsl,fman-tbi";
++				reg = <0xe3120 0xee0>;
++				interrupts = <0x64 0x1 0x0 0x0>;
++			};
++
++			port@8a000 {
++				cell-index = <0x2>;
++				compatible = "fsl,fman-port-1g-rx";
++				reg = <0x8a000 0x1000>;
++				linux,phandle = <0x14>;
++				phandle = <0x14>;
++			};
++
++			port@aa000 {
++				cell-index = <0x2>;
++				compatible = "fsl,fman-port-1g-tx";
++				reg = <0xaa000 0x1000>;
++				fsl,qman-channel-id = <0x43>;
++				linux,phandle = <0x15>;
++				phandle = <0x15>;
++			};
++
++			port@8b000 {
++				cell-index = <0x3>;
++				compatible = "fsl,fman-port-1g-rx";
++				reg = <0x8b000 0x1000>;
++				linux,phandle = <0x19>;
++				phandle = <0x19>;
++			};
++
++			port@ab000 {
++				cell-index = <0x3>;
++				compatible = "fsl,fman-port-1g-tx";
++				reg = <0xab000 0x1000>;
++				fsl,qman-channel-id = <0x44>;
++				linux,phandle = <0x1a>;
++				phandle = <0x1a>;
++			};
++
++			port@8c000 {
++				cell-index = <0x4>;
++				compatible = "fsl,fman-port-1g-rx";
++				reg = <0x8c000 0x1000>;
++				linux,phandle = <0x1d>;
++				phandle = <0x1d>;
++			};
++
++			port@ac000 {
++				cell-index = <0x4>;
++				compatible = "fsl,fman-port-1g-tx";
++				reg = <0xac000 0x1000>;
++				fsl,qman-channel-id = <0x45>;
++				linux,phandle = <0x1e>;
++				phandle = <0x1e>;
++			};
++
++			ethernet@e8000 {
++				cell-index = <0x4>;
++				compatible = "fsl,fman-1g-mac";
++				reg = <0xe8000 0x1000>;
++				fsl,port-handles = <0x1d 0x1e>;
++				ptimer-handle = <0x16>;
++			};
++
++			mdio@e9120 {
++				#address-cells = <0x1>;
++				#size-cells = <0x0>;
++				compatible = "fsl,fman-tbi";
++				reg = <0xe9120 0xee0>;
++				interrupts = <0x64 0x1 0x0 0x0>;
++			};
++
++			port@90000 {
++				cell-index = <0x0>;
++				compatible = "fsl,fman-port-10g-rx";
++				reg = <0x90000 0x1000>;
++				linux,phandle = <0x1f>;
++				phandle = <0x1f>;
++			};
++
++			port@b0000 {
++				cell-index = <0x0>;
++				compatible = "fsl,fman-port-10g-tx";
++				reg = <0xb0000 0x1000>;
++				fsl,qman-channel-id = <0x40>;
++				linux,phandle = <0x20>;
++				phandle = <0x20>;
++			};
++
++			ethernet@f0000 {
++				cell-index = <0x0>;
++				compatible = "fsl,fman-10g-mac";
++				reg = <0xf0000 0x1000>;
++				fsl,port-handles = <0x1f 0x20>;
++			};
++
++			mdio@f1000 {
++				#address-cells = <0x1>;
++				#size-cells = <0x0>;
++				compatible = "fsl,fman-xmdio";
++				reg = <0xf1000 0x1000>;
++				interrupts = <0x64 0x1 0x0 0x0>;
++			};
++
++			port@a8000 {
++				fsl,qman-channel-id = <0x41>;
++			};
++		};
++
++		soc-sram-error {
++			compatible = "fsl,soc-sram-error";
++			interrupts = <0x10 0x2 0x1 0x1d>;
++		};
++
++		corenet-law@0 {
++			compatible = "fsl,corenet-law";
++			reg = <0x0 0x1000>;
++			fsl,num-laws = <0x20>;
++		};
++
++		memory-controller@8000 {
++			compatible = "fsl,qoriq-memory-controller-v4.5", "fsl,qoriq-memory-controller";
++			reg = <0x8000 0x1000>;
++			interrupts = <0x10 0x2 0x1 0x17>;
++			linux,phandle = <0xb>;
++			phandle = <0xb>;
++		};
++
++		l3-cache-controller@10000 {
++			compatible = "fsl,p2041-l3-cache-controller", "fsl,p4080-l3-cache-controller", "cache";
++			reg = <0x10000 0x1000>;
++			interrupts = <0x10 0x2 0x1 0x1b>;
++			linux,phandle = <0x4>;
++			phandle = <0x4>;
++		};
++
++		corenet-cf@18000 {
++			compatible = "fsl,corenet-cf";
++			reg = <0x18000 0x1000>;
++			interrupts = <0x10 0x2 0x1 0x1f>;
++			fsl,ccf-num-csdids = <0x20>;
++			fsl,ccf-num-snoopids = <0x20>;
++		};
++
++		iommu@20000 {
++			compatible = "fsl,pamu-v1.0", "fsl,pamu";
++			reg = <0x20000 0x4000>;
++			ranges = <0x0 0x20000 0x4000>;
++			#address-cells = <0x1>;
++			#size-cells = <0x1>;
++			interrupts = <0x18 0x2 0x0 0x0 0x10 0x2 0x1 0x1e>;
++
++			pamu@0 {
++				reg = <0x0 0x1000>;
++				fsl,primary-cache-geometry = <0x20 0x1>;
++				fsl,secondary-cache-geometry = <0x80 0x2>;
++				linux,phandle = <0x24>;
++				phandle = <0x24>;
++			};
++
++			pamu@1000 {
++				reg = <0x1000 0x1000>;
++				fsl,primary-cache-geometry = <0x20 0x1>;
++				fsl,secondary-cache-geometry = <0x80 0x2>;
++				linux,phandle = <0x10>;
++				phandle = <0x10>;
++			};
++
++			pamu@2000 {
++				reg = <0x2000 0x1000>;
++				fsl,primary-cache-geometry = <0x20 0x1>;
++				fsl,secondary-cache-geometry = <0x80 0x2>;
++			};
++
++			pamu@3000 {
++				reg = <0x3000 0x1000>;
++				fsl,primary-cache-geometry = <0x20 0x1>;
++				fsl,secondary-cache-geometry = <0x80 0x2>;
++			};
++		};
++
++		pic@40000 {
++			interrupt-controller;
++			#address-cells = <0x0>;
++			#interrupt-cells = <0x4>;
++			reg = <0x40000 0x40000>;
++			compatible = "fsl,mpic", "chrp,open-pic";
++			device_type = "open-pic";
++			clock-frequency = <0x0>;
++			linux,phandle = <0x1>;
++			phandle = <0x1>;
++		};
++
++		timer@41100 {
++			compatible = "fsl,mpic-global-timer";
++			reg = <0x41100 0x100 0x41300 0x4>;
++			interrupts = <0x0 0x0 0x3 0x0 0x1 0x0 0x3 0x0 0x2 0x0 0x3 0x0 0x3 0x0 0x3 0x0>;
++		};
++
++		msi@41600 {
++			compatible = "fsl,mpic-msi";
++			reg = <0x41600 0x200 0x44140 0x4>;
++			msi-available-ranges = <0x0 0x100>;
++			interrupts = <0xe0 0x0 0x0 0x0 0xe1 0x0 0x0 0x0 0xe2 0x0 0x0 0x0 0xe3 0x0 0x0 0x0 0xe4 0x0 0x0 0x0 0xe5 0x0 0x0 0x0 0xe6 0x0 0x0 0x0 0xe7 0x0 0x0 0x0>;
++		};
++
++		msi@41800 {
++			compatible = "fsl,mpic-msi";
++			reg = <0x41800 0x200 0x45140 0x4>;
++			msi-available-ranges = <0x0 0x100>;
++			interrupts = <0xe8 0x0 0x0 0x0 0xe9 0x0 0x0 0x0 0xea 0x0 0x0 0x0 0xeb 0x0 0x0 0x0 0xec 0x0 0x0 0x0 0xed 0x0 0x0 0x0 0xee 0x0 0x0 0x0 0xef 0x0 0x0 0x0>;
++		};
++
++		msi@41a00 {
++			compatible = "fsl,mpic-msi";
++			reg = <0x41a00 0x200 0x46140 0x4>;
++			msi-available-ranges = <0x0 0x100>;
++			interrupts = <0xf0 0x0 0x0 0x0 0xf1 0x0 0x0 0x0 0xf2 0x0 0x0 0x0 0xf3 0x0 0x0 0x0 0xf4 0x0 0x0 0x0 0xf5 0x0 0x0 0x0 0xf6 0x0 0x0 0x0 0xf7 0x0 0x0 0x0>;
++		};
++
++		timer@42100 {
++			compatible = "fsl,mpic-global-timer";
++			reg = <0x42100 0x100 0x42300 0x4>;
++			interrupts = <0x4 0x0 0x3 0x0 0x5 0x0 0x3 0x0 0x6 0x0 0x3 0x0 0x7 0x0 0x3 0x0>;
++		};
++
++		global-utilities@e0000 {
++			compatible = "fsl,qoriq-device-config-1.0";
++			reg = <0xe0000 0xe00>;
++			fsl,has-rstcr;
++			#sleep-cells = <0x1>;
++			fsl,liodn-bits = <0xc>;
++			linux,phandle = <0x11>;
++			phandle = <0x11>;
++		};
++
++		global-utilities@e0e00 {
++			compatible = "fsl,qoriq-pin-control-1.0";
++			reg = <0xe0e00 0x200>;
++			#sleep-cells = <0x2>;
++		};
++
++		global-utilities@e1000 {
++			compatible = "fsl,p2041-clockgen", "fsl,qoriq-clockgen-1.0", "fixed-clock";
++			reg = <0xe1000 0x1000>;
++			clock-frequency = <0x0>;
++			clock-output-names = "sysclk";
++			#clock-cells = <0x0>;
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			linux,phandle = <0x21>;
++			phandle = <0x21>;
++
++			pll0@800 {
++				#clock-cells = <0x1>;
++				reg = <0x800>;
++				compatible = "fsl,core-pll-clock";
++				clocks = <0x21>;
++				clock-output-names = "pll0", "pll0-div2";
++				linux,phandle = <0x22>;
++				phandle = <0x22>;
++			};
++
++			pll1@820 {
++				#clock-cells = <0x1>;
++				reg = <0x820>;
++				compatible = "fsl,core-pll-clock";
++				clocks = <0x21>;
++				clock-output-names = "pll1", "pll1-div2";
++				linux,phandle = <0x23>;
++				phandle = <0x23>;
++			};
++
++			mux0@0 {
++				#clock-cells = <0x0>;
++				reg = <0x0>;
++				compatible = "fsl,core-mux-clock";
++				clocks = <0x22 0x0 0x22 0x1 0x23 0x0 0x23 0x1>;
++				clock-names = "pll0_0", "pll0_1", "pll1_0", "pll1_1";
++				clock-output-names = "cmux0";
++				linux,phandle = <0x2>;
++				phandle = <0x2>;
++			};
++
++			mux1@20 {
++				#clock-cells = <0x0>;
++				reg = <0x20>;
++				compatible = "fsl,core-mux-clock";
++				clocks = <0x22 0x0 0x22 0x1 0x23 0x0 0x23 0x1>;
++				clock-names = "pll0_0", "pll0_1", "pll1_0", "pll1_1";
++				clock-output-names = "cmux1";
++				linux,phandle = <0x5>;
++				phandle = <0x5>;
++			};
++
++			mux2@40 {
++				#clock-cells = <0x0>;
++				reg = <0x40>;
++				compatible = "fsl,core-mux-clock";
++				clocks = <0x22 0x0 0x22 0x1 0x23 0x0 0x23 0x1>;
++				clock-names = "pll0_0", "pll0_1", "pll1_0", "pll1_1";
++				clock-output-names = "cmux2";
++				linux,phandle = <0x7>;
++				phandle = <0x7>;
++			};
++
++			mux3@60 {
++				#clock-cells = <0x0>;
++				reg = <0x60>;
++				compatible = "fsl,core-mux-clock";
++				clocks = <0x22 0x0 0x22 0x1 0x23 0x0 0x23 0x1>;
++				clock-names = "pll0_0", "pll0_1", "pll1_0", "pll1_1";
++				clock-output-names = "cmux3";
++				linux,phandle = <0x9>;
++				phandle = <0x9>;
++			};
++		};
++
++		global-utilities@e2000 {
++			compatible = "fsl,qoriq-rcpm-1.0";
++			reg = <0xe2000 0x1000>;
++			#sleep-cells = <0x1>;
++		};
++
++		sfp@e8000 {
++			compatible = "fsl,p2041-sfp", "fsl,qoriq-sfp-1.0";
++			reg = <0xe8000 0x1000>;
++		};
++
++		serdes@ea000 {
++			compatible = "fsl,p2041-serdes";
++			reg = <0xea000 0x1000>;
++		};
++
++		dma@100300 {
++			#address-cells = <0x1>;
++			#size-cells = <0x1>;
++			compatible = "fsl,eloplus-dma";
++			reg = <0x100300 0x4>;
++			ranges = <0x0 0x100100 0x200>;
++			cell-index = <0x0>;
++			fsl,iommu-parent = <0x24>;
++			fsl,liodn-reg = <0x11 0x580>;
++
++			dma-channel@0 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x0 0x80>;
++				cell-index = <0x0>;
++				interrupts = <0x1c 0x2 0x0 0x0>;
++			};
++
++			dma-channel@80 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x80 0x80>;
++				cell-index = <0x1>;
++				interrupts = <0x1d 0x2 0x0 0x0>;
++			};
++
++			dma-channel@100 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x100 0x80>;
++				cell-index = <0x2>;
++				interrupts = <0x1e 0x2 0x0 0x0>;
++			};
++
++			dma-channel@180 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x180 0x80>;
++				cell-index = <0x3>;
++				interrupts = <0x1f 0x2 0x0 0x0>;
++			};
++		};
++
++		dma@101300 {
++			#address-cells = <0x1>;
++			#size-cells = <0x1>;
++			compatible = "fsl,eloplus-dma";
++			reg = <0x101300 0x4>;
++			ranges = <0x0 0x101100 0x200>;
++			cell-index = <0x1>;
++			fsl,iommu-parent = <0x24>;
++			fsl,liodn-reg = <0x11 0x584>;
++
++			dma-channel@0 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x0 0x80>;
++				cell-index = <0x0>;
++				interrupts = <0x20 0x2 0x0 0x0>;
++			};
++
++			dma-channel@80 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x80 0x80>;
++				cell-index = <0x1>;
++				interrupts = <0x21 0x2 0x0 0x0>;
++			};
++
++			dma-channel@100 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x100 0x80>;
++				cell-index = <0x2>;
++				interrupts = <0x22 0x2 0x0 0x0>;
++			};
++
++			dma-channel@180 {
++				compatible = "fsl,eloplus-dma-channel";
++				reg = <0x180 0x80>;
++				cell-index = <0x3>;
++				interrupts = <0x23 0x2 0x0 0x0>;
++			};
++		};
++
++		sdhc@114000 {
++			compatible = "fsl,p2041-esdhc", "fsl,esdhc";
++			reg = <0x114000 0x1000>;
++			interrupts = <0x30 0x2 0x0 0x0>;
++			clock-frequency = <0x0>;
++			fsl,iommu-parent = <0x10>;
++			fsl,liodn-reg = <0x11 0x530>;
++			sdhci,auto-cmd12;
++		};
++
++		i2c@119000 {
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			cell-index = <0x2>;
++			compatible = "fsl-i2c";
++			reg = <0x119000 0x100>;
++			interrupts = <0x27 0x2 0x0 0x0>;
++			dfsrr;
++		};
++
++		i2c@119100 {
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			cell-index = <0x3>;
++			compatible = "fsl-i2c";
++			reg = <0x119100 0x100>;
++			interrupts = <0x27 0x2 0x0 0x0>;
++			dfsrr;
++		};
++
++		serial@11c500 {
++			cell-index = <0x0>;
++			device_type = "serial";
++			compatible = "fsl,ns16550", "ns16550";
++			reg = <0x11c500 0x100>;
++			clock-frequency = <0x0>;
++			interrupts = <0x24 0x2 0x0 0x0>;
++		};
++
++		serial@11c600 {
++			cell-index = <0x1>;
++			device_type = "serial";
++			compatible = "fsl,ns16550", "ns16550";
++			reg = <0x11c600 0x100>;
++			clock-frequency = <0x0>;
++			interrupts = <0x24 0x2 0x0 0x0>;
++		};
++
++		serial@11d500 {
++			cell-index = <0x2>;
++			device_type = "serial";
++			compatible = "fsl,ns16550", "ns16550";
++			reg = <0x11d500 0x100>;
++			clock-frequency = <0x0>;
++			interrupts = <0x25 0x2 0x0 0x0>;
++		};
++
++		serial@11d600 {
++			cell-index = <0x3>;
++			device_type = "serial";
++			compatible = "fsl,ns16550", "ns16550";
++			reg = <0x11d600 0x100>;
++			clock-frequency = <0x0>;
++			interrupts = <0x25 0x2 0x0 0x0>;
++		};
++
++		gpio@130000 {
++			compatible = "fsl,qoriq-gpio";
++			reg = <0x130000 0x1000>;
++			interrupts = <0x37 0x2 0x0 0x0>;
++			#gpio-cells = <0x2>;
++			gpio-controller;
++		};
++
++		rman@1e0000 {
++			compatible = "fsl,rman";
++			#address-cells = <0x1>;
++			#size-cells = <0x1>;
++			ranges = <0x0 0x1e0000 0x20000>;
++			reg = <0x1e0000 0x20000>;
++			interrupts = <0x10 0x2 0x1 0xb>;
++			fsl,qman-channels-id = <0x62 0x63>;
++
++			inbound-block@0 {
++				compatible = "fsl,rman-inbound-block";
++				reg = <0x0 0x800>;
++			};
++
++			global-cfg@b00 {
++				compatible = "fsl,rman-global-cfg";
++				reg = <0xb00 0x500>;
++			};
++
++			inbound-block@1000 {
++				compatible = "fsl,rman-inbound-block";
++				reg = <0x1000 0x800>;
++			};
++
++			inbound-block@2000 {
++				compatible = "fsl,rman-inbound-block";
++				reg = <0x2000 0x800>;
++			};
++
++			inbound-block@3000 {
++				compatible = "fsl,rman-inbound-block";
++				reg = <0x3000 0x800>;
++			};
++		};
++
++		usb@210000 {
++			reg = <0x210000 0x1000>;
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			interrupts = <0x2c 0x2 0x0 0x0>;
++			compatible = "fsl-usb2-dr-v1.6", "fsl,mpc85xx-usb2-dr", "fsl-usb2-dr";
++			phy_type = "utmi";
++			fsl,iommu-parent = <0x10>;
++			fsl,liodn-reg = <0x11 0x520>;
++			dr_mode = "host";
++		};
++
++		sata@220000 {
++			compatible = "fsl,pq-sata-v2";
++			reg = <0x220000 0x1000>;
++			interrupts = <0x44 0x2 0x0 0x0>;
++			fsl,iommu-parent = <0x10>;
++			fsl,liodn-reg = <0x11 0x550>;
++		};
++
++		sata@221000 {
++			compatible = "fsl,pq-sata-v2";
++			reg = <0x221000 0x1000>;
++			interrupts = <0x45 0x2 0x0 0x0>;
++			fsl,iommu-parent = <0x10>;
++			fsl,liodn-reg = <0x11 0x554>;
++		};
++
++		crypto@300000 {
++			compatible = "fsl,sec-v4.2", "fsl,sec-v4.0";
++			fsl,sec-era = <0x3>;
++			#address-cells = <0x1>;
++			#size-cells = <0x1>;
++			reg = <0x300000 0x10000>;
++			ranges = <0x0 0x300000 0x10000>;
++			interrupts = <0x5c 0x2 0x0 0x0>;
++			fsl,iommu-parent = <0x10>;
++
++			jr@1000 {
++				compatible = "fsl,sec-v4.2-job-ring", "fsl,sec-v4.0-job-ring";
++				reg = <0x1000 0x1000>;
++				interrupts = <0x58 0x2 0x0 0x0>;
++			};
++
++			jr@2000 {
++				compatible = "fsl,sec-v4.2-job-ring", "fsl,sec-v4.0-job-ring";
++				reg = <0x2000 0x1000>;
++				interrupts = <0x59 0x2 0x0 0x0>;
++			};
++
++			jr@3000 {
++				compatible = "fsl,sec-v4.2-job-ring", "fsl,sec-v4.0-job-ring";
++				reg = <0x3000 0x1000>;
++				interrupts = <0x5a 0x2 0x0 0x0>;
++			};
++
++			jr@4000 {
++				compatible = "fsl,sec-v4.2-job-ring", "fsl,sec-v4.0-job-ring";
++				reg = <0x4000 0x1000>;
++				interrupts = <0x5b 0x2 0x0 0x0>;
++			};
++
++			rtic@6000 {
++				compatible = "fsl,sec-v4.2-rtic", "fsl,sec-v4.0-rtic";
++				#address-cells = <0x1>;
++				#size-cells = <0x1>;
++				reg = <0x6000 0x100>;
++				ranges = <0x0 0x6100 0xe00>;
++
++				rtic-a@0 {
++					compatible = "fsl,sec-v4.2-rtic-memory", "fsl,sec-v4.0-rtic-memory";
++					reg = <0x0 0x20 0x100 0x80>;
++				};
++
++				rtic-b@20 {
++					compatible = "fsl,sec-v4.2-rtic-memory", "fsl,sec-v4.0-rtic-memory";
++					reg = <0x20 0x20 0x200 0x80>;
++				};
++
++				rtic-c@40 {
++					compatible = "fsl,sec-v4.2-rtic-memory", "fsl,sec-v4.0-rtic-memory";
++					reg = <0x40 0x20 0x300 0x80>;
++				};
++
++				rtic-d@60 {
++					compatible = "fsl,sec-v4.2-rtic-memory", "fsl,sec-v4.0-rtic-memory";
++					reg = <0x60 0x20 0x500 0x80>;
++				};
++			};
++		};
++
++		sec_mon@314000 {
++			compatible = "fsl,sec-v4.2-mon", "fsl,sec-v4.0-mon";
++			reg = <0x314000 0x1000>;
++			interrupts = <0x5d 0x2 0x0 0x0>;
++		};
++
++		pme@316000 {
++			compatible = "fsl,pme";
++			reg = <0x316000 0x10000>;
++			interrupts = <0x10 0x2 0x1 0x5>;
++		};
++
++		qman@318000 {
++			compatible = "fsl,qman";
++			reg = <0x318000 0x2000>;
++			interrupts = <0x10 0x2 0x1 0x3>;
++		};
++
++		bman@31a000 {
++			compatible = "fsl,bman";
++			reg = <0x31a000 0x1000>;
++			interrupts = <0x10 0x2 0x1 0x2>;
++		};
++	};
++
++	rapidio@ffe0c0000 {
++		reg = <0xf 0xfe0c0000 0x0 0x11000>;
++		compatible = "fsl,srio";
++		interrupts = <0x10 0x2 0x1 0xb>;
++		#address-cells = <0x2>;
++		#size-cells = <0x2>;
++		fsl,iommu-parent = <0x24>;
++		ranges;
++
++		port1 {
++			ranges = <0x0 0x0 0xc 0x20000000 0x0 0x10000000>;
++			#address-cells = <0x2>;
++			#size-cells = <0x2>;
++			cell-index = <0x1>;
++			fsl,liodn-reg = <0x11 0x510>;
++		};
++
++		port2 {
++			ranges = <0x0 0x0 0xc 0x30000000 0x0 0x10000000>;
++			#address-cells = <0x2>;
++			#size-cells = <0x2>;
++			cell-index = <0x2>;
++			fsl,liodn-reg = <0x11 0x514>;
++		};
++	};
++
++	localbus@ffe124000 {
++		reg = <0xf 0xfe124000 0x0 0x1000>;
++		compatible = "fsl,p2041-elbc", "fsl,elbc", "simple-bus";
++		interrupts = <0x19 0x2 0x0 0x0>;
++		#address-cells = <0x2>;
++		#size-cells = <0x1>;
++	};
++
++	pcie@ffe200000 {
++		reg = <0xf 0xfe200000 0x0 0x1000>;
++		ranges = <0x2000000 0x0 0xd0000000 0x0 0xd0000000 0x0 0x8000000 0x1000000 0x0 0x0 0x0 0xf8000000 0x0 0x10000>;
++		compatible = "fsl,p2041-pcie", "fsl,qoriq-pcie-v2.2", "fsl,qoriq-pcie";
++		device_type = "pci";
++		#size-cells = <0x2>;
++		#address-cells = <0x3>;
++		bus-range = <0x0 0xff>;
++		clock-frequency = <0x1fca055>;
++		interrupts = <0x10 0x2 0x1 0xf>;
++		fsl,iommu-parent = <0x24>;
++		fsl,liodn-reg = <0x11 0x500>;
++
++		pcie@0 {
++			ranges = <0x2000000 0x0 0xe0000000 0x2000000 0x0 0xe0000000 0x0 0x8000000 0x1000000 0x0 0x0 0x1000000 0x0 0x0 0x0 0x10000>;
++			reg = <0x0 0x0 0x0 0x0 0x0>;
++			#interrupt-cells = <0x1>;
++			#size-cells = <0x2>;
++			#address-cells = <0x3>;
++			device_type = "pci";
++			interrupts = <0x10 0x2 0x1 0xf>;
++			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
++			interrupt-map = <0x0 0x0 0x0 0x1 0x1 0x28 0x1 0x0 0x0 0x0 0x0 0x0 0x2 0x1 0x1 0x1 0x0 0x0 0x0 0x0 0x0 0x3 0x1 0x2 0x1 0x0 0x0 0x0 0x0 0x0 0x4 0x1 0x3 0x1 0x0 0x0>;
++		};
++	};
++
++	pcie@ffe201000 {
++		reg = <0xf 0xfe201000 0x0 0x1000>;
++		ranges = <0x2000000 0x0 0xd8000000 0x0 0xd8000000 0x0 0x8000000 0x1000000 0x0 0x0 0x0 0xf8010000 0x0 0x10000>;
++		compatible = "fsl,p2041-pcie", "fsl,qoriq-pcie-v2.2", "fsl,qoriq-pcie";
++		device_type = "pci";
++		#size-cells = <0x2>;
++		#address-cells = <0x3>;
++		bus-range = <0x0 0xff>;
++		clock-frequency = <0x1fca055>;
++		interrupts = <0x10 0x2 0x1 0xe>;
++		fsl,iommu-parent = <0x24>;
++		fsl,liodn-reg = <0x11 0x504>;
++
++		pcie@0 {
++			ranges = <0x2000000 0x0 0xe0000000 0x2000000 0x0 0xe0000000 0x0 0x8000000 0x1000000 0x0 0x0 0x1000000 0x0 0x0 0x0 0x10000>;
++			reg = <0x0 0x0 0x0 0x0 0x0>;
++			#interrupt-cells = <0x1>;
++			#size-cells = <0x2>;
++			#address-cells = <0x3>;
++			device_type = "pci";
++			interrupts = <0x10 0x2 0x1 0xe>;
++			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
++			interrupt-map = <0x0 0x0 0x0 0x1 0x1 0x29 0x1 0x0 0x0 0x0 0x0 0x0 0x2 0x1 0x5 0x1 0x0 0x0 0x0 0x0 0x0 0x3 0x1 0x6 0x1 0x0 0x0 0x0 0x0 0x0 0x4 0x1 0x7 0x1 0x0 0x0>;
++		};
++	};
++
++	pcie@ffe202000 {
++		reg = <0xf 0xfe202000 0x0 0x1000>;
++		ranges = <0x2000000 0x0 0xe0000000 0x0 0xe0000000 0x0 0x8000000 0x1000000 0x0 0x0 0x0 0xf8020000 0x0 0x10000>;
++		compatible = "fsl,p2041-pcie", "fsl,qoriq-pcie-v2.2", "fsl,qoriq-pcie";
++		device_type = "pci";
++		#size-cells = <0x2>;
++		#address-cells = <0x3>;
++		bus-range = <0x0 0xff>;
++		clock-frequency = <0x1fca055>;
++		interrupts = <0x10 0x2 0x1 0xd>;
++		fsl,iommu-parent = <0x24>;
++		fsl,liodn-reg = <0x11 0x508>;
++
++		pcie@0 {
++			ranges = <0x2000000 0x0 0xe0000000 0x2000000 0x0 0xe0000000 0x0 0x8000000 0x1000000 0x0 0x0 0x1000000 0x0 0x0 0x0 0x10000>;
++			reg = <0x0 0x0 0x0 0x0 0x0>;
++			#interrupt-cells = <0x1>;
++			#size-cells = <0x2>;
++			#address-cells = <0x3>;
++			device_type = "pci";
++			interrupts = <0x10 0x2 0x1 0xd>;
++			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
++			interrupt-map = <0x0 0x0 0x0 0x1 0x1 0x2a 0x1 0x0 0x0 0x0 0x0 0x0 0x2 0x1 0x9 0x1 0x0 0x0 0x0 0x0 0x0 0x3 0x1 0xa 0x1 0x0 0x0 0x0 0x0 0x0 0x4 0x1 0xb 0x1 0x0 0x0>;
++		};
++	};
++
++	fsl,dpaa {
++		compatible = "fsl,p2041-dpaa", "fsl,dpaa";
++
++		ethernet@0 {
++			compatible = "fsl,p2041-dpa-ethernet", "fsl,dpa-ethernet";
++			fsl,fman-mac = <0x25>;
++		};
++
++		ethernet@1 {
++			compatible = "fsl,p2041-dpa-ethernet", "fsl,dpa-ethernet";
++			fsl,fman-mac = <0x26>;
++		};
++	};
++};
+diff --git a/arch/powerpc/boot/dts/accton_as6700_32x-r1.dts b/arch/powerpc/boot/dts/accton_as6700_32x-r1.dts
+new file mode 100644
+index 0000000..d167be1
+--- /dev/null
++++ b/arch/powerpc/boot/dts/accton_as6700_32x-r1.dts
+@@ -0,0 +1,1498 @@
++/*
++ * Accton Technology AS6700_32X Device Tree Source
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under  the terms of the GNU General  Public License as published by the
++ * Free Software Foundation;  either version 2 of the  License, or (at your
++ * option) any later version.
++ *
++ */
++
++/dts-v1/;
++
++/ {
++	compatible = "accton,as6700_32x";
++	#address-cells = <0x2>;
++	#size-cells = <0x2>;
++	interrupt-parent = <0x1>;
++	model = "accton,as6700_32x";
++
++	cpus {
++		power-isa-version = "2.06";
++		power-isa-b;
++		power-isa-e;
++		power-isa-atb;
++		power-isa-cs;
++		power-isa-ds;
++		power-isa-e.ed;
++		power-isa-e.pd;
++		power-isa-e.hv;
++		power-isa-e.le;
++		power-isa-e.pm;
++		power-isa-e.pc;
++		power-isa-ecl;
++		power-isa-exp;
++		power-isa-fp;
++		power-isa-fp.r;
++		power-isa-mmc;
++		power-isa-scpm;
++		power-isa-wt;
++		fsl,eref-deo;
++		mmu-type = "power-embedded";
++		#address-cells = <0x1>;
++		#size-cells = <0x0>;
++
++		PowerPC,e500mc@0 {
++			device_type = "cpu";
++			reg = <0x0>;
++			clocks = <0x2>;
++			next-level-cache = <0x3>;
++			linux,phandle = <0xc>;
++			phandle = <0xc>;
++
++			l2-cache {
++				next-level-cache = <0x4>;
++				linux,phandle = <0x3>;
++				phandle = <0x3>;
++			};
++		};
++
++		PowerPC,e500mc@1 {
++			device_type = "cpu";
++			reg = <0x1>;
++			clocks = <0x5>;
++			next-level-cache = <0x6>;
++			linux,phandle = <0xd>;
++			phandle = <0xd>;
++
++			l2-cache {
++				next-level-cache = <0x4>;
++				linux,phandle = <0x6>;
++				phandle = <0x6>;
++			};
++		};
++
++		PowerPC,e500mc@2 {
++			device_type = "cpu";
++			reg = <0x2>;
++			clocks = <0x7>;
++			next-level-cache = <0x8>;
++			linux,phandle = <0xe>;
++			phandle = <0xe>;
++
++			l2-cache {
++				next-level-cache = <0x4>;
++				linux,phandle = <0x8>;
++				phandle = <0x8>;
++			};
++		};
++
++		PowerPC,e500mc@3 {
++			device_type = "cpu";
++			reg = <0x3>;
++			clocks = <0x9>;
++			next-level-cache = <0xa>;
++			linux,phandle = <0xf>;
++			phandle = <0xf>;
++
++			l2-cache {
++				next-level-cache = <0x4>;
++				linux,phandle = <0xa>;
++				phandle = <0xa>;
++			};
++		};
++	};
++
++	aliases {
++		ccsr = "/soc@ffe000000";
++		dcsr = "/dcsr@f00000000";
++		serial0 = "/soc@ffe000000/serial@11c500";
++		serial1 = "/soc@ffe000000/serial@11c600";
++		serial2 = "/soc@ffe000000/serial@11d500";
++		serial3 = "/soc@ffe000000/serial@11d600";
++		pci0 = "/pcie@ffe200000";
++		pci1 = "/pcie@ffe201000";
++		pci2 = "/pcie@ffe202000";
++		usb0 = "/soc@ffe000000/usb@210000";
++		usb1 = "/soc@ffe000000/usb@211000";
++		dma0 = "/soc@ffe000000/dma@100300";
++		dma1 = "/soc@ffe000000/dma@101300";
++		sdhc = "/soc@ffe000000/sdhc@114000";
++		msi0 = "/soc@ffe000000/msi@41600";
++		msi1 = "/soc@ffe000000/msi@41800";
++		msi2 = "/soc@ffe000000/msi@41a00";
++		crypto = "/soc@ffe000000/crypto@300000";
++		sec_jr0 = "/soc@ffe000000/crypto@300000/jr@1000";
++		sec_jr1 = "/soc@ffe000000/crypto@300000/jr@2000";
++		sec_jr2 = "/soc@ffe000000/crypto@300000/jr@3000";
++		sec_jr3 = "/soc@ffe000000/crypto@300000/jr@4000";
++		rtic_a = "/soc@ffe000000/crypto@300000/rtic@6000/rtic-a@0";
++		rtic_b = "/soc@ffe000000/crypto@300000/rtic@6000/rtic-b@20";
++		rtic_c = "/soc@ffe000000/crypto@300000/rtic@6000/rtic-c@40";
++		rtic_d = "/soc@ffe000000/crypto@300000/rtic@6000/rtic-d@60";
++		sec_mon = "/soc@ffe000000/sec_mon@314000";
++		rman = "/soc@ffe000000/rman@1e0000";
++		pme = "/soc@ffe000000/pme@316000";
++		qman = "/soc@ffe000000/qman@318000";
++		bman = "/soc@ffe000000/bman@31a000";
++		fman0 = "/soc@ffe000000/fman@400000";
++		ethernet0 = "/soc@ffe000000/fman@400000/ethernet@e6000";
++		ethernet1 = "/soc@ffe000000/fman@400000/ethernet@e4000";
++		phy_sgmii_1e = "/soc@ffe000000/fman@400000/mdio@e1120/ethernet-phy@1e";
++		phy_sgmii_1 = "/soc@ffe000000/fman@400000/mdio@e1120/ethernet-phy@1";
++	};
++
++	memory {
++		device_type = "memory";
++	};
++
++	dcsr@f00000000 {
++		ranges = <0x0 0xf 0x0 0x1008000>;
++		#address-cells = <0x1>;
++		#size-cells = <0x1>;
++		compatible = "fsl,dcsr", "simple-bus";
++
++		dcsr-epu@0 {
++			compatible = "fsl,p2041-dcsr-epu", "fsl,dcsr-epu";
++			interrupts = <0x34 0x2 0x0 0x0 0x54 0x2 0x0 0x0 0x55 0x2 0x0 0x0>;
++			reg = <0x0 0x1000>;
++		};
++
++		dcsr-npc {
++			compatible = "fsl,dcsr-npc";
++			reg = <0x1000 0x1000 0x1000000 0x8000>;
++		};
++
++		dcsr-nxc@2000 {
++			compatible = "fsl,dcsr-nxc";
++			reg = <0x2000 0x1000>;
++		};
++
++		dcsr-corenet {
++			compatible = "fsl,dcsr-corenet";
++			reg = <0x8000 0x1000 0xb0000 0x1000>;
++		};
++
++		dcsr-dpaa@9000 {
++			compatible = "fsl,p2041-dcsr-dpaa", "fsl,dcsr-dpaa";
++			reg = <0x9000 0x1000>;
++		};
++
++		dcsr-ocn@11000 {
++			compatible = "fsl,p2041-dcsr-ocn", "fsl,dcsr-ocn";
++			reg = <0x11000 0x1000>;
++		};
++
++		dcsr-ddr@12000 {
++			compatible = "fsl,dcsr-ddr";
++			dev-handle = <0xb>;
++			reg = <0x12000 0x1000>;
++		};
++
++		dcsr-nal@18000 {
++			compatible = "fsl,p2041-dcsr-nal", "fsl,dcsr-nal";
++			reg = <0x18000 0x1000>;
++		};
++
++		dcsr-rcpm@22000 {
++			compatible = "fsl,p2041-dcsr-rcpm", "fsl,dcsr-rcpm";
++			reg = <0x22000 0x1000>;
++		};
++
++		dcsr-cpu-sb-proxy@40000 {
++			compatible = "fsl,dcsr-e500mc-sb-proxy", "fsl,dcsr-cpu-sb-proxy";
++			cpu-handle = <0xc>;
++			reg = <0x40000 0x1000>;
++		};
++
++		dcsr-cpu-sb-proxy@41000 {
++			compatible = "fsl,dcsr-e500mc-sb-proxy", "fsl,dcsr-cpu-sb-proxy";
++			cpu-handle = <0xd>;
++			reg = <0x41000 0x1000>;
++		};
++
++		dcsr-cpu-sb-proxy@42000 {
++			compatible = "fsl,dcsr-e500mc-sb-proxy", "fsl,dcsr-cpu-sb-proxy";
++			cpu-handle = <0xe>;
++			reg = <0x42000 0x1000>;
++		};
++
++		dcsr-cpu-sb-proxy@43000 {
++			compatible = "fsl,dcsr-e500mc-sb-proxy", "fsl,dcsr-cpu-sb-proxy";
++			cpu-handle = <0xf>;
++			reg = <0x43000 0x1000>;
++		};
++	};
++
++	bman-portals@ff4000000 {
++		ranges = <0x0 0xf 0xf4000000 0x200000>;
++		#address-cells = <0x1>;
++		#size-cells = <0x1>;
++		compatible = "simple-bus";
++
++		bman-portal@0 {
++			cell-index = <0x0>;
++			compatible = "fsl,bman-portal";
++			reg = <0x0 0x4000 0x100000 0x1000>;
++			interrupts = <0x69 0x2 0x0 0x0>;
++		};
++
++		bman-portal@4000 {
++			cell-index = <0x1>;
++			compatible = "fsl,bman-portal";
++			reg = <0x4000 0x4000 0x101000 0x1000>;
++			interrupts = <0x6b 0x2 0x0 0x0>;
++		};
++
++		bman-portal@8000 {
++			cell-index = <0x2>;
++			compatible = "fsl,bman-portal";
++			reg = <0x8000 0x4000 0x102000 0x1000>;
++			interrupts = <0x6d 0x2 0x0 0x0>;
++		};
++
++		bman-portal@c000 {
++			cell-index = <0x3>;
++			compatible = "fsl,bman-portal";
++			reg = <0xc000 0x4000 0x103000 0x1000>;
++			interrupts = <0x6f 0x2 0x0 0x0>;
++		};
++
++		bman-portal@10000 {
++			cell-index = <0x4>;
++			compatible = "fsl,bman-portal";
++			reg = <0x10000 0x4000 0x104000 0x1000>;
++			interrupts = <0x71 0x2 0x0 0x0>;
++		};
++
++		bman-portal@14000 {
++			cell-index = <0x5>;
++			compatible = "fsl,bman-portal";
++			reg = <0x14000 0x4000 0x105000 0x1000>;
++			interrupts = <0x73 0x2 0x0 0x0>;
++		};
++
++		bman-portal@18000 {
++			cell-index = <0x6>;
++			compatible = "fsl,bman-portal";
++			reg = <0x18000 0x4000 0x106000 0x1000>;
++			interrupts = <0x75 0x2 0x0 0x0>;
++		};
++
++		bman-portal@1c000 {
++			cell-index = <0x7>;
++			compatible = "fsl,bman-portal";
++			reg = <0x1c000 0x4000 0x107000 0x1000>;
++			interrupts = <0x77 0x2 0x0 0x0>;
++		};
++
++		bman-portal@20000 {
++			cell-index = <0x8>;
++			compatible = "fsl,bman-portal";
++			reg = <0x20000 0x4000 0x108000 0x1000>;
++			interrupts = <0x79 0x2 0x0 0x0>;
++		};
++
++		bman-portal@24000 {
++			cell-index = <0x9>;
++			compatible = "fsl,bman-portal";
++			reg = <0x24000 0x4000 0x109000 0x1000>;
++			interrupts = <0x7b 0x2 0x0 0x0>;
++		};
++
++		bman-bpids@0 {
++			compatible = "fsl,bpid-range";
++			fsl,bpid-range = <0x20 0x20>;
++		};
++	};
++
++	qman-portals@ff4200000 {
++		ranges = <0x0 0xf 0xf4200000 0x200000>;
++		#address-cells = <0x1>;
++		#size-cells = <0x1>;
++		compatible = "simple-bus";
++
++		qman-portal@0 {
++			cell-index = <0x0>;
++			compatible = "fsl,qman-portal";
++			reg = <0x0 0x4000 0x100000 0x1000>;
++			interrupts = <0x68 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x0>;
++		};
++
++		qman-portal@4000 {
++			cell-index = <0x1>;
++			compatible = "fsl,qman-portal";
++			reg = <0x4000 0x4000 0x101000 0x1000>;
++			interrupts = <0x6a 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x1>;
++		};
++
++		qman-portal@8000 {
++			cell-index = <0x2>;
++			compatible = "fsl,qman-portal";
++			reg = <0x8000 0x4000 0x102000 0x1000>;
++			interrupts = <0x6c 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x2>;
++		};
++
++		qman-portal@c000 {
++			cell-index = <0x3>;
++			compatible = "fsl,qman-portal";
++			reg = <0xc000 0x4000 0x103000 0x1000>;
++			interrupts = <0x6e 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x3>;
++		};
++
++		qman-portal@10000 {
++			cell-index = <0x4>;
++			compatible = "fsl,qman-portal";
++			reg = <0x10000 0x4000 0x104000 0x1000>;
++			interrupts = <0x70 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x4>;
++		};
++
++		qman-portal@14000 {
++			cell-index = <0x5>;
++			compatible = "fsl,qman-portal";
++			reg = <0x14000 0x4000 0x105000 0x1000>;
++			interrupts = <0x72 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x5>;
++		};
++
++		qman-portal@18000 {
++			cell-index = <0x6>;
++			compatible = "fsl,qman-portal";
++			reg = <0x18000 0x4000 0x106000 0x1000>;
++			interrupts = <0x74 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x6>;
++		};
++
++		qman-portal@1c000 {
++			cell-index = <0x7>;
++			compatible = "fsl,qman-portal";
++			reg = <0x1c000 0x4000 0x107000 0x1000>;
++			interrupts = <0x76 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x7>;
++		};
++
++		qman-portal@20000 {
++			cell-index = <0x8>;
++			compatible = "fsl,qman-portal";
++			reg = <0x20000 0x4000 0x108000 0x1000>;
++			interrupts = <0x78 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x8>;
++		};
++
++		qman-portal@24000 {
++			cell-index = <0x9>;
++			compatible = "fsl,qman-portal";
++			reg = <0x24000 0x4000 0x109000 0x1000>;
++			interrupts = <0x7a 0x2 0x0 0x0>;
++			fsl,qman-channel-id = <0x9>;
++		};
++
++		qman-fqids@0 {
++			compatible = "fsl,fqid-range";
++			fsl,fqid-range = <0x100 0x100>;
++		};
++
++		qman-fqids@1 {
++			compatible = "fsl,fqid-range";
++			fsl,fqid-range = <0x8000 0x8000>;
++		};
++
++		qman-pools@0 {
++			compatible = "fsl,pool-channel-range";
++			fsl,pool-channel-range = <0x21 0xf>;
++		};
++
++		qman-cgrids@0 {
++			compatible = "fsl,cgrid-range";
++			fsl,cgrid-range = <0x0 0x100>;
++		};
++	};
++
++	soc@ffe000000 {
++		ranges = <0x0 0xf 0xfe000000 0x1000000>;
++		reg = <0xf 0xfe000000 0x0 0x1000>;
++		#address-cells = <0x1>;
++		#size-cells = <0x1>;
++		device_type = "soc";
++		compatible = "simple-bus";
++
++		spi@110000 {
++			#address-cells = <0x1>;
++			#size-cells = <0x0>;
++			compatible = "fsl,mpc8536-espi";
++			reg = <0x110000 0x1000>;
++			interrupts = <0x35 0x2 0x0 0x0>;
++			fsl,espi-num-chipselects = <0x4>;
++
++			flash@0 {
++				#address-cells = <0x1>;
++				#size-cells = <0x1>;
++				compatible = "s25fl512s","numonyx,n25q512a13";
 +
 +				reg = <0x0>;
 +				spi-max-frequency = <0xb71b00>;

--- a/machine/accton/accton_as6700_32x/machine.make
+++ b/machine/accton/accton_as6700_32x/machine.make
@@ -8,11 +8,13 @@
 
 ONIE_ARCH ?= powerpc-softfloat
 
-VENDOR_REV ?= 0
+VENDOR_REV ?= r01c
 
 # Translate hardware revision to ONIE hardware revision
-ifeq ($(VENDOR_REV),0)
+ifeq ($(VENDOR_REV),r01b)
   MACHINE_REV = 0
+else ifeq ($(VENDOR_REV),r01c)
+  MACHINE_REV = 1
 else
   $(warning Unknown VENDOR_REV '$(VENDOR_REV)' for MACHINE '$(MACHINE)')
   $(error Unknown VENDOR_REV)
@@ -21,8 +23,7 @@ endif
 EXT3_4_ENABLE = yes
 UBOOT_PBL_ENABLE = yes
 
-UBOOT_MACHINE = AS6700_32X
-KERNEL_DTB = as6700_32x.dtb
+KERNEL_DTB = $(MACHINE_PREFIX).dtb
 
 # Vendor ID -- IANA Private Enterprise Number:
 # http://www.iana.org/assignments/enterprise-numbers

--- a/machine/accton/accton_as6700_32x/onie-rom.conf
+++ b/machine/accton/accton_as6700_32x/onie-rom.conf
@@ -13,8 +13,6 @@ description="Accton, AS6700_32X"
 
 format=ubootenv_onie
 
-uboot_machine=AS6700_32X
-
 uimage_max_size=$(( 8 * 1024 * 1024 ))
 
 # CONFIG_ENV_SECT_SIZE set in u-boot config

--- a/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
+++ b/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
@@ -20791,7 +20791,7 @@ index 078a6e4..10ce3de 100644
  };
  
 diff --git a/boards.cfg b/boards.cfg
-index e4b0d44..46f3029 100644
+index e4b0d44..8348ace 100644
 --- a/boards.cfg
 +++ b/boards.cfg
 @@ -732,6 +732,12 @@ MPC8569MDS_NAND              powerpc     mpc85xx     mpc8569mds          freesca
@@ -20841,15 +20841,16 @@ index e4b0d44..46f3029 100644
  P2010RDB                     powerpc     mpc85xx     p1_p2_rdb           freescale      -           P1_P2_RDB:P2010RDB
  P2010RDB_36BIT               powerpc     mpc85xx     p1_p2_rdb           freescale      -           P1_P2_RDB:P2010RDB,36BIT
  P2010RDB_36BIT_SDCARD        powerpc     mpc85xx     p1_p2_rdb           freescale      -           P1_P2_RDB:P2010RDB,36BIT,SDCARD
-@@ -836,6 +850,7 @@ P2041RDB_NAND	             powerpc     mpc85xx     p2041rdb            freescale
+@@ -836,6 +850,8 @@ P2041RDB_NAND	             powerpc     mpc85xx     p2041rdb            freescale
  P2041RDB_SDCARD              powerpc     mpc85xx     p2041rdb            freescale      -           P2041RDB:RAMBOOT_PBL,SDCARD,SYS_TEXT_BASE=0xFFF80000
  P2041RDB_SECURE_BOOT         powerpc     mpc85xx     p2041rdb            freescale      -           P2041RDB:SECURE_BOOT
  P2041RDB_SPIFLASH            powerpc     mpc85xx     p2041rdb            freescale      -           P2041RDB:RAMBOOT_PBL,SPIFLASH,SYS_TEXT_BASE=0xFFF80000
-+AS6700_32X                   powerpc     mpc85xx     as6700_32x          freescale      -           AS6700_32X:RAMBOOT_PBL,SPIFLASH,SYS_TEXT_BASE=0xFFF80000
++ACCTON_AS6700_32X-R0         powerpc     mpc85xx     as6700_32x          freescale      -           ACCTON_AS6700_32X-R0:RAMBOOT_PBL,SPIFLASH,SYS_TEXT_BASE=0xFFF80000
++ACCTON_AS6700_32X-R1         powerpc     mpc85xx     as6700_32x          freescale      -           ACCTON_AS6700_32X-R1:RAMBOOT_PBL,SPIFLASH,SYS_TEXT_BASE=0xFFF80000
  P2041RDB_SRIO_PCIE_BOOT          powerpc     mpc85xx     p2041rdb          freescale      -           P2041RDB:SRIO_PCIE_BOOT_SLAVE,SYS_TEXT_BASE=0xFFF80000
  P3041DS                      powerpc     mpc85xx     corenet_ds          freescale
  P3041DS_NAND		     powerpc     mpc85xx     corenet_ds          freescale      -           P3041DS:RAMBOOT_PBL,NAND,SYS_TEXT_BASE=0xFFF80000
-@@ -855,13 +870,52 @@ P5020DS_SECURE_BOOT          powerpc     mpc85xx     corenet_ds          freesca
+@@ -855,13 +871,52 @@ P5020DS_SECURE_BOOT          powerpc     mpc85xx     corenet_ds          freesca
  P5020DS_SPIFLASH	     powerpc     mpc85xx     corenet_ds          freescale      -           P5020DS:RAMBOOT_PBL,SPIFLASH,SYS_TEXT_BASE=0xFFF80000
  P5020DS_SRIO_PCIE_BOOT          powerpc     mpc85xx     corenet_ds          freescale      -           P5020DS:SRIO_PCIE_BOOT_SLAVE,SYS_TEXT_BASE=0xFFF80000
  P5040DS                      powerpc     mpc85xx     corenet_ds          freescale
@@ -37723,11 +37724,895 @@ index a29f6a6..f26a80d 100644
  int populate_serial_number(void);
  extern u8 _binary_dt_dtb_start[];	/* embedded device tree blob */
  int set_cpu_clk_info(void);
-diff --git a/include/configs/AS6700_32X.h b/include/configs/AS6700_32X.h
+diff --git a/include/configs/ACCTON_AS6700_32X-R0.h b/include/configs/ACCTON_AS6700_32X-R0.h
+new file mode 100644
+index 0000000..c104e77
+--- /dev/null
++++ b/include/configs/ACCTON_AS6700_32X-R0.h
+@@ -0,0 +1,878 @@
++/*
++ * Copyright 2011-2012 Freescale Semiconductor, Inc.
++ *
++ * See file CREDITS for list of people who contributed to this
++ * project.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License as
++ * published by the Free Software Foundation; either version 2 of
++ * the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
++ * MA 02111-1307 USA
++ */
++
++/*
++ * P2041 RDB board configuration file
++ * Also supports P2040 RDB
++ */
++#ifndef __CONFIG_H
++#define __CONFIG_H
++
++#define ACCTON_AS6700_32X
++#define CONFIG_BOARDNAME "Accton AS6700_32X"
++#define CONFIG_LAST_STAGE_INIT
++
++#define CONFIG_SYNC_VERSION_VARIABLE_TO_FLASH
++
++#define CONFIG_P2041RDB
++#define CONFIG_PHYS_64BIT
++#define CONFIG_PPC_P2041
++
++#ifdef CONFIG_RAMBOOT_PBL
++#define CONFIG_RAMBOOT_TEXT_BASE	CONFIG_SYS_TEXT_BASE
++#define CONFIG_RESET_VECTOR_ADDRESS	0xfffffffc
++#define CONFIG_PBLPBI_CONFIG $(SRCTREE)/board/freescale/as6700_32x/pbi.cfg
++#define CONFIG_PBLRCW_CONFIG $(SRCTREE)/board/freescale/as6700_32x/rcw.cfg
++#endif
++
++#if 0
++#ifdef CONFIG_SRIO_PCIE_BOOT_SLAVE
++/* Set 1M boot space */
++#define CONFIG_SYS_SRIO_PCIE_BOOT_SLAVE_ADDR (CONFIG_SYS_TEXT_BASE & 0xfff00000)
++#define CONFIG_SYS_SRIO_PCIE_BOOT_SLAVE_ADDR_PHYS \
++		(0x300000000ull | CONFIG_SYS_SRIO_PCIE_BOOT_SLAVE_ADDR)
++#define CONFIG_RESET_VECTOR_ADDRESS 0xfffffffc
++#define CONFIG_SYS_NO_FLASH
++#endif
++#endif
++
++/* High Level Configuration Options */
++#define CONFIG_BOOKE
++#define CONFIG_E500			/* BOOKE e500 family */
++#define CONFIG_E500MC			/* BOOKE e500mc family */
++#define CONFIG_SYS_BOOK3E_HV		/* Category E.HV supported */
++#define CONFIG_MPC85xx			/* MPC85xx/PQ3 platform */
++#define CONFIG_MP			/* support multiple processors */
++
++#ifndef CONFIG_SYS_TEXT_BASE
++#define CONFIG_SYS_TEXT_BASE	0xeff80000
++#endif
++
++#ifndef CONFIG_RESET_VECTOR_ADDRESS
++#define CONFIG_RESET_VECTOR_ADDRESS	0xeffffffc
++#endif
++
++#define CONFIG_SYS_FSL_CPC		/* Corenet Platform Cache */
++#define CONFIG_SYS_NUM_CPC		CONFIG_NUM_DDR_CONTROLLERS
++#define CONFIG_FSL_ELBC			/* Has Enhanced localbus controller */
++#define CONFIG_PCI			/* Enable PCI/PCIE */
++#define CONFIG_PCIE1			/* PCIE controler 1 */
++#define CONFIG_PCIE2			/* PCIE controler 2 */
++#define CONFIG_PCIE3			/* PCIE controler 3 */
++#define CONFIG_FSL_PCI_INIT		/* Use common FSL init code */
++#define CONFIG_SYS_PCI_64BIT		/* enable 64-bit PCI resources */
++
++#if 0
++#define CONFIG_SYS_SRIO
++#define CONFIG_SRIO1			/* SRIO port 1 */
++#define CONFIG_SRIO2			/* SRIO port 2 */
++#define CONFIG_SRIO_PCIE_BOOT_MASTER
++#define CONFIG_SYS_DPAA_RMAN		/* RMan */
++#endif
++
++#define CONFIG_FSL_LAW			/* Use common FSL init code */
++
++#define CONFIG_ENV_OVERWRITE
++
++#define CONFIG_SYS_NO_FLASH
++
++#ifdef CONFIG_SYS_NO_FLASH
++#if !defined(CONFIG_RAMBOOT_PBL) && !defined(CONFIG_SRIO_PCIE_BOOT_SLAVE)
++#define CONFIG_ENV_IS_NOWHERE
++#endif
++#else
++#define CONFIG_FLASH_CFI_DRIVER
++#define CONFIG_SYS_FLASH_CFI
++#define CONFIG_SYS_FLASH_USE_BUFFER_WRITE
++#endif
++
++#define CONFIG_SPI_FLASH_STMICRO
++#define CONFIG_SPI_FLASH_MACRONIX
++#define CONFIG_SPI_FLASH_BAR
++
++#if defined(CONFIG_SPIFLASH)
++	#define CONFIG_SYS_EXTRA_ENV_RELOC
++	#define CONFIG_ENV_IS_IN_SPI_FLASH
++	#define CONFIG_ENV_SPI_BUS              0
++	#define CONFIG_ENV_SPI_CS               0
++	#define CONFIG_ENV_SPI_MAX_HZ           10000000
++	#define CONFIG_ENV_SPI_MODE             0
++	#define CONFIG_ENV_SIZE                 0x2000          /* 8KB */
++	#define CONFIG_ENV_OFFSET               0x100000        /* 1MB */
++	#define CONFIG_ENV_SECT_SIZE            0x10000
++#elif defined(CONFIG_SDCARD)
++	#define CONFIG_SYS_EXTRA_ENV_RELOC
++	#define CONFIG_ENV_IS_IN_MMC
++	#define CONFIG_FSL_FIXED_MMC_LOCATION
++	#define CONFIG_SYS_MMC_ENV_DEV          0
++	#define CONFIG_ENV_SIZE			0x2000
++	#define CONFIG_ENV_OFFSET		(512 * 1105)
++#else
++	#error No supported storage type was defined.
++#endif
++
++/*#define CONFIG_BOOTARGS     "root=/dev/ram rw console=ttyS0,115200 mem=3968M quiet"*/
++/*#define CONFIG_ETHADDR      00:E0:0C:00:00:FD*/
++/*#define CONFIG_ETH2ADDR     00:00:00:00:00:02*/
++/*#define CONFIG_ETH3ADDR     00:00:00:00:00:03*/
++#define CONFIG_IPADDR       192.168.3.10
++#define CONFIG_SERVERIP     192.168.3.14
++#define CONFIG_GATEWAYIP    192.168.3.14
++#define CONFIG_NETMASK      255.255.255.0
++
++#ifndef __ASSEMBLY__
++unsigned long get_board_sys_clk(unsigned long dummy);
++#endif
++#define CONFIG_SYS_CLK_FREQ	get_board_sys_clk(0)
++
++/*
++ * These can be toggled for performance analysis, otherwise use default.
++ */
++#define CONFIG_SYS_CACHE_STASHING
++#define CONFIG_BACKSIDE_L2_CACHE
++#define CONFIG_SYS_INIT_L2CSR0		L2CSR0_L2E
++#define CONFIG_BTB			/* toggle branch predition */
++
++#define CONFIG_ENABLE_36BIT_PHYS
++
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_ADDR_MAP
++#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
++#endif
++
++#define CONFIG_POST CONFIG_SYS_POST_MEMORY	/* test POST memory test */
++#define CONFIG_SYS_MEMTEST_START	0x00200000	/* memtest works on */
++#define CONFIG_SYS_MEMTEST_END		0x00400000
++#define CONFIG_SYS_ALT_MEMTEST
++#define CONFIG_PANIC_HANG	/* do not reset board on panic */
++
++/*
++ *  Config the L3 Cache as L3 SRAM
++ */
++#define CONFIG_SYS_INIT_L3_ADDR		CONFIG_RAMBOOT_TEXT_BASE
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_INIT_L3_ADDR_PHYS	(0xf00000000ull | \
++		CONFIG_RAMBOOT_TEXT_BASE)
++#else
++#define CONFIG_SYS_INIT_L3_ADDR_PHYS	CONFIG_SYS_INIT_L3_ADDR
++#endif
++#define CONFIG_SYS_L3_SIZE		(1024 << 10)
++#define CONFIG_SYS_INIT_L3_END (CONFIG_SYS_INIT_L3_ADDR + CONFIG_SYS_L3_SIZE)
++
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_DCSRBAR		0xf0000000
++#define CONFIG_SYS_DCSRBAR_PHYS		0xf00000000ull
++#endif
++
++/* EEPROM */
++#define CONFIG_ID_EEPROM
++#define CONFIG_SYS_I2C_EEPROM_NXID
++#define CONFIG_SYS_EEPROM_BUS_NUM	0
++#define CONFIG_SYS_I2C_EEPROM_ADDR	0x50
++#define CONFIG_SYS_I2C_EEPROM_ADDR_LEN	1
++
++/*
++ * DDR Setup
++ */
++#define CONFIG_VERY_BIG_RAM
++#define CONFIG_SYS_DDR_SDRAM_BASE	0x00000000
++#define CONFIG_SYS_SDRAM_BASE		CONFIG_SYS_DDR_SDRAM_BASE
++
++#define CONFIG_DIMM_SLOTS_PER_CTLR	1
++#define CONFIG_CHIP_SELECTS_PER_CTRL    (1 * CONFIG_DIMM_SLOTS_PER_CTLR)
++
++#define CONFIG_DDR_SPD
++#define CONFIG_FSL_DDR3
++
++#define CONFIG_DDR_ECC
++#define CONFIG_MEM_INIT_VALUE 0xdeadbeef
++/*#define CONFIG_SYS_DRAM_TEST*/
++
++#define CONFIG_SYS_SPD_BUS_NUM	0
++
++#define SPD_EEPROM_ADDRESS 0x50
++#define CONFIG_SYS_SDRAM_SIZE 2048  /* for fixed parameter use */
++
++/*
++ * Local Bus Definitions
++ */
++
++/* Set the local bus clock 1/8 of platform clock */
++#define CONFIG_SYS_LBC_LCRR     LCRR_CLKDIV_32
++
++/*
++ * This board doesn't have a promjet connector.
++ * However, it uses commone corenet board LAW and TLB.
++ * It is necessary to use the same start address with proper offset.
++ */
++#define CONFIG_SYS_FLASH_BASE       0xec000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_FLASH_BASE_PHYS  0xfec000000ull
++#else
++#define CONFIG_SYS_FLASH_BASE_PHYS	CONFIG_SYS_FLASH_BASE
++#endif
++
++/*#define CONFIG_SYS_FLASH_BR_PRELIM \
++		(BR_PHYS_ADDR((CONFIG_SYS_FLASH_BASE_PHYS + 0x8000000)) | \
++		BR_PS_16 | BR_V)*/
++#define CONFIG_SYS_FLASH_BR_PRELIM \
++        (BR_PHYS_ADDR(CONFIG_SYS_FLASH_BASE_PHYS) | BR_PS_16 | BR_V)
++/*#define CONFIG_SYS_FLASH_OR_PRELIM \
++		((0xf8000ff7 & ~OR_GPCM_SCY & ~OR_GPCM_EHTR) \
++		 | OR_GPCM_SCY_8 | OR_GPCM_EHTR_CLEAR)*/
++#define CONFIG_SYS_FLASH_OR_PRELIM \
++        ((0xfc000ff7 & ~OR_GPCM_SCY & ~OR_GPCM_EHTR) \
++         | OR_GPCM_SCY_8 | OR_GPCM_EHTR_CLEAR)
++
++#define CONFIG_FSL_CPLD
++#define CPLD_BASE		0xffdf0000	/* CPLD registers */
++#ifdef CONFIG_PHYS_64BIT
++#define CPLD_BASE_PHYS		0xfffdf0000ull
++#else
++#define CPLD_BASE_PHYS		CPLD_BASE
++#endif
++
++#define CONFIG_SYS_BR3_PRELIM	(BR_PHYS_ADDR(CPLD_BASE_PHYS) | BR_PS_8 | BR_V)
++#define CONFIG_SYS_OR3_PRELIM	0xffffeff7	/* 32KB but only 4k mapped */
++
++#define PIXIS_LBMAP_SWITCH	7
++#define PIXIS_LBMAP_MASK	0xf0
++#define PIXIS_LBMAP_SHIFT	4
++#define PIXIS_LBMAP_ALTBANK	0x40
++
++#define CONFIG_SYS_FLASH_QUIET_TEST
++#define CONFIG_FLASH_SHOW_PROGRESS	45 /* count down from 45/5: 9..1 */
++
++#define CONFIG_SYS_MAX_FLASH_BANKS	1		/* number of banks */
++#define CONFIG_SYS_MAX_FLASH_SECT	1024		/* sectors per device */
++#define CONFIG_SYS_FLASH_ERASE_TOUT	60000		/* Erase Timeout (ms) */
++#define CONFIG_SYS_FLASH_WRITE_TOUT	500		/* Write Timeout (ms) */
++
++#define CONFIG_SYS_MONITOR_BASE		CONFIG_SYS_TEXT_BASE
++
++#if defined(CONFIG_RAMBOOT_PBL)
++#define CONFIG_SYS_RAMBOOT
++#endif
++
++/*#define CONFIG_NAND_FSL_ELBC*/
++/* Nand Flash */
++#ifdef CONFIG_NAND_FSL_ELBC
++#define CONFIG_SYS_NAND_BASE		0xffa00000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_NAND_BASE_PHYS	0xfffa00000ull
++#else
++#define CONFIG_SYS_NAND_BASE_PHYS	CONFIG_SYS_NAND_BASE
++#endif
++
++#define CONFIG_SYS_NAND_BASE_LIST     {CONFIG_SYS_NAND_BASE}
++#define CONFIG_SYS_MAX_NAND_DEVICE	1
++#define CONFIG_MTD_NAND_VERIFY_WRITE
++#define CONFIG_CMD_NAND
++#define CONFIG_SYS_NAND_BLOCK_SIZE    (128 * 1024)
++
++/* NAND flash config */
++#define CONFIG_SYS_NAND_BR_PRELIM  (BR_PHYS_ADDR(CONFIG_SYS_NAND_BASE_PHYS) \
++			       | (2<<BR_DECC_SHIFT)    /* Use HW ECC */ \
++			       | BR_PS_8	       /* Port Size = 8 bit */ \
++			       | BR_MS_FCM	       /* MSEL = FCM */ \
++			       | BR_V)		       /* valid */
++#define CONFIG_SYS_NAND_OR_PRELIM  (0xFFFC0000	      /* length 256K */ \
++			       | OR_FCM_PGS	       /* Large Page*/ \
++			       | OR_FCM_CSCT \
++			       | OR_FCM_CST \
++			       | OR_FCM_CHT \
++			       | OR_FCM_SCY_1 \
++			       | OR_FCM_TRLX \
++			       | OR_FCM_EHTR)
++
++#ifdef CONFIG_NAND
++#define CONFIG_SYS_BR0_PRELIM  CONFIG_SYS_NAND_BR_PRELIM /* NAND Base Address */
++#define CONFIG_SYS_OR0_PRELIM  CONFIG_SYS_NAND_OR_PRELIM /* NAND Options */
++#define CONFIG_SYS_BR1_PRELIM  CONFIG_SYS_FLASH_BR_PRELIM /* NOR Base Address */
++#define CONFIG_SYS_OR1_PRELIM  CONFIG_SYS_FLASH_OR_PRELIM /* NOR Options */
++#else
++#define CONFIG_SYS_BR0_PRELIM  CONFIG_SYS_FLASH_BR_PRELIM /* NOR Base Address */
++#define CONFIG_SYS_OR0_PRELIM  CONFIG_SYS_FLASH_OR_PRELIM /* NOR Options */
++#define CONFIG_SYS_BR1_PRELIM  CONFIG_SYS_NAND_BR_PRELIM /* NAND Base Address */
++#define CONFIG_SYS_OR1_PRELIM  CONFIG_SYS_NAND_OR_PRELIM /* NAND Options */
++#endif
++#else
++#define CONFIG_SYS_BR0_PRELIM  CONFIG_SYS_FLASH_BR_PRELIM /* NOR Base Address */
++#define CONFIG_SYS_OR0_PRELIM  CONFIG_SYS_FLASH_OR_PRELIM /* NOR Options */
++#endif /* CONFIG_NAND_FSL_ELBC */
++
++#define CONFIG_SYS_FLASH_EMPTY_INFO
++#define CONFIG_SYS_FLASH_AMD_CHECK_DQ7
++/*#define CONFIG_SYS_FLASH_BANKS_LIST	{CONFIG_SYS_FLASH_BASE_PHYS + 0x8000000}*/
++#define CONFIG_SYS_FLASH_BANKS_LIST {CONFIG_SYS_FLASH_BASE_PHYS}
++
++#define CONFIG_BOARD_EARLY_INIT_F
++#define CONFIG_BOARD_EARLY_INIT_R	/* call board_early_init_r function */
++#define CONFIG_MISC_INIT_R
++
++#define CONFIG_HWCONFIG
++
++/* define to use L1 as initial stack */
++#define CONFIG_L1_INIT_RAM
++#define CONFIG_SYS_INIT_RAM_LOCK
++#define CONFIG_SYS_INIT_RAM_ADDR	0xffd00000	/* Initial L1 address */
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_INIT_RAM_ADDR_PHYS_HIGH 0xf
++#define CONFIG_SYS_INIT_RAM_ADDR_PHYS_LOW CONFIG_SYS_INIT_RAM_ADDR
++/* The assembler doesn't like typecast */
++#define CONFIG_SYS_INIT_RAM_ADDR_PHYS \
++	((CONFIG_SYS_INIT_RAM_ADDR_PHYS_HIGH * 1ull << 32) | \
++	  CONFIG_SYS_INIT_RAM_ADDR_PHYS_LOW)
++#else
++#define CONFIG_SYS_INIT_RAM_ADDR_PHYS	CONFIG_SYS_INIT_RAM_ADDR
++#define CONFIG_SYS_INIT_RAM_ADDR_PHYS_HIGH 0
++#define CONFIG_SYS_INIT_RAM_ADDR_PHYS_LOW CONFIG_SYS_INIT_RAM_ADDR_PHYS
++#endif
++#define CONFIG_SYS_INIT_RAM_SIZE	0x00004000
++
++#define CONFIG_SYS_GBL_DATA_OFFSET	(CONFIG_SYS_INIT_RAM_SIZE - \
++					GENERATED_GBL_DATA_SIZE)
++#define CONFIG_SYS_INIT_SP_OFFSET	CONFIG_SYS_GBL_DATA_OFFSET
++
++#define CONFIG_SYS_MONITOR_LEN		(512 * 1024)
++#define CONFIG_SYS_MALLOC_LEN		(1024 * 1024)
++
++/* Serial Port - controlled on board with jumper J8
++ * open - index 2
++ * shorted - index 1
++ */
++#define CONFIG_CONS_INDEX	1
++#define CONFIG_SYS_NS16550
++#define CONFIG_SYS_NS16550_SERIAL
++#define CONFIG_SYS_NS16550_REG_SIZE	1
++#define CONFIG_SYS_NS16550_CLK		(get_bus_freq(0)/2)
++
++#define CONFIG_SYS_BAUDRATE_TABLE	\
++	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200}
++
++#define CONFIG_SYS_NS16550_COM1	(CONFIG_SYS_CCSRBAR+0x11C500)
++#define CONFIG_SYS_NS16550_COM2	(CONFIG_SYS_CCSRBAR+0x11C600)
++#define CONFIG_SYS_NS16550_COM3	(CONFIG_SYS_CCSRBAR+0x11D500)
++#define CONFIG_SYS_NS16550_COM4	(CONFIG_SYS_CCSRBAR+0x11D600)
++
++/* Use the HUSH parser */
++#define CONFIG_SYS_HUSH_PARSER
++
++/* pass open firmware flat tree */
++#define CONFIG_OF_LIBFDT
++#define CONFIG_OF_BOARD_SETUP
++#define CONFIG_OF_STDOUT_VIA_ALIAS
++
++/* new uImage format support */
++#define CONFIG_FIT
++#define CONFIG_FIT_VERBOSE	/* enable fit_format_{error,warning}() */
++
++/* I2C */
++#define CONFIG_FSL_I2C		/* Use FSL common I2C driver */
++#define CONFIG_HARD_I2C		/* I2C with hardware support */
++#define CONFIG_I2C_MULTI_BUS
++#define CONFIG_I2C_CMD_TREE
++#define CONFIG_SYS_I2C_SPEED		100000
++#define CONFIG_SYS_I2C_SLAVE		0x7F
++#define CONFIG_SYS_I2C_OFFSET		0x118000
++#define CONFIG_SYS_I2C2_OFFSET		0x118100
++#define CONFIG_SYS_I2C3_OFFSET      0x119000
++#define CONFIG_SYS_I2C4_OFFSET      0x119100
++
++
++#if 0
++/*
++ * RapidIO
++ */
++#define CONFIG_SYS_SRIO1_MEM_VIRT	0xa0000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_SRIO1_MEM_PHYS	0xc20000000ull
++#else
++#define CONFIG_SYS_SRIO1_MEM_PHYS	0xa0000000
++#endif
++#define CONFIG_SYS_SRIO1_MEM_SIZE	0x10000000	/* 256M */
++
++#define CONFIG_SYS_SRIO2_MEM_VIRT	0xb0000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_SRIO2_MEM_PHYS	0xc30000000ull
++#else
++#define CONFIG_SYS_SRIO2_MEM_PHYS	0xb0000000
++#endif
++#define CONFIG_SYS_SRIO2_MEM_SIZE	0x10000000	/* 256M */
++
++/*
++ * for slave u-boot IMAGE instored in master memory space,
++ * PHYS must be aligned based on the SIZE
++ */
++#define CONFIG_SRIO_PCIE_BOOT_IMAGE_MEM_PHYS 0xfef080000ull
++#define CONFIG_SRIO_PCIE_BOOT_IMAGE_MEM_BUS1 0xfff80000ull
++#define CONFIG_SRIO_PCIE_BOOT_IMAGE_SIZE 0x80000	/* 512K */
++#define CONFIG_SRIO_PCIE_BOOT_IMAGE_MEM_BUS2 0x3fff80000ull
++/*
++ * for slave UCODE and ENV instored in master memory space,
++ * PHYS must be aligned based on the SIZE
++ */
++#define CONFIG_SRIO_PCIE_BOOT_UCODE_ENV_MEM_PHYS 0xfef040000ull
++#define CONFIG_SRIO_PCIE_BOOT_UCODE_ENV_MEM_BUS 0x3ffe00000ull
++#define CONFIG_SRIO_PCIE_BOOT_UCODE_ENV_SIZE 0x40000	/* 256K */
++
++/* slave core release by master*/
++#define CONFIG_SRIO_PCIE_BOOT_BRR_OFFSET 0xe00e4
++#define CONFIG_SRIO_PCIE_BOOT_RELEASE_MASK 0x00000001 /* release core 0 */
++
++/*
++ * SRIO_PCIE_BOOT - SLAVE
++ */
++#ifdef CONFIG_SRIO_PCIE_BOOT_SLAVE
++#define CONFIG_SYS_SRIO_PCIE_BOOT_UCODE_ENV_ADDR 0xFFE00000
++#define CONFIG_SYS_SRIO_PCIE_BOOT_UCODE_ENV_ADDR_PHYS \
++		(0x300000000ull | CONFIG_SYS_SRIO_PCIE_BOOT_UCODE_ENV_ADDR)
++#endif
++
++#endif
++
++/*
++ * eSPI - Enhanced SPI
++ */
++#define CONFIG_FSL_ESPI
++#define CONFIG_SPI_FLASH
++/*#define CONFIG_SPI_FLASH_SPANSION*/
++#define CONFIG_CMD_SF
++#define CONFIG_SF_DEFAULT_SPEED         10000000
++#define CONFIG_SF_DEFAULT_MODE          3
++
++/*PCIE default setting*/
++#if 0
++/*
++ * General PCI
++ * Memory space is mapped 1-1, but I/O space must start from 0.
++ */
++
++/* controller 1, direct to uli, tgtid 3, Base address 20000 */
++#define CONFIG_SYS_PCIE1_MEM_VIRT	0x80000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_PCIE1_MEM_BUS	0xe0000000
++#define CONFIG_SYS_PCIE1_MEM_PHYS	0xc00000000ull
++#else
++#define CONFIG_SYS_PCIE1_MEM_BUS	0x80000000
++#define CONFIG_SYS_PCIE1_MEM_PHYS	0x80000000
++#endif
++#define CONFIG_SYS_PCIE1_MEM_SIZE	0x20000000	/* 512M */
++#define CONFIG_SYS_PCIE1_IO_VIRT	0xf8000000
++#define CONFIG_SYS_PCIE1_IO_BUS		0x00000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_PCIE1_IO_PHYS	0xff8000000ull
++#else
++#define CONFIG_SYS_PCIE1_IO_PHYS	0xf8000000
++#endif
++#define CONFIG_SYS_PCIE1_IO_SIZE	0x00010000	/* 64k */
++
++/* controller 2, Slot 2, tgtid 2, Base address 201000 */
++#define CONFIG_SYS_PCIE2_MEM_VIRT	0xa0000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_PCIE2_MEM_BUS	0xe0000000
++#define CONFIG_SYS_PCIE2_MEM_PHYS	0xc20000000ull
++#else
++#define CONFIG_SYS_PCIE2_MEM_BUS	0xa0000000
++#define CONFIG_SYS_PCIE2_MEM_PHYS	0xa0000000
++#endif
++#define CONFIG_SYS_PCIE2_MEM_SIZE	0x20000000	/* 512M */
++#define CONFIG_SYS_PCIE2_IO_VIRT	0xf8010000
++#define CONFIG_SYS_PCIE2_IO_BUS		0x00000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_PCIE2_IO_PHYS	0xff8010000ull
++#else
++#define CONFIG_SYS_PCIE2_IO_PHYS	0xf8010000
++#endif
++#define CONFIG_SYS_PCIE2_IO_SIZE	0x00010000	/* 64k */
++
++/* controller 3, Slot 1, tgtid 1, Base address 202000 */
++#define CONFIG_SYS_PCIE3_MEM_VIRT	0xc0000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_PCIE3_MEM_BUS	0xe0000000
++#define CONFIG_SYS_PCIE3_MEM_PHYS	0xc40000000ull
++#else
++#define CONFIG_SYS_PCIE3_MEM_BUS	0xc0000000
++#define CONFIG_SYS_PCIE3_MEM_PHYS	0xc0000000
++#endif
++#define CONFIG_SYS_PCIE3_MEM_SIZE	0x20000000	/* 512M */
++#define CONFIG_SYS_PCIE3_IO_VIRT	0xf8020000
++#define CONFIG_SYS_PCIE3_IO_BUS		0x00000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_PCIE3_IO_PHYS	0xff8020000ull
++#else
++#define CONFIG_SYS_PCIE3_IO_PHYS	0xf8020000
++#endif
++#define CONFIG_SYS_PCIE3_IO_SIZE	0x00010000	/* 64k */
++#endif
++
++/* controller 1, direct to uli, tgtid 3, Base address 20000 */
++#define CONFIG_SYS_PCIE1_MEM_VIRT   0xd0000000
++#define CONFIG_SYS_PCIE1_MEM_BUS    0xd0000000
++#define CONFIG_SYS_PCIE1_MEM_PHYS   0xd0000000
++#define CONFIG_SYS_PCIE1_MEM_SIZE   0x08000000  /* 128M */
++
++#define CONFIG_SYS_PCIE1_IO_VIRT    0xf8000000
++#define CONFIG_SYS_PCIE1_IO_BUS     0x00000000
++#define CONFIG_SYS_PCIE1_IO_PHYS    0xf8000000
++#define CONFIG_SYS_PCIE1_IO_SIZE    0x00010000  /* 64k */
++
++/* controller 2, Slot 2, tgtid 2, Base address 201000 */
++#define CONFIG_SYS_PCIE2_MEM_VIRT   0xd8000000
++#define CONFIG_SYS_PCIE2_MEM_BUS    0xd8000000
++#define CONFIG_SYS_PCIE2_MEM_PHYS   0xd8000000
++#define CONFIG_SYS_PCIE2_MEM_SIZE   0x08000000  /* 128M */
++
++#define CONFIG_SYS_PCIE2_IO_VIRT    0xf8010000
++#define CONFIG_SYS_PCIE2_IO_BUS     0x00000000
++#define CONFIG_SYS_PCIE2_IO_PHYS    0xf8010000
++#define CONFIG_SYS_PCIE2_IO_SIZE    0x00010000  /* 64k */
++
++/* controller 3, Slot 1, tgtid 1, Base address 202000 */
++#define CONFIG_SYS_PCIE3_MEM_VIRT   0xe0000000
++#define CONFIG_SYS_PCIE3_MEM_BUS    0xe0000000
++#define CONFIG_SYS_PCIE3_MEM_PHYS   0xe0000000
++#define CONFIG_SYS_PCIE3_MEM_SIZE   0x08000000  /* 128M */
++
++#define CONFIG_SYS_PCIE3_IO_VIRT    0xf8020000
++#define CONFIG_SYS_PCIE3_IO_BUS     0x00000000
++#define CONFIG_SYS_PCIE3_IO_PHYS    0xf8020000
++#define CONFIG_SYS_PCIE3_IO_SIZE    0x00010000  /* 64k */
++
++/* Qman/Bman */
++#define CONFIG_SYS_DPAA_QBMAN		/* Support Q/Bman */
++#define CONFIG_SYS_BMAN_NUM_PORTALS	10
++#define CONFIG_SYS_BMAN_MEM_BASE	0xf4000000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_BMAN_MEM_PHYS	0xff4000000ull
++#else
++#define CONFIG_SYS_BMAN_MEM_PHYS	CONFIG_SYS_BMAN_MEM_BASE
++#endif
++#define CONFIG_SYS_BMAN_MEM_SIZE	0x00200000
++#define CONFIG_SYS_QMAN_NUM_PORTALS	10
++#define CONFIG_SYS_QMAN_MEM_BASE	0xf4200000
++#ifdef CONFIG_PHYS_64BIT
++#define CONFIG_SYS_QMAN_MEM_PHYS	0xff4200000ull
++#else
++#define CONFIG_SYS_QMAN_MEM_PHYS	CONFIG_SYS_QMAN_MEM_BASE
++#endif
++#define CONFIG_SYS_QMAN_MEM_SIZE	0x00200000
++
++#define CONFIG_SYS_DPAA_FMAN
++#define CONFIG_SYS_DPAA_PME
++/* Default address of microcode for the Linux Fman driver */
++#if defined(CONFIG_SPIFLASH)
++/*
++ * env is stored at 0x100000, sector size is 0x10000, ucode is stored after
++ * env, so we got 0x110000.
++ */
++#define CONFIG_SYS_QE_FW_IN_SPIFLASH
++#define CONFIG_SYS_QE_FMAN_FW_ADDR	0x110000
++#elif defined(CONFIG_SDCARD)
++/*
++ * PBL SD boot image should stored at 0x1000(8 blocks), the size of the image is
++ * about 545KB (1089 blocks), Env is stored after the image, and the env size is
++ * 0x2000 (16 blocks), 8 + 1089 + 16 = 1113, enlarge it to 1130.
++ */
++#define CONFIG_SYS_QE_FMAN_FW_IN_MMC
++#define CONFIG_SYS_QE_FMAN_FW_ADDR	(512 * 1130)
++#elif defined(CONFIG_NAND)
++#define CONFIG_SYS_QE_FMAN_FW_IN_NAND
++#define CONFIG_SYS_QE_FMAN_FW_ADDR	(6 * CONFIG_SYS_NAND_BLOCK_SIZE)
++#elif defined(CONFIG_SRIO_PCIE_BOOT_SLAVE)
++/*
++ * Slave has no ucode locally, it can fetch this from remote. When implementing
++ * in two corenet boards, slave's ucode could be stored in master's memory
++ * space, the address can be mapped from slave TLB->slave LAW->
++ * slave SRIO or PCIE outbound window->master inbound window->
++ * master LAW->the ucode address in master's memory space.
++ */
++#define CONFIG_SYS_QE_FMAN_FW_IN_REMOTE
++#define CONFIG_SYS_QE_FMAN_FW_ADDR	0xFFE00000
++#else
++#define CONFIG_SYS_QE_FMAN_FW_IN_NOR
++#define CONFIG_SYS_QE_FMAN_FW_ADDR	0xEFF40000
++#endif
++#define CONFIG_SYS_QE_FMAN_FW_LENGTH	0x10000
++#define CONFIG_SYS_FDT_PAD		(0x3000 + CONFIG_SYS_QE_FMAN_FW_LENGTH)
++
++#ifdef CONFIG_SYS_DPAA_FMAN
++#define CONFIG_FMAN_ENET
++#define CONFIG_PHYLIB_10G
++
++/*#define CONFIG_PHY_VITESSE*/
++#define CONFIG_PHY_BROADCOM
++
++#define CONFIG_PHY_TERANETICS
++#endif
++
++#ifdef CONFIG_PCI
++#define CONFIG_NET_MULTI
++#define CONFIG_PCI_PNP			/* do pci plug-and-play */
++#define CONFIG_E1000
++
++#define CONFIG_PCI_SCAN_SHOW		/* show pci devices on startup */
++#define CONFIG_DOS_PARTITION
++#endif	/* CONFIG_PCI */
++
++/* SATA */
++#define CONFIG_FSL_SATA_V2
++
++#ifdef CONFIG_FSL_SATA_V2
++#define CONFIG_FSL_SATA
++#define CONFIG_LIBATA
++
++#define CONFIG_SYS_SATA_MAX_DEVICE	2
++#define CONFIG_SATA1
++#define CONFIG_SYS_SATA1		CONFIG_SYS_MPC85xx_SATA1_ADDR
++#define CONFIG_SYS_SATA1_FLAGS		FLAGS_DMA
++#define CONFIG_SATA2
++#define CONFIG_SYS_SATA2		CONFIG_SYS_MPC85xx_SATA2_ADDR
++#define CONFIG_SYS_SATA2_FLAGS		FLAGS_DMA
++
++#define CONFIG_LBA48
++#define CONFIG_CMD_SATA
++#define CONFIG_DOS_PARTITION
++#define CONFIG_CMD_EXT2
++#endif
++
++#ifdef CONFIG_FMAN_ENET
++#define CONFIG_SYS_FM1_DTSEC1_PHY_ADDR	0x2
++#define CONFIG_SYS_FM1_DTSEC2_PHY_ADDR	0x3
++#define CONFIG_SYS_FM1_DTSEC3_PHY_ADDR	0x4
++#define CONFIG_SYS_FM1_DTSEC4_PHY_ADDR	0x1
++#define CONFIG_SYS_FM1_DTSEC5_PHY_ADDR	0x0
++
++#define CONFIG_SYS_FM1_DTSEC1_RISER_PHY_ADDR	0x1c
++#define CONFIG_SYS_FM1_DTSEC2_RISER_PHY_ADDR	0x1d
++#define CONFIG_SYS_FM1_DTSEC3_RISER_PHY_ADDR	0x1e
++#define CONFIG_SYS_FM1_DTSEC4_RISER_PHY_ADDR    0x01
++
++#define CONFIG_SYS_FM1_10GEC1_PHY_ADDR	0
++
++#define CONFIG_SYS_TBIPA_VALUE	8
++#define CONFIG_MII		/* MII PHY management */
++#define CONFIG_ETHPRIME		"FM1@DTSEC1"
++#define CONFIG_PHY_GIGE		/* Include GbE speed/duplex detection */
++#endif
++
++/*
++ * Environment
++ */
++#define CONFIG_LOADS_ECHO		/* echo on for serial download */
++#define CONFIG_SYS_LOADS_BAUD_CHANGE	/* allow baudrate change */
++
++/*
++ * Command line configuration.
++ */
++#include <config_cmd_default.h>
++
++#define CONFIG_CMD_DHCP
++#define CONFIG_CMD_ELF
++#define CONFIG_CMD_ERRATA
++#define CONFIG_CMD_GREPENV
++#define CONFIG_CMD_IRQ
++#define CONFIG_CMD_I2C
++#define CONFIG_CMD_MII
++#define CONFIG_CMD_PING
++#define CONFIG_CMD_SETEXPR
++
++#ifdef CONFIG_PCI
++#define CONFIG_CMD_PCI
++#define CONFIG_CMD_NET
++#endif
++
++/*
++* USB
++*/
++#define CONFIG_HAS_FSL_DR_USB
++#define CONFIG_HAS_FSL_MPH_USB
++
++#if defined(CONFIG_HAS_FSL_DR_USB) || defined(CONFIG_HAS_FSL_MPH_USB)
++#define CONFIG_CMD_USB
++#define CONFIG_USB_STORAGE
++#define CONFIG_USB_EHCI
++#define CONFIG_USB_EHCI_FSL
++#define CONFIG_EHCI_HCD_INIT_AFTER_RESET
++#endif
++
++#define CONFIG_CMD_EXT2
++
++#define CONFIG_MMC
++
++#ifdef CONFIG_MMC
++#define CONFIG_FSL_ESDHC
++#define CONFIG_SYS_FSL_ESDHC_ADDR       CONFIG_SYS_MPC85xx_ESDHC_ADDR
++#define CONFIG_SYS_FSL_ESDHC_BROKEN_TIMEOUT
++#define CONFIG_CMD_MMC
++#define CONFIG_GENERIC_MMC
++#define CONFIG_CMD_EXT2
++#define CONFIG_CMD_FAT
++#define CONFIG_DOS_PARTITION
++#endif
++
++/*
++ * Miscellaneous configurable options
++ */
++#define CONFIG_SYS_LONGHELP			/* undef to save memory	*/
++#define CONFIG_CMDLINE_EDITING			/* Command-line editing */
++#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
++#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
++#define CONFIG_SYS_PROMPT	"=> "		/* Monitor Command Prompt */
++#ifdef CONFIG_CMD_KGDB
++#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
++#else
++#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
++#endif
++/* Print Buffer Size */
++#define CONFIG_SYS_PBSIZE	(CONFIG_SYS_CBSIZE + \
++				sizeof(CONFIG_SYS_PROMPT)+16)
++#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
++/* Boot Argument Buffer Size */
++#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
++#define CONFIG_SYS_HZ		1000		/* decrementer freq 1ms ticks */
++
++/*
++ * For booting Linux, the board info and command line data
++ * have to be in the first 64 MB of memory, since this is
++ * the maximum mapped by the Linux kernel during initialization.
++ */
++#define CONFIG_SYS_BOOTMAPSZ	(64 << 20)	/* Initial Memory for Linux */
++#define CONFIG_SYS_BOOTM_LEN	(64 << 20)	/* Increase max gunzip size */
++
++#ifdef CONFIG_CMD_KGDB
++#define CONFIG_KGDB_BAUDRATE	230400	/* speed to run kgdb serial port */
++#define CONFIG_KGDB_SER_INDEX	2	/* which serial port to use */
++#endif
++
++/*
++ * Environment Configuration
++ */
++#define CONFIG_ROOTPATH		"/opt/nfsroot"
++#define CONFIG_BOOTFILE		"uImage"
++#define CONFIG_UBOOTPATH	u-boot.bin
++
++/* default location for tftp and bootm */
++#define CONFIG_LOADADDR     2000000
++
++/* -1 disables auto-boot */
++#define CONFIG_BOOTDELAY 3
++
++#define CONFIG_BAUDRATE	115200
++
++#define __USB_PHY_TYPE	utmi
++
++/*ONIE redefined*/
++/*
++#define	CONFIG_EXTRA_ENV_SETTINGS				\
++	"hwconfig=fsl_ddr:ctlr_intlv=cacheline,"		\
++	"bank_intlv=cs0_cs1\0"					\
++	"netdev=eth0\0"						\
++	"uboot=" __stringify(CONFIG_UBOOTPATH) "\0"			\
++	"ubootaddr=" __stringify(CONFIG_SYS_TEXT_BASE) "\0"		\
++	"tftpflash=tftpboot $loadaddr $uboot && "		\
++	"protect off $ubootaddr +$filesize && "			\
++	"erase $ubootaddr +$filesize && "			\
++	"cp.b $loadaddr $ubootaddr $filesize && "		\
++	"protect on $ubootaddr +$filesize && "			\
++	"cmp.b $loadaddr $ubootaddr $filesize\0"		\
++	"consoledev=ttyS0\0"					\
++	"usb_phy_type=" __stringify(__USB_PHY_TYPE) "\0"		\
++	"usb_dr_mode=host\0"					\
++	"ramdiskaddr=2000000\0"					\
++	"ramdiskfile=p2041rdb/ramdisk.uboot\0"			\
++	"fdtaddr=c00000\0"					\
++	"fdtfile=p2041rdb/p2041rdb.dtb\0"			\
++	"bdev=sda3\0"						\
++	"c=ffe\0"
++*/
++#define CONFIG_HDBOOT					\
++	"setenv bootargs root=/dev/$bdev rw "		\
++	"console=$consoledev,$baudrate $othbootargs;"	\
++	"tftp $loadaddr $bootfile;"			\
++	"tftp $fdtaddr $fdtfile;"			\
++	"bootm $loadaddr - $fdtaddr"
++
++#define CONFIG_NFSBOOTCOMMAND			\
++	"setenv bootargs root=/dev/nfs rw "	\
++	"nfsroot=$serverip:$rootpath "		\
++	"ip=$ipaddr:$serverip:$gatewayip:$netmask:$hostname:$netdev:off " \
++	"console=$consoledev,$baudrate $othbootargs;"	\
++	"tftp $loadaddr $bootfile;"		\
++	"tftp $fdtaddr $fdtfile;"		\
++	"bootm $loadaddr - $fdtaddr"
++
++#define CONFIG_RAMBOOTCOMMAND				\
++	"setenv bootargs root=/dev/ram rw "		\
++	"console=$consoledev,$baudrate $othbootargs;"	\
++	"tftp $ramdiskaddr $ramdiskfile;"		\
++	"tftp $loadaddr $bootfile;"			\
++	"tftp $fdtaddr $fdtfile;"			\
++	"bootm $loadaddr $ramdiskaddr $fdtaddr"
++
++/*#define CONFIG_BOOTCOMMAND        CONFIG_HDBOOT*/ /*ONIE redefined*/
++
++#ifdef CONFIG_SECURE_BOOT
++#include <asm/fsl_secure_boot.h>
++#endif
++
++/* ICOS Fastpath app image file support */
++#define CONFIG_FASTPATH
++
++#ifdef CONFIG_FASTPATH
++#define CONFIG_FDT_INDEX        4
++#endif
++
++/* ONIE */
++#include "common_config.h"
++
++#define CONFIG_SYS_EEPROM_LOAD_ENV_MAC
++#define CONFIG_CMD_SYS_EEPROM
++#define CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS 2
++
++#define CONFIG_SYS_EEPROM_USE_COMMON_SPI_IO
++#define CONFIG_SYS_SPI_FLASH_HWINFO_ADDR        0x00120000
++#define CONFIG_SYS_SPI_FLASH_HWINFO_SECT_SIZE   0x00010000
++#define CONFIG_PLATFORM_ENV     \
++    "hwconfig=fsl_ddr:ctlr_intlv=cacheline," \
++    "bank_intlv=cs0_cs1\0"      \
++    "consoledev=ttyS0\0"        \
++    "boot_diag=if test -n $onie_boot_reason; then " \
++        "if test $onie_boot_reason = diag; then "   \
++        "run diag_bootcmd; fi; fi\0"                \
++    "diag_bootcmd=setenv bootargs root=/dev/ram rw console=ttyS0,$baudrate quiet $diagargs;"    \
++        "run fan_default_speed;"    \
++        "sf probe; sf read $loadaddr $diag_start ${diag_sz.b}; bootm $loadaddr\0"   \
++    "fan_speed_level=7\0"       \
++    "fan_default_speed=i2c dev 1; i2c mw 0x35 0x20 $fan_speed_level\0"  \
++    "diag_start=0x00930000\0"   \
++    "diag_sz.b=0x02000000\0"    \
++    "onie_start=0x00130000\0"   \
++    "onie_sz.b=0x800000\0"
++
++#define CONFIG_EXTRA_ENV_SETTINGS \
++    CONFIG_PLATFORM_ENV           \
++    CONFIG_ONIE_COMMON_UBOOT_ENV
++/* ONIE */
++
++
++#endif	/* __CONFIG_H */
+diff --git a/include/configs/ACCTON_AS6700_32X-R1.h b/include/configs/ACCTON_AS6700_32X-R1.h
 new file mode 100644
 index 0000000..9e9c024
 --- /dev/null
-+++ b/include/configs/AS6700_32X.h
++++ b/include/configs/ACCTON_AS6700_32X-R1.h
 @@ -0,0 +1,879 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.


### PR DESCRIPTION
The `r01c` machine uses another SPI flash and new partition table.
Current `r0` ONIE is no longer compatible with the new machine.
The patch will separate the ONIE into `r0` and `r1`.  The `r1`
ONIE is suitable for the `r01c` machine.
