### PR TITLE
xtools: restart build on failure

### DIFF
--- a/build-config/make/xtools.make
+++ b/build-config/make/xtools.make
@@ -58,7 +58,8 @@ xtools-build: $(XTOOLS_BUILD_STAMP)
 $(XTOOLS_BUILD_STAMP): $(XTOOLS_BUILD_DIR)/.config $(CROSSTOOL_NG_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building xtools for $(XTOOLS_VERSION) ===="
-	$(Q) cd $(XTOOLS_BUILD_DIR) && $(CROSSTOOL_NG_DIR)/ct-ng build
+	$(Q) cd $(XTOOLS_BUILD_DIR) && \
+		$(CROSSTOOL_NG_DIR)/ct-ng build || (rm $(XTOOLS_BUILD_DIR)/.config.2 && false)
 	$(Q) touch $@
 
 xtools-clean:


### PR DESCRIPTION
Today the crosstools-ng build has the bad property that when
restarting a build after a failure the crosstool-ng system believes
the toolchain is built correctly.  This leads to all manner of
downstream build errors and confusion for developers who are trying to
make progress after a crosstool-ng failure.

This patch coaxes the xtools target into being "out of date" whenever
the crosstool-ng build fails.  This is accomplished by removing the
$(XTOOLS_BUILD_DIR)/.config.2 file, which the crosstool-ng system uses
as a prerequisite for building, whenever the crosstool-ng build fails.

Signed-off-by: Curt Brune curt@cumulusnetworks.com
