### PR TITLE
ONIE updater be able to check machine image via install-platform

### DIFF
--- a/build-config/scripts/onie-mk-installer.sh
+++ b/build-config/scripts/onie-mk-installer.sh
@@ -86,6 +86,10 @@ cp $installer_dir/install.sh $tmp_installdir || exit 1
 echo -n "."
 cp -r $installer_dir/$arch/* $tmp_installdir
 
+[ -r $machine_dir/installer/install-platform ] && {
+    cp $machine_dir/installer/install-platform $tmp_installdir
+}
+
 # Escape special chars in the user provide kernel cmdline string for use in
 # sed. Special chars are: \ / &
 EXTRA_CMDLINE_LINUX=`echo $EXTRA_CMDLINE_LINUX | sed -e 's/[\/&]/\\\&/g'`

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -99,6 +99,8 @@ check_machine_image()
     fi
 }
 
+[ -r ./install-platform ] && . ./install-platform
+
 fail=
 check_machine_image
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -86,16 +86,21 @@ while getopts "$args" a ; do
     esac
 done
 
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}
+
 fail=
-if [ "$onie_machine" != "$image_machine" ] ; then
-    fail=yes
-fi
-if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
-    fail=yes
-fi
-if [ "$onie_arch" != "$image_arch" ] ; then
-    fail=yes
-fi
+check_machine_image
 
 if [ "$fail" = "yes" ] && [ "$force" = "no" ] ; then
     echo "ERROR: Machine mismatch"

--- a/machine/accton/accton_as4600_54t/installer/install-platform
+++ b/machine/accton/accton_as4600_54t/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as5600_52x/installer/install-platform
+++ b/machine/accton/accton_as5600_52x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as5610_52x/installer/install-platform
+++ b/machine/accton/accton_as5610_52x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as5700_96x/installer/install-platform
+++ b/machine/accton/accton_as5700_96x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as5710_54x/installer/install-platform
+++ b/machine/accton/accton_as5710_54x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as5712_54x/installer/install-platform
+++ b/machine/accton/accton_as5712_54x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as6700_32x/installer/install-platform
+++ b/machine/accton/accton_as6700_32x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as6701_32x/installer/install-platform
+++ b/machine/accton/accton_as6701_32x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as6710_32x/installer/install-platform
+++ b/machine/accton/accton_as6710_32x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as6712_32x/installer/install-platform
+++ b/machine/accton/accton_as6712_32x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as7700_32x/installer/install-platform
+++ b/machine/accton/accton_as7700_32x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}

--- a/machine/accton/accton_as7702_32x/installer/install-platform
+++ b/machine/accton/accton_as7702_32x/installer/install-platform
@@ -1,0 +1,14 @@
+
+check_machine_image()
+{
+    if [ "$onie_machine" != "$image_machine" ] &&
+       [ "accton_$onie_machine" != "$image_machine" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
+        fail=yes
+    fi
+    if [ "$onie_arch" != "$image_arch" ] ; then
+        fail=yes
+    fi
+}


### PR DESCRIPTION
As discussed in the thread:
http://lists.opencompute.org/pipermail/opencompute-onie/2015-February/000414.html

Add install-platform for machine vendor to override the behaviour of checking machine image.