### PR TITLE
Dropbear 2015.67

### DIFF
--- a/build-config/make/dropbear.make
+++ b/build-config/make/dropbear.make
@@ -1,6 +1,7 @@
 #-------------------------------------------------------------------------------
 #
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 Nikolay Shopik <shopik@inblock.ru>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -9,7 +10,7 @@
 # This is a makefile fragment that defines the build of dropbear
 #
 
-DROPBEAR_VERSION		= 2013.58
+DROPBEAR_VERSION		= 2015.67
 DROPBEAR_TARBALL		= dropbear-$(DROPBEAR_VERSION).tar.bz2
 DROPBEAR_TARBALL_URLS		+= $(ONIE_MIRROR) https://matt.ucc.asn.au/dropbear/releases
 DROPBEAR_BUILD_DIR		= $(MBUILDDIR)/dropbear

--- a/upstream/dropbear-2015.67.tar.bz2.sha1
+++ b/upstream/dropbear-2015.67.tar.bz2.sha1
@@ -1,0 +1,1 @@
+73ad881fd30770ae20f8910f1db60725ab3ef6ed  dropbear-2015.67.tar.bz2


### PR DESCRIPTION
Update dropbear to latest version.
fixes CVE-2013-4421, CVE-2013-4434
memory exhaustion denial-of-service and avoids disclosing which users are valid