### PR TITLE
AS6701_32x remove unavailable usb node from DTS

### DIFF
--- a/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
+++ b/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
@@ -24927,7 +24927,7 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS5710_54X.h b/include/configs/AS5710_54X.h
 new file mode 100644
-index 0000000..fe3d32c
+index 0000000..809e4e7
 --- /dev/null
 +++ b/include/configs/AS5710_54X.h
 @@ -0,0 +1,687 @@
@@ -25569,7 +25569,7 @@ index 0000000..fe3d32c
 +#define CONFIG_SYS_EEPROM_MAX_SIZE		CONFIG_SYS_FLASH_HWINFO_SECT_SIZE
 +
 +#define ONIE_SIZE_B	\
-+	"onie_sz.b=0x00d00000\0"
++	"onie_sz.b=0x00500000\0"
 +
 +#if defined(CONFIG_BOOT_DEVICE_NOR_FLASH_SIZE_128MB)
 +#define CONFIG_PLATFORM_ENV	    \

--- a/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
+++ b/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
@@ -37451,7 +37451,7 @@ index a29f6a6..f26a80d 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/ACCTON_AS6700_32X-R0.h b/include/configs/ACCTON_AS6700_32X-R0.h
 new file mode 100644
-index 0000000..16223e8
+index 0000000..2ed0c8b
 --- /dev/null
 +++ b/include/configs/ACCTON_AS6700_32X-R0.h
 @@ -0,0 +1,879 @@
@@ -38325,7 +38325,7 @@ index 0000000..16223e8
 +    "diag_start=0x00930000\0"   \
 +    "diag_sz.b=0x02000000\0"    \
 +    "onie_start=0x00130000\0"   \
-+    "onie_sz.b=0x800000\0"
++    "onie_sz.b=0x500000\0"
 +
 +#define CONFIG_EXTRA_ENV_SETTINGS \
 +    CONFIG_PLATFORM_ENV           \
@@ -38336,7 +38336,7 @@ index 0000000..16223e8
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/ACCTON_AS6700_32X-R1.h b/include/configs/ACCTON_AS6700_32X-R1.h
 new file mode 100644
-index 0000000..1fdf450
+index 0000000..873c69a
 --- /dev/null
 +++ b/include/configs/ACCTON_AS6700_32X-R1.h
 @@ -0,0 +1,880 @@
@@ -39211,7 +39211,7 @@ index 0000000..1fdf450
 +    "diag_start=0x009c0000\0"   \
 +    "diag_sz.b=0x02000000\0"    \
 +    "onie_start=0x001c0000\0"   \
-+    "onie_sz.b=0x800000\0"
++    "onie_sz.b=0x500000\0"
 +
 +#define CONFIG_EXTRA_ENV_SETTINGS \
 +    CONFIG_PLATFORM_ENV           \

--- a/machine/accton/accton_as6701_32x/kernel/platform-as6701_32x.patch
+++ b/machine/accton/accton_as6701_32x/kernel/platform-as6701_32x.patch
@@ -4,10 +4,10 @@ Support for the Accton AS6701_32X networking platform.
 
 diff --git a/arch/powerpc/boot/dts/as6701_32x.dts b/arch/powerpc/boot/dts/as6701_32x.dts
 new file mode 100644
-index 0000000..92131f6
+index 0000000..abc5412
 --- /dev/null
 +++ b/arch/powerpc/boot/dts/as6701_32x.dts
-@@ -0,0 +1,556 @@
+@@ -0,0 +1,548 @@
 +/*
 + * Accton Technology AS6701_32X Device Tree Source
 + *
@@ -391,14 +391,6 @@ index 0000000..92131f6
 +				cell-index = <0x3>;
 +				interrupts = <0x17 0x2 0x0 0x0>;
 +			};
-+		};
-+
-+		usb@23000 {
-+			compatible = "fsl-usb2-dr";
-+			reg = <0x23000 0x1000>;
-+			#address-cells = <0x1>;
-+			#size-cells = <0x0>;
-+			interrupts = <0x2e 0x2 0x0 0x0>;
 +		};
 +
 +		sdhc@2e000 {

--- a/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
+++ b/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
@@ -24822,7 +24822,7 @@ index a29f6a6..f26a80d 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6701_32X.h b/include/configs/AS6701_32X.h
 new file mode 100644
-index 0000000..24145e5
+index 0000000..1adaf21
 --- /dev/null
 +++ b/include/configs/AS6701_32X.h
 @@ -0,0 +1,821 @@
@@ -25633,7 +25633,7 @@ index 0000000..24145e5
 +    "hwconfig=usb1:dr_mode=host,phy_type=ulpi\0"    \
 +    "consoledev=ttyS0\0"        \
 +    "onie_start=0xec040000\0"   \
-+    "onie_sz.b=0xd00000\0"      \
++    "onie_sz.b=0x500000\0"      \
 +    "diag_start=0xecd40000\0"   \
 +    "diag_sz.b=0x01600000\0"    \
 +    "boot_diag=if test -n $onie_boot_reason; then if test $onie_boot_reason = diag; then run diag_bootcmd; fi; fi\0" \

--- a/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
+++ b/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
@@ -8673,10 +8673,10 @@ index 0000000..4437731
 +'setenv hwconfig 'qe;tdm'' to enalbe QE TDM and disable Nor-Flash/CPLD.
 diff --git a/board/accton/as6701_32x/as6701_32x.c b/board/accton/as6701_32x/as6701_32x.c
 new file mode 100644
-index 0000000..06737ae
+index 0000000..3479684
 --- /dev/null
 +++ b/board/accton/as6701_32x/as6701_32x.c
-@@ -0,0 +1,1155 @@
+@@ -0,0 +1,1140 @@
 +/*
 + * Copyright 2010-2011 Freescale Semiconductor, Inc.
 + *
@@ -9214,7 +9214,7 @@ index 0000000..06737ae
 +	phys_addr_t base;
 +	phys_size_t size;
 +	const char *soc_usb_compat = "fsl-usb2-dr";
-+	int err, usb1_off, usb2_off;
++	int err, usb1_off;
 +
 +	ft_cpu_setup(blob, bd);
 +
@@ -9264,7 +9264,6 @@ index 0000000..06737ae
 +	}
 +#endif
 +
-+/* Delete USB2 node as it is muxed with eLBC */
 +	usb1_off = fdt_node_offset_by_compatible(blob, -1,
 +		soc_usb_compat);
 +	if (usb1_off < 0) {
@@ -9273,20 +9272,6 @@ index 0000000..06737ae
 +			fdt_strerror(usb1_off));
 +		return;
 +	}
-+	usb2_off = fdt_node_offset_by_compatible(blob, usb1_off,
-+			soc_usb_compat);
-+	if (usb2_off < 0) {
-+		printf("WARNING: (usb2_off) could not find compatible node"
-+			" %s: %s.\n", soc_usb_compat,
-+			fdt_strerror(usb2_off));
-+		return;
-+	}
-+	err = fdt_del_node(blob, usb2_off);
-+	if (err < 0) {
-+		printf("WARNING: could not remove %s: %s.\n",
-+			soc_usb_compat, fdt_strerror(err));
-+	}
-+
 +}
 +#endif
 +

--- a/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
+++ b/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
@@ -24958,7 +24958,7 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6710_32X.h b/include/configs/AS6710_32X.h
 new file mode 100644
-index 0000000..a64651d
+index 0000000..fe5ae07
 --- /dev/null
 +++ b/include/configs/AS6710_32X.h
 @@ -0,0 +1,699 @@
@@ -25606,7 +25606,7 @@ index 0000000..a64651d
 +#define CONFIG_SYS_EEPROM_MAX_SIZE		CONFIG_SYS_FLASH_HWINFO_SECT_SIZE
 +
 +#define ONIE_SIZE_B \
-+	"onie_sz.b=0x00d00000\0"
++	"onie_sz.b=0x00500000\0"
 +
 +#if defined(CONFIG_BOOT_DEVICE_NOR_FLASH_SIZE_128MB)
 +#define CONFIG_PLATFORM_ENV	    \

--- a/machine/accton/accton_as7700_32x/u-boot/platform-accton-as7700_32x.patch
+++ b/machine/accton/accton_as7700_32x/u-boot/platform-accton-as7700_32x.patch
@@ -24979,7 +24979,7 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS7700_32X.h b/include/configs/AS7700_32X.h
 new file mode 100644
-index 0000000..181102a
+index 0000000..301aac4
 --- /dev/null
 +++ b/include/configs/AS7700_32X.h
 @@ -0,0 +1,681 @@
@@ -25622,7 +25622,7 @@ index 0000000..181102a
 +#define CONFIG_SYS_EEPROM_MAX_SIZE		CONFIG_SYS_FLASH_HWINFO_SECT_SIZE
 +
 +#define ONIE_SIZE_B \
-+	"onie_sz.b=0x00d00000\0"
++	"onie_sz.b=0x00500000\0"
 +
 +#if defined(CONFIG_BOOT_DEVICE_NOR_FLASH_SIZE_128MB)
 +#define CONFIG_PLATFORM_ENV	    \


### PR DESCRIPTION
The other commit is used to revise 'onie_sz.b' to speed up booting into ONIE.  This patch is for all powerpc platforms except AS4600_54T, AS5600_52X, and AS5610_52X.