### PR TITLE
x86 uninstall: append diag menu entry to grub.cfg if there's no one

### DIFF
--- a/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
@@ -172,7 +172,8 @@ uninstall_system()
 
     # If there is a diag partition add a chainload entry for it.
     diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
-    if [ -n "$diag_label" ] ; then
+    if [ -n "$diag_label" ] &&
+       [ -z '$(grep "$diag_label" $grub_root_dir/grub.cfg)' ] ; then
         cat <<EOF >> $grub_root_dir/grub.cfg
 menuentry '$diag_label $onie_platform' {
         search --no-floppy --label --set=root $diag_label


### PR DESCRIPTION
The x86_64 uninstall-arch always appends a diag menu entry to ONIE's
grub.cfg.  The grub.cfg will have more than one diag menu entry
if user executes ONIE Uninstall more than one time.