### PR TITLE
Simplier way of building ONIE

### DIFF
--- a/contrib/autobuild/build-onie.py
+++ b/contrib/autobuild/build-onie.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+import os
+import os.path
+import sys
+
+BUILD_CONFIG_PATH = None
+MACHINE_ROOT_PATH = None
+QEMU_TARGETS = []
+VENDOR_MACHINES = {}
+
+
+def is_vendor(vendor):
+    global VENDOR_MACHINES
+    return vendor in VENDOR_MACHINES
+
+
+def is_machine(machine):
+    global VENDOR_MACHINES
+
+    for machines in VENDOR_MACHINES.values():
+        if machine in machines:
+            return True
+    return False
+
+
+def get_vendor(machine):
+    global VENDOR_MACHINES
+
+    for vendor, machines in VENDOR_MACHINES.items():
+        if machine in machines:
+            return vendor
+    return None
+
+
+def add_vendor_machine(vendor, machine):
+    global VENDOR_MACHINES
+
+    if vendor in VENDOR_MACHINES:
+        machines = VENDOR_MACHINES[vendor]
+        machines.append(machine)
+        machines.sort()
+    else:
+        machines = [machine]
+        VENDOR_MACHINES[vendor] = machines
+
+
+def determine_machine_dir(dir):
+    contents = os.listdir(dir)
+    for f in contents:
+        rel_path = os.path.join(dir, f)
+        if os.path.isfile(rel_path) and f == 'machine.make':
+            return True
+    return False
+
+
+def determine_paths():
+    global BUILD_CONFIG_PATH
+    global MACHINE_ROOT_PATH
+
+    build_str = 'build-config'
+    machine_str = 'machine'
+
+    current_path = os.path.abspath(os.path.curdir)
+    if os.path.basename(current_path) == 'autobuild':
+        # calling from within the dir, go two dirs up
+        BUILD_CONFIG_PATH = os.path.join(current_path, '..', '..', build_str)
+        BUILD_CONFIG_PATH = os.path.abspath(BUILD_CONFIG_PATH)
+        MACHINE_ROOT_PATH = os.path.join(current_path, '..', '..', machine_str)
+        MACHINE_ROOT_PATH = os.path.abspath(MACHINE_ROOT_PATH)
+    else:
+        # check if this dir has machines and build_config
+        found_build_config = False
+        found_machine_root = False
+        contents = os.listdir(current_path)
+        for f in contents:
+            if f == build_str:
+                found_build_config = True
+            if f == machine_str:
+                found_machine_root = True
+
+        if found_build_config and found_machine_root:
+            BUILD_CONFIG_PATH = os.path.join(current_path, build_str)
+            BUILD_CONFIG_PATH = os.path.abspath(BUILD_CONFIG_PATH)
+            MACHINE_ROOT_PATH = os.path.join(current_path, machine_str)
+            MACHINE_ROOT_PATH = os.path.abspath(MACHINE_ROOT_PATH)
+        else:
+            sys.stderr.write('Not a valid ONIE repo\n')
+            sys.exit(-1)
+
+
+def process_vendor_machines():
+    global MACHINE_ROOT_PATH
+
+    potential_vendors = []
+    machine_dir = MACHINE_ROOT_PATH
+
+    contents = os.listdir(machine_dir)
+    for v in contents:
+        rel_path = os.path.join(machine_dir, v)
+        if os.path.isdir(rel_path):
+            potential_vendors.append(v)
+
+    for v in potential_vendors:
+        rel_path = os.path.join(machine_dir, v)
+        contents = os.listdir(rel_path)
+        # contents might be a machine dir, check
+        if determine_machine_dir(rel_path):
+            # Add Vendor 'UNKNOWN' and machine dir
+            add_vendor_machine('UNKNOWN', v)
+        else:
+            # We are in Vendor dir, listdir and determine machine_dir
+            for mac in contents:
+                potential_mac_path = os.path.join(machine_dir, v, mac)
+                if determine_machine_dir(potential_mac_path):
+                    add_vendor_machine(v, mac)
+
+
+def list_all():
+    global VENDOR_MACHINES
+    from collections import OrderedDict
+    sorted_dict = OrderedDict(sorted(VENDOR_MACHINES.items(),
+                                     key=lambda t: t[0]))
+
+    for key, values in sorted_dict.items():
+        print key
+        for v in values:
+            print '\t{0}'.format(v)
+        print '\n'
+
+
+def build(machine_or_vendor, dry_run=True, args=''):
+    import subprocess
+    global MACHINE_ROOT_PATH
+    global VENDOR_MACHINES
+
+    if is_vendor(machine_or_vendor):
+        # build everything under that vendor
+        print 'Building everything for vendor: {0}'.format(machine_or_vendor)
+        machines = VENDOR_MACHINES[machine_or_vendor]
+        for machine in machines:
+            build(machine, dry_run, args)
+
+    elif is_machine(machine_or_vendor):
+        vendor = get_vendor(machine_or_vendor)
+        print 'Building {0} / {1}'.format(vendor, machine_or_vendor)
+        machine_root = os.path.join(MACHINE_ROOT_PATH, vendor)
+        if vendor != 'UNKNOWN':
+            cmd = 'make {0} MACHINEROOT={1} MACHINE={2} all'.\
+                  format(args, machine_root, machine_or_vendor)
+        else:
+            cmd = 'make {0} MACHINE={1} all'.\
+                  format(args, machine_or_vendor)
+        print cmd
+        if not dry_run:
+            subprocess.call(cmd, shell=True)
+
+    else:
+        print 'Invalid Target: {0}'.format(machine_or_vendor)
+
+
+def main():
+    import argparse
+    global BUILD_CONFIG_PATH
+
+    parser = argparse.ArgumentParser(description="Build ONIE")
+    parser.add_argument('-l', '--list', action='store_true', default=False,
+                        help='list all vendors and machines')
+    parser.add_argument('-b', '--build', action='append', metavar='TARGET',
+                        help='Vendor or Machine to compile')
+    parser.add_argument('-n', '--dry-run', action='store_true', default=False,
+                        help='perform a dry run, do not execute')
+    parser.add_argument('-m', '--make-args', action='store', metavar='ARGS',
+                        default='',
+                        help='additional args to be passed to make')
+
+    args = parser.parse_args()
+    if args.list is None and args.build is None:
+        parser.print_help()
+        sys.exit(-1)
+
+    determine_paths()
+    process_vendor_machines()
+
+    if args.list:
+        list_all()
+        sys.exit(0)
+
+    if args.build:
+        print 'cd {0}'.format(BUILD_CONFIG_PATH)
+        os.chdir(BUILD_CONFIG_PATH)
+        if 'all' in args.build:
+            for vendor in VENDOR_MACHINES.keys():
+                build(vendor, args.dry_run, args.make_args)
+        else:
+            for b in args.build:
+                build(b, args.dry_run, args.make_args)
+    else:
+        sys.stderr.write('No action performed\n')
+        parser.print_help()
+        sys.exit(-1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Simplier way of building ONIE
Examples:

To run it, you can be either in its directory (ONIE/contrib/autobuild)
or in the ONIE directory.
$ ./build-onie.py -h
usage: build-onie.py [-h] [-l] [-b TARGET] [-n] [-m ARGS]

Build ONIE

optional arguments:
  -h, --help            show this help message and exit
  -l, --list            list all vendors and machines
  -b TARGET, --build TARGET
                        Vendor or Machine to compile
  -n, --dry-run         perform a dry run, do not execute
  -m ARGS, --make-args ARGS
                        additional args to be passed to make

Using the list (-l or --list), you will see all possible vendors and
machines.
$ ./build-onie.py -l
UNKNOWN
        fsl_p2020rdbpca
        im_n29xx_t40n
        kvm_x86_64

accton
        accton_as4600_54t
        accton_as5600_52x
        accton_as5610_52x
        accton_as5710_54x
        accton_as5712_54x
        accton_as6700_32x
        accton_as6701_32x
        accton_as6710_32x
        accton_as6712_32x
        accton_as7700_32x
        accton_as7702_32x

alpha_networks
        alpha_networks_snq6070_320f
        alpha_networks_snq60a0_320f
        alpha_networks_snx6070_486f
        alpha_networks_snx60a0_486f

celestica
        cel_redstone_xp

dell
        dell_s4810_on_p2020
        dell_s6000_s1220

mellanox
        mlnx_x86

quanta
        quanta_lb8d
        quanta_lb9
        quanta_ly2
        quanta_ly3

Now, you can build any targets you want based on either the vendor or
machine names.

$ ./build-onie.py -b mlnx_x86
*\* Builds the mlnx_x86 machine under mellanox

$ ./build-onie.py -b accton
*\* Builds all machines under the accton vendor

$ ./build-onie.py -b quanta_lb9 -b cel_redstone_xp
*\* Builds both the quanta_lb9 and cel_redstone_xp machines

$ ./build-onie.py -b dell_s4810_on_p2020 -b alpha_networks
*\* Builds the dell_s4810_on_p2020 machine and all alpha_networks
machines

$ ./build-onie.py -b all
*\* Builds all machines and reference platforms
