### PR TITLE
Add support for upstream syslinux

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -275,6 +275,9 @@ include make/kernel-download.make
 include make/uclibc-download.make
 include make/xtools.make
 include make/sysroot.make
+ifeq ($(SYSLINUX_ENABLE),yes)
+include make/syslinux.make
+endif
 include make/kernel.make
 ifeq ($(UBOOT_ENABLE),yes)
   include make/u-boot.make
@@ -371,7 +374,7 @@ machine-prefix:
 # Install required build packages for a x86_64 debian based build host
 DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools python-sphinx rst2pdf \
 				  gperf device-tree-compiler python-all-dev genisoimage \
-				  syslinux-common autoconf automake bison flex texinfo libtool \
+				  autoconf automake bison flex texinfo libtool \
 				  realpath gawk libncurses5 libncurses5-dev bc
 
 PHONY += debian-prepare-build-host

--- a/build-config/arch/x86_64.make
+++ b/build-config/arch/x86_64.make
@@ -109,6 +109,9 @@ LVM2_ENABLE = yes
 # Include ethtool by default
 ETHTOOL_ENABLE ?= yes
 
+# Enable Syslinux as the bootloader for this platform
+SYSLINUX_ENABLE = yes
+
 # Update this if the GRUB configuration mechanism changes from one
 # release to the next.
 ONIE_CONFIG_VERSION = 1

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -62,6 +62,10 @@ ifeq ($(GRUB_ENABLE),yes)
   PACKAGES_INSTALL_STAMPS += $(GRUB_INSTALL_STAMP)
 endif
 
+ifeq ($(SYSLINUX_ENABLE),yes)
+  PACKAGES_INSTALL_STAMPS += $(SYSLINUX_SOURCE_STAMP)
+endif
+
 ifndef MAKE_CLEAN
 SYSROOT_NEW_FILES = $(shell \
 			test -d $(ROOTCONFDIR)/default && \
@@ -270,6 +274,9 @@ RECOVERY_INITRD_STAMP	= $(STAMPDIR)/recovery-initrd
 RECOVERY_ISO_STAMP	= $(STAMPDIR)/recovery-iso
 PXE_EFI64_STAMP		= $(STAMPDIR)/pxe-efi64
 
+RECOVERY_ISO_SYSLINUX_FILES = $(SYSLINUX_DIR)/core/isolinux.bin \
+                              $(SYSLINUX_DIR)/com32/menu/menu.c32
+
 PHONY += pxe-efi64 recovery-initrd recovery-iso
 
 # Make an initrd based on the ONIE sysroot that also includes the ONIE
@@ -292,12 +299,7 @@ $(RECOVERY_ISO_STAMP): $(RECOVERY_INITRD_STAMP) $(RECOVERY_CONF_DIR)/grub-pxe.cf
 	$(Q) mkdir -p $(RECOVERY_ISO_SYSROOT)
 	$(Q) cp $(UPDATER_VMLINUZ) $(RECOVERY_ISO_SYSROOT)/vmlinuz
 	$(Q) cp $(RECOVERY_INITRD) $(RECOVERY_ISO_SYSROOT)/initrd.xz
-	$(Q) [ -r /usr/lib/syslinux/isolinux.bin ] || {						\
-		echo "ERROR:  /usr/lib/syslinux/isolinux.bin is not present";			\
-		echo "ERROR:  Is the syslinux-common package installed on your build host??" ;	\
-		exit 1; }
-	$(Q) cp /usr/lib/syslinux/isolinux.bin $(RECOVERY_ISO_SYSROOT)
-	$(Q) cp /usr/lib/syslinux/menu.c32 $(RECOVERY_ISO_SYSROOT)
+	$(Q) cp $(RECOVERY_ISO_SYSLINUX_FILES) $(RECOVERY_ISO_SYSROOT)
 	$(Q) sed -e 's/<CONSOLE_SPEED>/$(CONSOLE_SPEED)/g' \
 		 -e 's/<CONSOLE_DEV>/$(CONSOLE_DEV)/g' \
 		 -e 's/<CONSOLE_FLAG>/$(CONSOLE_FLAG)/g' \

--- a/build-config/make/syslinux.make
+++ b/build-config/make/syslinux.make
@@ -1,0 +1,57 @@
+#-------------------------------------------------------------------------------
+#
+#  Copyright (C) 2013-2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+#
+#-------------------------------------------------------------------------------
+#
+# makefile fragment that defines the download of a specific syslinux version
+#
+#-------------------------------------------------------------------------------
+
+SYSLINUX_VERSION		?= 4.07
+SYSLINUX_TARBALL		?= syslinux-$(SYSLINUX_VERSION).tar.xz
+SYSLINUX_TARBALL_URLS	+= $(ONIE_MIRROR) https://www.kernel.org/pub/linux/utils/boot/syslinux/
+SYSLINUX_BUILD_DIR		= $(MBUILDDIR)/syslinux
+SYSLINUX_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/syslinux-download-$(SYSLINUX_VERSION)
+SYSLINUX_SOURCE_STAMP	= $(STAMPDIR)/syslinux-source
+SYSLINUX_DIR            = $(SYSLINUX_BUILD_DIR)/syslinux-$(SYSLINUX_VERSION)
+
+export SYSLINUX_TARBALL
+export SYSLINUX_VERSION
+export SYSLINUX_DIR
+
+SYSLINUX_STAMP          = $(SYSLINUX_DOWNLOAD_STAMP) \
+                          $(SYSLINUX_SOURCE_STAMP)
+
+PHONY += syslinux-download syslinux-source syslinux-download-clean
+
+syslinux: $(SYSLINUX_STAMP)
+
+DOWNLOAD += $(SYSLINUX_DOWNLOAD_STAMP)
+syslinux-download: $(SYSLINUX_DOWNLOAD_STAMP)
+$(SYSLINUX_DOWNLOAD_STAMP): $(PROJECT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Getting syslinux ===="
+	$(Q) $(SCRIPTDIR)/fetch-package $(DOWNLOADDIR) $(UPSTREAMDIR) \
+		$(SYSLINUX_TARBALL) $(SYSLINUX_TARBALL_URLS)
+	$(Q) touch $@
+
+SOURCE += $(SYSLINUX_SOURCE_STAMP)
+syslinux-source: $(SYSLINUX_SOURCE_STAMP)
+$(SYSLINUX_SOURCE_STAMP): $(TREE_STAMP) | $(SYSLINUX_DOWNLOAD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Extracting upstream syslinux ===="
+	$(Q) $(SCRIPTDIR)/extract-package $(SYSLINUX_BUILD_DIR) $(DOWNLOADDIR)/$(SYSLINUX_TARBALL)
+	$(Q) touch $@
+
+DOWNLOAD_CLEAN += syslinux-download-clean
+syslinux-download-clean:
+	$(Q) rm -f $(SYSLINUX_DOWNLOAD_STAMP) $(DOWNLOADDIR)/$(SYSLINUX_TARBALL)
+
+#-------------------------------------------------------------------------------
+#
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/upstream/syslinux-4.07.tar.xz.sha1
+++ b/upstream/syslinux-4.07.tar.xz.sha1
@@ -1,0 +1,1 @@
+ceda70713fd575bd46fc497b503ed90f121ab3b1  syslinux-4.07.tar.xz


### PR DESCRIPTION
To insulate ONIE build from syslinux version changes in different Linux
distro's, we're pulling in a specific `syslinux` version from upstream.

The version selected is the latest from the 4.x series which is what
ONIE has been using till now. The exact version is - `4.07`.

The upstream package already comes bundled with pre-built binaries which
we are using directly (hence no syslinux source build needed).

The `debian-prepare-build-host` target has the `syslinux-common` package
removed as it's no longer needed.
