### PR TITLE
x86 uninstall: fix shell script issue in commit 2684576

### DIFF
--- a/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
@@ -173,7 +173,7 @@ uninstall_system()
     # If there is a diag partition add a chainload entry for it.
     diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
     if [ -n "$diag_label" ] &&
-       [ -z '$(grep "$diag_label" $grub_root_dir/grub.cfg)' ] ; then
+       [ -z "$(grep $diag_label $grub_root_dir/grub.cfg)" ] ; then
         cat <<EOF >> $grub_root_dir/grub.cfg
 menuentry '$diag_label $onie_platform' {
         search --no-floppy --label --set=root $diag_label


### PR DESCRIPTION
In commit 2684576, the expression enclosed by single quotation
marks is always taken as a normal string.  So that test of zero
length of string never occurs.  The patch revised to use double
quotation marks to enclose the expression.