### PR TITLE
Accton AS6710_32X: Remove autoboot prompt from u-boot

### DIFF
--- a/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
+++ b/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
@@ -24958,10 +24958,10 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6710_32X.h b/include/configs/AS6710_32X.h
 new file mode 100644
-index 0000000..fe5ae07
+index 0000000..e65dc71
 --- /dev/null
 +++ b/include/configs/AS6710_32X.h
-@@ -0,0 +1,699 @@
+@@ -0,0 +1,689 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -25518,16 +25518,6 @@ index 0000000..fe5ae07
 +
 +/* default location for tftp and bootm */
 +#define CONFIG_LOADADDR		1000000
-+
-+/*move to common_config.h*/
-+#if 0
-+#define CONFIG_AUTOBOOT_KEYED 1
-+#define CONFIG_AUTOBOOT_STOP_STR "123\r"
-+#define CONFIG_AUTOBOOT_PROMPT "Type 123<ENTER> to STOP autoboot\n"
-+#define CONFIG_BOOTDELAY 3 /* -1 disables auto-boot */
-+#endif
-+
-+#define CONFIG_BAUDRATE	115200
 +
 +#define __USB_PHY_TYPE	utmi
 +
@@ -30461,7 +30451,7 @@ index 76b3ca6..3a166d9 100644
 +
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..a108864 100644
+index e9e2135..46308b8 100644
 --- a/include/configs/common_config.h
 +++ b/include/configs/common_config.h
 @@ -26,7 +26,7 @@
@@ -30538,16 +30528,6 @@ index e9e2135..a108864 100644
  
  #define CONFIG_ENV_SIZE		0x2000
  
-@@ -143,6 +146,9 @@
- /*
-  * Environment Variable Configuration
-  */
-+#define CONFIG_AUTOBOOT_KEYED 1
-+#define CONFIG_AUTOBOOT_STOP_STR "123\r"
-+#define CONFIG_AUTOBOOT_PROMPT "Type 123<ENTER> to STOP autoboot\n"
- 
- #define CONFIG_BOOTDELAY 10	/* -1 disables auto-boot */
- #undef	CONFIG_BOOTARGS		/* the boot command will set bootargs*/
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h


### PR DESCRIPTION
Remove "123&lt;ENTER&gt;" autoboot prompt from u-boot