### PR TITLE
Accton AS5610_52X: Correct GPIO (pca9506) nodes in DTS

### DIFF
--- a/machine/accton/accton_as5610_52x/kernel/platform-accton-as5610_52x.patch
+++ b/machine/accton/accton_as5610_52x/kernel/platform-accton-as5610_52x.patch
@@ -4,10 +4,10 @@ Support for the Accton AS5610_52X networking platform.
 
 diff --git a/arch/powerpc/boot/dts/as5610_52x.dts b/arch/powerpc/boot/dts/as5610_52x.dts
 new file mode 100644
-index 0000000..bb3f7a7
+index 0000000..8023530
 --- /dev/null
 +++ b/arch/powerpc/boot/dts/as5610_52x.dts
-@@ -0,0 +1,1234 @@
+@@ -0,0 +1,1238 @@
 +/*
 + * Accton Technology AS5610_52X Device Tree Source
 + *
@@ -1048,25 +1048,29 @@ index 0000000..bb3f7a7
 +						compatible = "ti,pca9506";
 +						reg = <0x20>;
 +					};
-+					gpio@22 {
++					gpio@71 {
 +						// SFP+ OPRXLOSS 0..39
 +						compatible = "ti,pca9506";
-+						reg = <0x22>;
-+					};
-+					gpio@71 {
-+						// SFP+ MOD_ABS 40..47
-+						compatible = "ti,pca9538";
 +						reg = <0x71>;
 +					};
 +					gpio@72 {
++						// SFP+ OPRXLOSS 40..47
++						// SFP+ MOD_ABS 40..47
 +						// QSFP+ PRSNT 0..3
-+						compatible = "ti,pca9538";
++						// SFP+ OPTXFLT 40..47
++						// SFP+ OPTXENB 40..47
++						compatible = "ti,pca9506";
 +						reg = <0x72>;
 +					};
 +					gpio@73 {
-+						// SFP+ OPRXLOSS 40..47
-+						compatible = "ti,pca9538";
++						// SFP+ OPTXFLT 0..39
++						compatible = "ti,pca9506";
 +						reg = <0x73>;
++					};
++					gpio@74 {
++						// SFP+ OPTXENB 0..39
++						compatible = "ti,pca9506";
++						reg = <0x74>;
 +					};
 +			       };
 +			};


### PR DESCRIPTION
There are 4 wrong GPIO nodes in DTS.  It showes error messages during
kernel booting:

```
pca953x 17-0071: failed reading register
pca953x 17-0072: failed reading register
pca953x 17-0073: failed reading register
```

According to the HW spec, these 4 nodes are pca9506.
