### PR TITLE
Accton Platforms: u-boot can't load files from eUSB device

### DIFF
--- a/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
+++ b/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
@@ -25164,10 +25164,10 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS5710_54X.h b/include/configs/AS5710_54X.h
 new file mode 100644
-index 0000000..2abf3ee
+index 0000000..35334c4
 --- /dev/null
 +++ b/include/configs/AS5710_54X.h
-@@ -0,0 +1,685 @@
+@@ -0,0 +1,686 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -25653,6 +25653,7 @@ index 0000000..2abf3ee
 +*/
 +#define CONFIG_HAS_FSL_DR_USB
 +#define CONFIG_HAS_FSL_MPH_USB
++#define CONFIG_USB_MAX_CONTROLLER_COUNT 2
 +
 +/* Init USB251x with SW EEPROM contents. */
 +#define CONFIG_USB251x_SW_EEPROM

--- a/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
+++ b/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
@@ -25196,10 +25196,10 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6710_32X.h b/include/configs/AS6710_32X.h
 new file mode 100644
-index 0000000..b55a74e
+index 0000000..f86fa26
 --- /dev/null
 +++ b/include/configs/AS6710_32X.h
-@@ -0,0 +1,697 @@
+@@ -0,0 +1,698 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -25685,6 +25685,7 @@ index 0000000..b55a74e
 +*/
 +#define CONFIG_HAS_FSL_DR_USB
 +#define CONFIG_HAS_FSL_MPH_USB
++#define CONFIG_USB_MAX_CONTROLLER_COUNT 2
 +
 +/* Init USB251x with SW EEPROM contents. */
 +#define CONFIG_USB251x_SW_EEPROM


### PR DESCRIPTION
The platforms are including:
- AS5710_54X
- AS6710_32X
