### PR TITLE
discover: check both boot_file and bootfile variables

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -250,21 +250,26 @@ http_download()
 
 tftp_download()
 {
-    # Try BOOTP next-server and bootfile
-    if [ -n "$onie_disco_siaddr" ] && [ -n "$onie_disco_bootfile" ] ; then
-        url_run "tftp://$onie_disco_siaddr/$onie_disco_bootfile" && return 0
-    fi
+    # Busybox sets "boot_file" for the BOOTP boot file and sets
+    # "bootfile" (no underscore) for DHCP option 67.
 
-    # Try DHCP TFTP server name (opt 66) and bootfile (opt 67)
-    # Requires DNS
-    if [ -n "$onie_disco_tftp" ] && [ -n "$onie_disco_bootfile" ] ; then
-        url_run "tftp://$onie_disco_tftp/$onie_disco_bootfile" && return 0
-    fi
+    for f in $onie_disco_bootfile $onie_disco_boot_file ; do
+        # Try BOOTP next-server and bootfile
+        if [ -n "$onie_disco_siaddr" ] && [ -n "$f" ] ; then
+            url_run "tftp://$onie_disco_siaddr/$f" && return 0
+        fi
 
-    # Try DHCP TFTP server IP address (opt 150) and bootfile (opt 67)
-    if [ -n "$onie_disco_tftpsiaddr" ] && [ -n "$onie_disco_bootfile" ] ; then
-        url_run "tftp://$onie_disco_tftpsiaddr/$onie_disco_bootfile" && return 0
-    fi
+        # Try DHCP TFTP server name (opt 66) and bootfile
+        # Requires DNS
+        if [ -n "$onie_disco_tftp" ] && [ -n "$f" ] ; then
+            url_run "tftp://$onie_disco_tftp/$f" && return 0
+        fi
+
+        # Try DHCP TFTP server IP address (opt 150) and bootfile
+        if [ -n "$onie_disco_tftpsiaddr" ] && [ -n "$f" ] ; then
+            url_run "tftp://$onie_disco_tftpsiaddr/$f" && return 0
+        fi
+    done
 
     return 1
 }


### PR DESCRIPTION
Ticket: 126

The problem is in ONIE and the difference between the BOOTP "file"
field and DHCP option 67 "Boot file".

For bootp reference:
https://tools.ietf.org/html/rfc951

For DHCP option 67 reference:
https://tools.ietf.org/html/rfc2132

Busybox's udhcpd translates the BOOTP "file" field into a variable
named "boot_file", which the discovery process prepends with
"onie_disco_" to finally have: onie_disco_boot_file. You can see this
variable set in the log file. Also the PCAP shows the "Boot file name"
field in the BOOTP section.

DHCP option 67 is translated into "bootfile" (without the underscore),
which gives the ONIE variable "onie_disco_bootfile".

The problem is the ONIE download code is only using
$onie_disco_bootfile. ONIE should be checking both
$onie_disco_bootfile and $onie_disco_boot_file.

In the "exact TFTP" download section this patch now loops over both
variables looking for a hit.