### PR TITLE
Accton powerpc platforms: Revise the u-boot shell prompt

### DIFF
--- a/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
+++ b/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
@@ -24927,7 +24927,7 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS5710_54X.h b/include/configs/AS5710_54X.h
 new file mode 100644
-index 0000000..12e03aa
+index 0000000..fe3d32c
 --- /dev/null
 +++ b/include/configs/AS5710_54X.h
 @@ -0,0 +1,687 @@
@@ -25451,7 +25451,7 @@ index 0000000..12e03aa
 +#define CONFIG_CMDLINE_EDITING			/* Command-line editing */
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
-+#define CONFIG_SYS_PROMPT	"=> "		/* Monitor Command Prompt */
++#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
 +#ifdef CONFIG_CMD_KGDB
 +#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
 +#else

--- a/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
+++ b/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
@@ -37451,7 +37451,7 @@ index a29f6a6..f26a80d 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/ACCTON_AS6700_32X-R0.h b/include/configs/ACCTON_AS6700_32X-R0.h
 new file mode 100644
-index 0000000..9008272
+index 0000000..16223e8
 --- /dev/null
 +++ b/include/configs/ACCTON_AS6700_32X-R0.h
 @@ -0,0 +1,879 @@
@@ -38194,7 +38194,7 @@ index 0000000..9008272
 +#define CONFIG_CMDLINE_EDITING			/* Command-line editing */
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
-+#define CONFIG_SYS_PROMPT	"=> "		/* Monitor Command Prompt */
++#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
 +#ifdef CONFIG_CMD_KGDB
 +#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
 +#else
@@ -38336,7 +38336,7 @@ index 0000000..9008272
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/ACCTON_AS6700_32X-R1.h b/include/configs/ACCTON_AS6700_32X-R1.h
 new file mode 100644
-index 0000000..e553fa6
+index 0000000..1fdf450
 --- /dev/null
 +++ b/include/configs/ACCTON_AS6700_32X-R1.h
 @@ -0,0 +1,880 @@
@@ -39080,7 +39080,7 @@ index 0000000..e553fa6
 +#define CONFIG_CMDLINE_EDITING			/* Command-line editing */
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
-+#define CONFIG_SYS_PROMPT	"=> "		/* Monitor Command Prompt */
++#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
 +#ifdef CONFIG_CMD_KGDB
 +#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
 +#else

--- a/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
+++ b/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
@@ -24837,7 +24837,7 @@ index a29f6a6..f26a80d 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6701_32X.h b/include/configs/AS6701_32X.h
 new file mode 100644
-index 0000000..2496e57
+index 0000000..eabc7cd
 --- /dev/null
 +++ b/include/configs/AS6701_32X.h
 @@ -0,0 +1,826 @@
@@ -25507,7 +25507,7 @@ index 0000000..2496e57
 +#define CONFIG_CMDLINE_EDITING			/* Command-line editing */
 +#define CONFIG_AUTO_COMPLETE            /* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
-+#define CONFIG_SYS_PROMPT	"=> "		/* Monitor Command Prompt */
++#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
 +#if defined(CONFIG_CMD_KGDB)
 +#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
 +#else

--- a/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
+++ b/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
@@ -24958,7 +24958,7 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6710_32X.h b/include/configs/AS6710_32X.h
 new file mode 100644
-index 0000000..65444ac
+index 0000000..a64651d
 --- /dev/null
 +++ b/include/configs/AS6710_32X.h
 @@ -0,0 +1,699 @@
@@ -25482,7 +25482,7 @@ index 0000000..65444ac
 +#define CONFIG_CMDLINE_EDITING			/* Command-line editing */
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
-+#define CONFIG_SYS_PROMPT	"=> "		/* Monitor Command Prompt */
++#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
 +#ifdef CONFIG_CMD_KGDB
 +#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
 +#else


### PR DESCRIPTION
The platforms are including:
- AS5710_54X
- AS6700_32X
- AS6701_32X
- AS6710_32X

Revise the shell prompt to "LOADER=> " that will be consistent with
the one in other machines.
