### PR TITLE
HTTP iscdhcp webserver ip address quoted (shouldn't be)

### DIFF
--- a/contrib/autobuild/modules/iscdhcp.py
+++ b/contrib/autobuild/modules/iscdhcp.py
@@ -89,7 +89,7 @@ host {{ host.hostname }}
     option tftp-server-name "{{ tftp_server_name }}";
     {% endif %}
     {%- if www_server_ip %}
-    option www-server "{{ www_server_ip }}";
+    option www-server {{ www_server_ip }};
     {% endif %}
 }
 


### PR DESCRIPTION
Resolves issue 128: https://github.com/opencomputeproject/onie/issues/128