### PR TITLE
Accton platforms: Add context of installing u-boot in INSTALL

### DIFF
--- a/machine/accton/accton_as4600_54t/INSTALL
+++ b/machine/accton/accton_as4600_54t/INSTALL
@@ -18,9 +18,20 @@ When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 May  7 11:38 onie-accton_as4600_54t-r0.bin
+  -rw-r--r--  524288 May  7 11:38 onie-accton_as4600_54t-r0.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS4600_54T two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as4600_54t-r0.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as4600_54t-r0.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -28,8 +39,8 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install ONIE kernel (onie-accton_as4600_54t-r0.bin)
------------------------------------------------
+Step 2 -- Install image1 (onie-accton_as4600_54t-r0.bin)
+--------------------------------------------------------
 
 Copying the image down using TFTP and flash to the NOR flash::
 
@@ -39,13 +50,24 @@ Copying the image down using TFTP and flash to the NOR flash::
   => protect off $q1start +${q1sz.b} && erase $q1start +${q1sz.b}
   => cp.b $fileaddr $q1start ${q1sz.b} && protect on $q1start +${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as4600_54t-r0.bin.uboot)
+--------------------------------------------------------------
+
+Copying the image down using TFTP and flash to the NOR flash::
+
+  => setenv q2start 0xeff80000
+  => setenv q2sz.b 0x00080000
+  => tftp onie-accton_as4600_54t-r0.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -53,7 +75,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After

--- a/machine/accton/accton_as5600_52x/INSTALL
+++ b/machine/accton/accton_as5600_52x/INSTALL
@@ -18,10 +18,21 @@ type ``"make MACHINEROOT=../machine/accton MACHINE=accton_as5600_52x all"``
 When complete, the ONIE binaries are located in
 ``build/images``::
 
-  -rw-r--r-- 3604480 Jul  5 11:38 onie-accton_as5600_52x.bin
+  -rw-r--r-- 3604480 Jul  5 11:38 onie-accton_as5600_52x-r0.bin
+  -rw-r--r--  524288 Jul  5 11:38 onie-accton_as5600_52x-r0.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS5600_52X two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as5600_52x-r0.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as5600_52x-r0.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -29,8 +40,8 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install onie-accton_as5600_52x.bin
------------------------------------------------
+Step 2 -- Install image1 (onie-accton_as5600_52x-r0.bin)
+--------------------------------------------------------
 
 Copying the image down using TFTP and flash to the NOR flash::
 
@@ -40,13 +51,24 @@ Copying the image down using TFTP and flash to the NOR flash::
   => protect off $q1start +${q1sz.b} && erase $q1start +${q1sz.b}
   => cp.b $fileaddr $q1start ${q1sz.b} && protect on $q1start +${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as5600_52x-r0.bin.uboot)
+--------------------------------------------------------------
+
+Copying the image down using TFTP and flash to the NOR flash::
+
+  => setenv q2start 0xeff80000
+  => setenv q2sz.b 0x00080000
+  => tftp onie-accton_as5600_52x-r0.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -54,7 +76,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After

--- a/machine/accton/accton_as5610_52x/INSTALL
+++ b/machine/accton/accton_as5610_52x/INSTALL
@@ -19,9 +19,20 @@ When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 Jul  5 11:38 onie-accton_as5610_52x-r0.bin
+  -rw-r--r--  524288 Jul  5 11:38 onie-accton_as5610_52x-r0.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS5610_52X two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as5610_52x-r0.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as5610_52x-r0.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -29,8 +40,8 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install onie-accton_as5610_52x-r0.bin
------------------------------------------------
+Step 2 -- Install image1 (onie-accton_as5610_52x-r0.bin)
+--------------------------------------------------------
 
 Copying the image down using TFTP and flash to the NOR flash::
 
@@ -40,13 +51,24 @@ Copying the image down using TFTP and flash to the NOR flash::
   => protect off $q1start +${q1sz.b} && erase $q1start +${q1sz.b}
   => cp.b $fileaddr $q1start ${q1sz.b} && protect on $q1start +${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as5610_52x-r0.bin.uboot)
+--------------------------------------------------------------
+
+Copying the image down using TFTP and flash to the NOR flash::
+
+  => setenv q2start 0xeff80000
+  => setenv q2sz.b 0x00080000
+  => tftp onie-accton_as5610_52x-r0.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -54,7 +76,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After

--- a/machine/accton/accton_as5710_54x/INSTALL
+++ b/machine/accton/accton_as5710_54x/INSTALL
@@ -18,9 +18,20 @@ When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 May  7 11:38 onie-accton_as5710_54x-r0.bin
+  -rw-r--r--  524288 May  7 11:38 onie-accton_as5710_54x-r0.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS5710_54X two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as5710_54x-r0.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as5710_54x-r0.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -28,8 +39,9 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install ONIE kernel (onie-accton_as5710_54x-r0.bin)
------------------------------------------------
+Step 2 -- Install image1 (onie-accton_as5710_54x-r0.bin)
+--------------------------------------------------------
+
 Copying the image down using TFTP and flash to the NOR flash::
 
   => setenv q1start 0xe8040000
@@ -38,13 +50,24 @@ Copying the image down using TFTP and flash to the NOR flash::
   => protect off $q1start +${q1sz.b} && erase $q1start +${q1sz.b}
   => cp.b $fileaddr $q1start ${q1sz.b} && protect on $q1start +${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as5710_54x-r0.bin.uboot)
+--------------------------------------------------------------
+
+Copying the image down using TFTP and flash to the NOR flash::
+
+  => setenv q2start 0xeff80000
+  => setenv q2sz.b 0x00080000
+  => tftp onie-accton_as5710_54x-r0.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -52,7 +75,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After

--- a/machine/accton/accton_as6700_32x/INSTALL
+++ b/machine/accton/accton_as6700_32x/INSTALL
@@ -25,6 +25,7 @@ When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 May  7 11:38 onie-accton_as6700_32x-r0.bin
+  -rw-r--r--  557872 May  7 11:38 onie-accton_as6700_32x-r0.bin.uboot
 
 Compiling the r1 ONIE
 ---------------------
@@ -36,10 +37,20 @@ When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 May  7 11:38 onie-accton_as6700_32x-r1.bin
-
+  -rw-r--r--  557872 May  7 11:38 onie-accton_as6700_32x-r1.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS6700_32X two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as6700_32x-r*.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as6700_32x-r*.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -47,8 +58,8 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install ONIE kernel
------------------------------
+Step 2 -- Install image1 (onie-accton_as6700_32x-r*.bin)
+--------------------------------------------------------
 
 Copying the image (onie-accton_as6700_32x-r0.bin) down using TFTP and flash to
 the NOR flash on the machines till ``r01b`` revision::
@@ -70,13 +81,26 @@ flash the image (onie-accton_as6700_32x-r1.bin) to the NOR flash::
   => sf erase $q1start ${q1sz.b}
   => sf write $fileaddr $q1start ${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as6700_32x-r*.bin.uboot)
+--------------------------------------------------------------
+
+The start address and partition size in all types of machines are the
+same.  Copying the image (take 'r1' as an example) down using TFTP and
+flash to the NOR flash::
+
+  => setenv q2start 0xfe000000
+  => setenv q2sz.b 0x00100000
+  => tftp onie-accton_as6700_32x-r1.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -84,7 +108,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After

--- a/machine/accton/accton_as6701_32x/INSTALL
+++ b/machine/accton/accton_as6701_32x/INSTALL
@@ -18,9 +18,20 @@ When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 May  7 11:38 onie-accton_as6701_32x-r0.bin
+  -rw-r--r--  524288 May  7 11:38 onie-accton_as6701_32x-r0.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS6701_32X two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as6701_32x-r0.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as6701_32x-r0.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -28,8 +39,8 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install ONIE kernel (onie-accton_as6701_32x-r0.bin)
------------------------------------------------
+Step 2 -- Install image1 (onie-accton_as6701_32x-r0.bin)
+--------------------------------------------------------
 
 Copying the image down using TFTP and flash to the NOR flash::
 
@@ -39,13 +50,24 @@ Copying the image down using TFTP and flash to the NOR flash::
   => protect off $q1start +${q1sz.b} && erase $q1start +${q1sz.b}
   => cp.b $fileaddr $q1start ${q1sz.b} && protect on $q1start +${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as6701_32x-r0.bin.uboot)
+--------------------------------------------------------------
+
+Copying the image down using TFTP and flash to the NOR flash::
+
+  => setenv q2start 0xeff80000
+  => setenv q2sz.b 0x00080000
+  => tftp onie-accton_as6701_32x-r0.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -53,7 +75,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After

--- a/machine/accton/accton_as6710_32x/INSTALL
+++ b/machine/accton/accton_as6710_32x/INSTALL
@@ -17,10 +17,21 @@ For example::
 When complete, the ONIE binaries are located in
 ``build/images``::
 
-  -rw-r--r-- 3604480 May  7 11:38 onie-accton_as6710_32x-r0.bin
+  -rw-r--r-- 3604480 May  7 11:38 onie-accton_as6710_32x-r1.bin
+  -rw-r--r--  524288 May  7 11:38 onie-accton_as6710_32x-r1.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS6710_32X two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as6710_32x-r1.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as6710_32x-r1.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -28,23 +39,35 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install ONIE kernel (onie-accton_as6710_32x-r0.bin)
------------------------------------------------
+Step 2 -- Install image1 (onie-accton_as6710_32x-r1.bin)
+--------------------------------------------------------
+
 Copying the image down using TFTP and flash to the NOR flash::
 
   => setenv q1start 0xe8040000
   => setenv q1sz.b 0xd00000
-  => tftp onie-accton_as6710_32x-r0.bin
+  => tftp onie-accton_as6710_32x-r1.bin
   => protect off $q1start +${q1sz.b} && erase $q1start +${q1sz.b}
   => cp.b $fileaddr $q1start ${q1sz.b} && protect on $q1start +${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as6710_32x-r1.bin.uboot)
+--------------------------------------------------------------
+
+Copying the image down using TFTP and flash to the NOR flash::
+
+  => setenv q2start 0xeff80000
+  => setenv q2sz.b 0x00080000
+  => tftp onie-accton_as6710_32x-r1.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -52,7 +75,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After

--- a/machine/accton/accton_as7700_32x/INSTALL
+++ b/machine/accton/accton_as7700_32x/INSTALL
@@ -18,9 +18,20 @@ When complete, the ONIE binaries are located in
 ``build/images``::
 
   -rw-r--r-- 3604480 May  7 11:38 onie-accton_as7700_32x-r0.bin
+  -rw-r--r--  524288 May  7 11:38 onie-accton_as7700_32x-r0.bin.uboot
 
 Installing the ONIE binaries
 ============================
+
+For the Accton AS7700_32X two binary images need to be installed on the
+NOR flash.  Two images are required as a board info block resides in the
+NOR flash between U-Boot and the U-Boot environment variables::
+
+  Image 1 -- ONIE kernel and empty U-Boot envariables
+    name:  onie-accton_as7700_32x-r0.bin
+
+  Image 2 -- U-Boot binary
+    name:  onie-accton_as7700_32x-r0.bin.uboot
 
 Step 1 -- Put the ONIE files on a TFTP server
 ---------------------------------------------
@@ -28,8 +39,9 @@ Step 1 -- Put the ONIE files on a TFTP server
 The following directions assume the files are on the root of the TFTP
 server.
 
-Step 2 -- Install ONIE kernel (onie-accton_as7700_32x-r0.bin)
------------------------------------------------
+Step 2 -- Install image1 (onie-accton_as7700_32x-r0.bin)
+--------------------------------------------------------
+
 Copying the image down using TFTP and flash to the NOR flash::
 
   => setenv q1start 0xe8040000
@@ -38,13 +50,24 @@ Copying the image down using TFTP and flash to the NOR flash::
   => protect off $q1start +${q1sz.b} && erase $q1start +${q1sz.b}
   => cp.b $fileaddr $q1start ${q1sz.b} && protect on $q1start +${q1sz.b}
 
-Step 3 -- Configure Serial Console
+Step 3 -- Install image2 (onie-accton_as7700_32x-r0.bin.uboot)
+--------------------------------------------------------------
+
+Copying the image down using TFTP and flash to the NOR flash::
+
+  => setenv q2start 0xeff80000
+  => setenv q2sz.b 0x00080000
+  => tftp onie-accton_as7700_32x-r0.bin.uboot
+  => protect off $q2start +${q2sz.b} && erase $q2start +${q2sz.b}
+  => cp.b $fileaddr $q2start ${q2sz.b} && protect on $q2start +${q2sz.b}
+
+Step 4 -- Configure Serial Console
 ----------------------------------
 
 ONIE defaults the serial console baud rate to 115200.  You may need to
 adjust your terminal settings.
 
-Step 4 -- Restart The System
+Step 5 -- Restart The System
 ----------------------------
 
 You can interrupt the boot process by pressing any key during the
@@ -52,7 +75,7 @@ count down::
 
   => reset
 
-Step 5 -- Optional
+Step 6 -- Optional
 ------------------
 
 By default the system will start the ONIE in *install* mode.  After


### PR DESCRIPTION
The platforms are including:
- as4600_54t
- as5600_52x
- as5610_52x
- as5710_54x
- as6700_32x
- as6701_32x
- as6710_32x
- as7700_32x
