### PR TITLE
Uboot fsl sdk v1.7 feature patches

### DIFF
--- a/patches/u-boot/fsl-sdk-v1.7/feature-config-repeatable.patch
+++ b/patches/u-boot/fsl-sdk-v1.7/feature-config-repeatable.patch
@@ -1,0 +1,46 @@
+Add configuration option to disable repeating of prior command
+
+Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+Copyright (C) 2015 david_yang <david_yang@accton.com>
+
+SPDX-License-Identifier:     GPL-2.0
+
+Prior to history and an editable command line, u-boot had a "feature" that
+allowed users to type CR at the prompt and repeat the last command (some
+commands even auto-increment addresses).
+
+There are emails on the mailing list suggesting that the fucntion be limited to
+"useful" cases; however, it is clear that this "repeat" leads to unexpected
+behavior as it differs from almost every standard command parser.
+
+This patch allows users to completely disable the repeat to be completely
+disabled by defining "CONFIG_SYS_NO_REPEATABLE.
+
+diff --git a/common/cli_hush.c b/common/cli_hush.c
+index 38da5a0..a94d4c6 100644
+--- a/common/cli_hush.c
++++ b/common/cli_hush.c
+@@ -1027,6 +1027,9 @@ static void get_user_input(struct in_str *i)
+ 	if (had_ctrlc()) flag_repeat = 0;
+ 	clear_ctrlc();
+ 	do_repeat = 0;
++#ifdef CONFIG_SYS_NO_REPEATABLE
++	flag_repeat = 0;
++#endif
+ 	if (i->promptmode == 1) {
+ 		if (console_buffer[0] == '\n'&& flag_repeat == 0) {
+ 			strcpy(the_command,console_buffer);
+diff --git a/common/cli_simple.c b/common/cli_simple.c
+index 353ceeb..dd1f94e 100644
+--- a/common/cli_simple.c
++++ b/common/cli_simple.c
+@@ -248,6 +248,9 @@ int cli_simple_run_command(const char *cmd, int flag)
+ 		if (cmd_process(flag, argc, argv, &repeatable, NULL))
+ 			rc = -1;
+ 
++#ifdef CONFIG_SYS_NO_REPEATABLE
++		repeatable = 0;
++#endif
+ 		/* Did the user stop this? */
+ 		if (had_ctrlc())
+ 			return -1;	/* if stopped then not repeatable */

--- a/patches/u-boot/fsl-sdk-v1.7/feature-fdt-environment-size.patch
+++ b/patches/u-boot/fsl-sdk-v1.7/feature-fdt-environment-size.patch
@@ -1,0 +1,56 @@
+feature fdt environment size patch
+
+Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+Copyright (C) 2015 david_yang <david_yang@accton.com>
+
+SPDX-License-Identifier:     GPL-2.0
+
+When fixing up the device tree before booting store CONFIG_ENV_SIZE in
+the device tree.
+
+First find the FDT node with a property called "label" whose value is
+"uboot-env".
+
+If the node is found then set the "env_size" property to
+CONFIG_ENV_SIZE.
+
+diff --git a/README b/README
+index 5b37a20..7a7a48d 100644
+--- a/README
++++ b/README
+@@ -682,6 +682,19 @@ The following options need to be configured:
+ 		crash. This is needed for buggy hardware (uc101) where
+ 		no pull down resistor is connected to the signal IDE5V_DD7.
+ 
++		CONFIG_FDT_ENV_SIZE
++
++		When fixing up the device tree before booting store
++		the value of the CONFIG_ENV_SIZE macro in the device
++		tree.  This allows the OS to know how the environment
++		area is defined.
++
++		The method first finds the FDT node with a property
++		called "label" whose value is "uboot-env".
++
++		If the node is found then set the "env_size" property to
++		CONFIG_ENV_SIZE.
++
+ 		CONFIG_MACH_TYPE	[relevant for ARM only][mandatory]
+ 
+ 		This setting is mandatory for all boards that have only one
+diff --git a/common/image-fdt.c b/common/image-fdt.c
+index 9fc7481..290add8 100644
+--- a/common/image-fdt.c
++++ b/common/image-fdt.c
+@@ -472,6 +472,11 @@ int image_setup_libfdt(bootm_headers_t *images, void *blob,
+ 		ft_board_setup(blob, gd->bd);
+ 	fdt_fixup_ethernet(blob);
+ 
++#if defined(CONFIG_FDT_ENV_SIZE) && defined(CONFIG_ENV_SIZE)
++		do_fixup_by_prop_u32(blob, "label", "uboot-env", 10,
++				     "env_size", CONFIG_ENV_SIZE, 1);
++#endif
++
+ 	/* Delete the old LMB reservation */
+ 	lmb_free(lmb, (phys_addr_t)(u32)(uintptr_t)blob,
+ 		 (phys_size_t)fdt_totalsize(blob));

--- a/patches/u-boot/fsl-sdk-v1.7/series
+++ b/patches/u-boot/fsl-sdk-v1.7/series
@@ -1,4 +1,4 @@
-# This series applies on GIT commit 0051ea7ac041b330cc35776b5bbfe62c1cac31e6
+# This series applies on GIT commit 3e0a412c3a828c7ecb41c1f73cf20c2e09c14cf2
 git-ignore.patch
 feature-config-repeatable.patch
 feature-dhcp-options.patch
@@ -6,6 +6,7 @@ feature-save-default-env-on-bad-crc.patch
 feature-populate-serial-number.patch
 feature-sys-eeprom-tlv-common.patch
 feature-sys-eeprom-tlv.patch
+feature-fdt-environment-size.patch
 driver-support-new-broadcom-phys.patch
 platform-onie-common-env.patch
 platform-common-env.patch

--- a/patches/u-boot/fsl-sdk-v1.7/series
+++ b/patches/u-boot/fsl-sdk-v1.7/series
@@ -1,5 +1,6 @@
-# This series applies on GIT commit 81a197cff5938259deb645dd719e0a4617495863
+# This series applies on GIT commit 0051ea7ac041b330cc35776b5bbfe62c1cac31e6
 git-ignore.patch
+feature-config-repeatable.patch
 feature-dhcp-options.patch
 feature-save-default-env-on-bad-crc.patch
 feature-populate-serial-number.patch


### PR DESCRIPTION
To complement feature patches for u-boot fsl-sdk-v1.7 mentioned in PR #169.  The original patches for 2013.01.01 can't apply to fsl-sdk-v1.7 directly.  Some target files are renamed, some functions are moved to new files.  I discovered the targets in fsl-sdk-v1.7 and recreated new patches for it.  These two patches were tested in Accton AS7700_32X.