### PR TITLE
i2ctools: Modify the sleep time for i2c_write_3b function

### DIFF
--- a/patches/i2ctools/i2ctools-sys-eeprom.patch
+++ b/patches/i2ctools/i2ctools-sys-eeprom.patch
@@ -31,6 +31,15 @@ index 54c6342..be194ad 100644
 +	usleep(1000);
  	return r;
  }
+
+@@ -56,7 +56,7 @@ static int i2c_write_3b(struct eeprom *e, __u8 buf[3])
+ 	r = i2c_smbus_write_word_data(e->fd, buf[0], buf[2] << 8 | buf[1]);
+ 	if(r < 0)
+ 		fprintf(stderr, "Error i2c_write_3b: %s\n", strerror(errno));
+-	usleep(10);
++	usleep(1000);
+ 	return r;
+ }
  
 diff --git a/sys_eeprom/Module.mk b/sys_eeprom/Module.mk
 new file mode 100644


### PR DESCRIPTION
The sleep time in i2c_write_3b() should use the same sleep time in i2c_write_2b(). If the sleep time is not enough, write TLV content to 16 bits address EEPROM through "onie-syseeprom -s" command will occur failure.
