### PR TITLE
Accton AS7700_32X: Remove autoboot prompt from u-boot

### DIFF
--- a/machine/accton/accton_as7700_32x/u-boot/platform-accton-as7700_32x.patch
+++ b/machine/accton/accton_as7700_32x/u-boot/platform-accton-as7700_32x.patch
@@ -24979,10 +24979,10 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS7700_32X.h b/include/configs/AS7700_32X.h
 new file mode 100644
-index 0000000..301aac4
+index 0000000..ee36196
 --- /dev/null
 +++ b/include/configs/AS7700_32X.h
-@@ -0,0 +1,681 @@
+@@ -0,0 +1,677 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -25540,10 +25540,6 @@ index 0000000..301aac4
 +
 +/* default location for tftp and bootm */
 +#define CONFIG_LOADADDR		1000000
-+
-+#define CONFIG_AUTOBOOT_KEYED 1
-+#define CONFIG_AUTOBOOT_STOP_STR "123\r"
-+#define CONFIG_AUTOBOOT_PROMPT "Type 123<ENTER> to STOP autoboot\n"
 +
 +#define __USB_PHY_TYPE	utmi
 +


### PR DESCRIPTION
Remove "<123ENTER>" autoboot prompt from u-boot.