### PR TITLE
Accton powerpc platforms: Adjust u-boot boot delay to 10secs

### DIFF
--- a/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
+++ b/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
@@ -30418,7 +30418,7 @@ index 76b3ca6..3a166d9 100644
 +
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..00a987a 100644
+index e9e2135..46308b8 100644
 --- a/include/configs/common_config.h
 +++ b/include/configs/common_config.h
 @@ -26,7 +26,7 @@
@@ -30495,15 +30495,6 @@ index e9e2135..00a987a 100644
  
  #define CONFIG_ENV_SIZE		0x2000
  
-@@ -144,7 +147,7 @@
-  * Environment Variable Configuration
-  */
- 
--#define CONFIG_BOOTDELAY 10	/* -1 disables auto-boot */
-+#define CONFIG_BOOTDELAY 5	/* -1 disables auto-boot */
- #undef	CONFIG_BOOTARGS		/* the boot command will set bootargs*/
- 
- #define CONFIG_BAUDRATE	115200
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
+++ b/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
@@ -44354,7 +44354,7 @@ index 76b3ca6..3a166d9 100644
 +
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..b8bf4b0 100644
+index e9e2135..9d0d47d 100644
 --- a/include/configs/common_config.h
 +++ b/include/configs/common_config.h
 @@ -26,7 +26,7 @@
@@ -44440,15 +44440,6 @@ index e9e2135..b8bf4b0 100644
  
  #define CONFIG_ENV_SIZE		0x2000
  
-@@ -144,7 +147,7 @@
-  * Environment Variable Configuration
-  */
- 
--#define CONFIG_BOOTDELAY 10	/* -1 disables auto-boot */
-+#define CONFIG_BOOTDELAY 3	/* -1 disables auto-boot */
- #undef	CONFIG_BOOTARGS		/* the boot command will set bootargs*/
- 
- #define CONFIG_BAUDRATE	115200
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
+++ b/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
@@ -24837,10 +24837,10 @@ index a29f6a6..f26a80d 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6701_32X.h b/include/configs/AS6701_32X.h
 new file mode 100644
-index 0000000..eabc7cd
+index 0000000..24145e5
 --- /dev/null
 +++ b/include/configs/AS6701_32X.h
-@@ -0,0 +1,826 @@
+@@ -0,0 +1,821 @@
 +/*
 + * Copyright 2010-2011 Freescale Semiconductor, Inc.
 + *
@@ -25542,11 +25542,6 @@ index 0000000..eabc7cd
 +
 +/* default location for tftp and bootm */
 +#define CONFIG_LOADADDR	1000000
-+
-+#define CONFIG_BOOTDELAY 5	/* -1 disables auto-boot */
-+/*#define CONFIG_BOOTARGS*/	/* the boot command will set bootargs */
-+
-+#define CONFIG_BAUDRATE	115200
 +
 +#ifdef __SW_BOOT_NOR
 +#define __NOR_RST_CMD	\
@@ -30467,7 +30462,7 @@ index 76b3ca6..3a166d9 100644
 +
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..52ccb7d 100644
+index e9e2135..9d0d47d 100644
 --- a/include/configs/common_config.h
 +++ b/include/configs/common_config.h
 @@ -26,7 +26,7 @@
@@ -30553,15 +30548,6 @@ index e9e2135..52ccb7d 100644
  
  #define CONFIG_ENV_SIZE		0x2000
  
-@@ -144,7 +147,7 @@
-  * Environment Variable Configuration
-  */
- 
--#define CONFIG_BOOTDELAY 10	/* -1 disables auto-boot */
-+/*#define CONFIG_BOOTDELAY 3*/	/* -1 disables auto-boot */
- #undef	CONFIG_BOOTARGS		/* the boot command will set bootargs*/
- 
- #define CONFIG_BAUDRATE	115200
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
+++ b/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
@@ -30461,7 +30461,7 @@ index 76b3ca6..3a166d9 100644
 +
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..6d116c3 100644
+index e9e2135..a108864 100644
 --- a/include/configs/common_config.h
 +++ b/include/configs/common_config.h
 @@ -26,7 +26,7 @@
@@ -30538,19 +30538,16 @@ index e9e2135..6d116c3 100644
  
  #define CONFIG_ENV_SIZE		0x2000
  
-@@ -143,8 +146,11 @@
+@@ -143,6 +146,9 @@
  /*
   * Environment Variable Configuration
   */
 +#define CONFIG_AUTOBOOT_KEYED 1
 +#define CONFIG_AUTOBOOT_STOP_STR "123\r"
 +#define CONFIG_AUTOBOOT_PROMPT "Type 123<ENTER> to STOP autoboot\n"
-+#define CONFIG_BOOTDELAY 3 /* -1 disables auto-boot */
  
--#define CONFIG_BOOTDELAY 10	/* -1 disables auto-boot */
+ #define CONFIG_BOOTDELAY 10	/* -1 disables auto-boot */
  #undef	CONFIG_BOOTARGS		/* the boot command will set bootargs*/
- 
- #define CONFIG_BAUDRATE	115200
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as7700_32x/u-boot/platform-accton-as7700_32x.patch
+++ b/machine/accton/accton_as7700_32x/u-boot/platform-accton-as7700_32x.patch
@@ -30464,7 +30464,7 @@ index 76b3ca6..3a166d9 100644
 +
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..69ebc67 100644
+index e9e2135..4dbfbad 100644
 --- a/include/configs/common_config.h
 +++ b/include/configs/common_config.h
 @@ -26,7 +26,7 @@
@@ -30526,16 +30526,6 @@ index e9e2135..69ebc67 100644
  #define CONFIG_ENV_SIZE		0x2000
  
  /* Allow vendor environment vars to be overwritten, like ethaddr. */
-@@ -144,7 +125,8 @@
-  * Environment Variable Configuration
-  */
- 
--#define CONFIG_BOOTDELAY 10	/* -1 disables auto-boot */
-+#define CONFIG_BOOTDELAY 5	/* -1 disables auto-boot */
-+
- #undef	CONFIG_BOOTARGS		/* the boot command will set bootargs*/
- 
- #define CONFIG_BAUDRATE	115200
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h


### PR DESCRIPTION
The platforms are including:
- AS5710_54X
- AS6700_32X
- AS6701_32X
- AS6710_32X
- AS7700_32X

u-boot boot delay in these platforms were not consistent in the
past.  We decided to follow ONIE's original design recently.  So
that these boot delay patches in machines are removed now.
