### PR TITLE
Add support for configrable syslinux menu default

### DIFF
--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -276,6 +276,8 @@ PXE_EFI64_STAMP		= $(STAMPDIR)/pxe-efi64
 
 RECOVERY_ISO_SYSLINUX_FILES = $(SYSLINUX_DIR)/core/isolinux.bin \
                               $(SYSLINUX_DIR)/com32/menu/menu.c32
+# Default to rescue mode for Syslinux menu, if none specified in machine.make
+SYSLINUX_DEFAULT_MODE ?=rescue
 
 PHONY += pxe-efi64 recovery-initrd recovery-iso
 
@@ -304,6 +306,7 @@ $(RECOVERY_ISO_STAMP): $(RECOVERY_INITRD_STAMP) $(RECOVERY_CONF_DIR)/grub-pxe.cf
 		 -e 's/<CONSOLE_DEV>/$(CONSOLE_DEV)/g' \
 		 -e 's/<CONSOLE_FLAG>/$(CONSOLE_FLAG)/g' \
 		 -e 's/<CONSOLE_PORT>/$(CONSOLE_PORT)/g' \
+		 -e 's/<SYSLINUX_DEFAULT_MODE>/$(SYSLINUX_DEFAULT_MODE)/g' \
 	         $(RECOVERY_CONF_DIR)/syslinux.cfg \
 		 > $(RECOVERY_ISO_SYSROOT)/syslinux.cfg
 	$(Q) mkdir -p $(RECOVERY_ISO_SYSROOT)/boot/grub

--- a/build-config/recovery/syslinux.cfg
+++ b/build-config/recovery/syslinux.cfg
@@ -13,13 +13,13 @@ totaltimeout 9000
 
 console <CONSOLE_FLAG>
 
-default menu.c32
+ui menu.c32
+default <SYSLINUX_DEFAULT_MODE>
 
 menu title ONIE Installer
 
 label rescue
   menu label ONIE: Rescue
-  menu default
   kernel vmlinuz
   append initrd=initrd.xz console=tty0 console=ttyS<CONSOLE_DEV>,<CONSOLE_SPEED>n8 boot_env=recovery boot_reason=rescue
 

--- a/machine/kvm_x86_64/machine.make
+++ b/machine/kvm_x86_64/machine.make
@@ -64,6 +64,11 @@ UCLIBC_VERSION = 0.9.33.2
 #
 # NOTE: You can give multiple space separated parameters
 
+# Specify the default menu option for syslinux when booting a recovery image
+# Valid values are "rescue" or "embed" (without double-quotes). This parameter
+# defaults to "rescue" mode if not specified here.
+#SYSLINUX_DEFAULT_MODE=embed
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:


### PR DESCRIPTION
The default syslinux menu entry can be selected by specifying a
parameter in machine.make of a platform - SYSLINUX_DEFAULT_MODE.

This parameter is documented in machine/kvm_x86_64/machine.make.
