### PR TITLE
Ensure syslinux is installed

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -374,6 +374,7 @@ machine-prefix:
 # Install required build packages for a x86_64 debian based build host
 DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools python-sphinx rst2pdf \
 				  gperf device-tree-compiler python-all-dev genisoimage \
+				  syslinux \
 				  autoconf automake bison flex texinfo libtool \
 				  realpath gawk libncurses5 libncurses5-dev bc
 


### PR DESCRIPTION
Need to ensure ```syslinux``` is installed as part of
```debian-prepare-build-host``` as it provides ```isohybrid``` and a dep
package ```syslinux-common``` provides ```isohybrid.pl``` which is used
by ```recovery-iso``` build targets.