### PR TITLE
busybox: fix issue that flashcp progress can't reach 100%

### DIFF
--- a/patches/busybox/flashcp-progress-100.patch
+++ b/patches/busybox/flashcp-progress-100.patch
@@ -1,0 +1,23 @@
+Fix issue that flashcp progress cannot reach 100%
+
+diff --git a/miscutils/flashcp.c b/miscutils/flashcp.c
+index 790f9c0..c93fb62 100644
+--- a/miscutils/flashcp.c
++++ b/miscutils/flashcp.c
+@@ -123,12 +123,14 @@ int flashcp_main(int argc UNUSED_PARAM, char **argv)
+ 		done = 0;
+ 		count = BUFSIZE;
+ 		while (1) {
+-			uoff_t rem = statb.st_size - done;
++			uoff_t rem;
++
++			progress(i, done / 1024, (uoff_t)statb.st_size / 1024);
++			rem = statb.st_size - done;
+ 			if (rem == 0)
+ 				break;
+ 			if (rem < BUFSIZE)
+ 				count = rem;
+-			progress(i, done / 1024, (uoff_t)statb.st_size / 1024);
+ 			xread(fd_f, buf, count);
+ 			if (i == 1) {
+ 				int ret;

--- a/patches/busybox/series
+++ b/patches/busybox/series
@@ -1,8 +1,9 @@
-# This series applies on GIT commit d5f0dbdbb3e43604c17d56e60f875a02a582d65c
+# This series applies on GIT commit 0a268854bf2695b64b5c2c878b0bf7ade6e6ea6a
 gitignore.patch
 u-boot-env-tools.patch
 dhcp-additional-options.patch
 dhcp-hostname-sanitization-optional.patch
+flashcp-progress-100.patch
 feature-iproute-neigh.patch
 feature-flash-erase-command.patch
 feature-iorw-command.patch


### PR DESCRIPTION
When ONIE updates itself, flashcp progress can't reach 100% after
writing/verifying kernel and u-boot images.  It makes user be confused
in spite of the images has been written to flash completely and correctly.

    ONIE: Version       : 2015.3.11
    ONIE: Architecture  : powerpc
    ONIE: Machine       : accton_as7700_32x
    ONIE: Machine Rev   : 1
    ONIE: Config Version: 0
    Updating ONIE kernel ...
    Erasing block: 38/38 (100%)
    Writing kb: 4824/4830 (99%)
    Verifying kb: 4824/4830 (99%)
    Updating ONIE U-Boot ...
    Erasing block: 6/6 (100%)
    Writing kb: 760/768 (98%)
    Verifying kb: 760/768 (98%)

This issue is tracking by busybox's bugzilla now.  But the formal
solution has not been announced yet.  I create a patch according
to the proposal in bugzilla.

Reference:
http://lists.busybox.net/pipermail/busybox-cvs/2014-October/034792.html