### PR TITLE
x86 exec_installer: Fill serial number to HTTP headers

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -338,6 +338,7 @@ import_parms "$parms"
 rm -f $onie_installer
 
 [ -z "$onie_eth_addr" ] && onie_eth_addr="$(onie-sysinfo -e)"
+[ -z "$onie_serial_num" ] && onie_serial_num="$(onie-sysinfo -s)"
 
 from_cli=no
 


### PR DESCRIPTION
In powerpc platforms, the serial number is passed to kernel by
`bootargs` from u-boot.  But it is not in x86 platforms.  It
makes wget send an empty serial number field as part of the HTTP
request headers during doing HTTP discover.
