### PR TITLE
Accton platforms: Correct the comments in onie-rom.conf

### DIFF
--- a/machine/accton/accton_as4600_54t/onie-rom.conf
+++ b/machine/accton/accton_as4600_54t/onie-rom.conf
@@ -1,9 +1,9 @@
-# Accton 5654 onie ROM configuration
+# Accton AS4600_54T onie ROM configuration
 
-description="Accton, 5654"
+description="Accton, AS4600_54T"
 
 # make two ROM images: 1) just u-boot, 2) uboot-env + onie-uimage
-# see kernel/linux/arch/powerpc/boot/dts/accton_4654.dts for NOR flash layout
+# see kernel/linux/arch/powerpc/boot/dts/as4600_54t.dts for NOR flash layout
 #
 # Top Down the NOR flash looks like:
 # 1. u-boot image -- 512KB

--- a/machine/accton/accton_as5600_52x/onie-rom.conf
+++ b/machine/accton/accton_as5600_52x/onie-rom.conf
@@ -1,6 +1,6 @@
 # Accton AS5600_52X onie ROM configuration
 
-description="Accton, 5652"
+description="Accton, AS5600_52X"
 
 # make two ROM images: 1) just u-boot, 2) uboot-env + onie-uimage
 # see kernel/linux/arch/powerpc/boot/dts/as5600_52x.dts for NOR flash layout

--- a/machine/accton/accton_as5710_54x/onie-rom.conf
+++ b/machine/accton/accton_as5710_54x/onie-rom.conf
@@ -3,13 +3,7 @@
 description="Accton, AS5710_54X"
 
 # make two ROM images: 1) just u-boot, 2) uboot-env + onie-uimage
-# see kernel/linux/arch/powerpc/boot/dts/accton_4654.dts for NOR flash layout
-#
-# Top Down the NOR flash looks like:
-# 1. u-boot image -- 512KB
-# 2. board info   -- 1 sector 64KB
-# 3. u-boot env   -- 1 sector 64KB
-# 4. onie-uimage   -- 4MB
+# see kernel/linux/arch/powerpc/boot/dts/as5710_54x.dts for NOR flash layout
 
 format=ubootenv_onie
 

--- a/machine/accton/accton_as6700_32x/onie-rom.conf
+++ b/machine/accton/accton_as6700_32x/onie-rom.conf
@@ -1,15 +1,9 @@
-# Accton 5654 onie ROM configuration
+# Accton AS6700_32X onie ROM configuration
 
 description="Accton, AS6700_32X"
 
 # make two ROM images: 1) just u-boot, 2) uboot-env + onie-uimage
-# see kernel/linux/arch/powerpc/boot/dts/accton_4654.dts for NOR flash layout
-#
-# Top Down the NOR flash looks like:
-# 1. u-boot image -- 512KB
-# 2. board info   -- 1 sector 64KB
-# 3. u-boot env   -- 1 sector 64KB
-# 4. onie-uimage   -- 4MB
+# see kernel/linux/arch/powerpc/boot/dts/accton_as6700_32x-r*.dts for NOR flash layout
 
 format=ubootenv_onie
 

--- a/machine/accton/accton_as6701_32x/onie-rom.conf
+++ b/machine/accton/accton_as6701_32x/onie-rom.conf
@@ -2,6 +2,9 @@
 
 description="Accton, AS6701_32X"
 
+# make two ROM images: 1) just u-boot, 2) uboot-env + onie-uimage
+# see kernel/linux/arch/powerpc/boot/dts/as6701_32x.dts for NOR flash layout
+
 format=ubootenv_onie
 
 uboot_machine=AS6701_32X

--- a/machine/accton/accton_as6710_32x/onie-rom.conf
+++ b/machine/accton/accton_as6710_32x/onie-rom.conf
@@ -3,13 +3,7 @@
 description="Accton, AS6710_32X"
 
 # make two ROM images: 1) just u-boot, 2) uboot-env + onie-uimage
-# see kernel/linux/arch/powerpc/boot/dts/accton_4654.dts for NOR flash layout
-#
-# Top Down the NOR flash looks like:
-# 1. u-boot image -- 512KB
-# 2. board info   -- 1 sector 64KB
-# 3. u-boot env   -- 1 sector 64KB
-# 4. onie-uimage   -- 4MB
+# see kernel/linux/arch/powerpc/boot/dts/as6710_32x.dts for NOR flash layout
 
 format=ubootenv_onie
 


### PR DESCRIPTION
These platforms are including:
- AS4600_54T
- AS5600_52X
- AS5710_54X
- AS6700_32X
- AS6701_32X
- AS6710_32X

The onie-rom.conf were copid and revised from Accton 5652 (a.k.a.
AS5600_52x).  Some comments in thier onie-rom.conf were not quite
true.  We revise the sentances to conform to present fact.
