### PR TITLE
install.sh: move 'Rebooting...' message to exec_installer

### DIFF
--- a/demo/installer/powerpc-softfloat/install.sh
+++ b/demo/installer/powerpc-softfloat/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -36,5 +37,4 @@ EOF
 
 fw_setenv -f -s /tmp/env.txt
 
-echo "Rebooting..."
-reboot
+cd /

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -128,6 +129,4 @@ xz -d -c onie-update.tar.xz | tar -xf -
 # arch specific ONIE install method
 install_onie "$@"
 
-echo "Rebooting..."
 cd /
-reboot

--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -2,7 +2,7 @@
 
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014 Matt Peterson <matt-github@peterson.org>
-#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -57,7 +57,7 @@ run_installer()
         tee_path=/dev/console
     fi
     { $onie_installer; echo "$?" > /var/run/install.rc; } 2>&1 | tee $tee_path | logger $log_stderr -t os-install -p ${syslog_onie}.info
-    [ "$(cat /var/run/install.rc)" = "0" ] && reboot && return 0
+    [ "$(cat /var/run/install.rc)" = "0" ] && echo "Rebooting..." && reboot && return 0
 
     # installer should not return
     return 1


### PR DESCRIPTION
The x86_64 demo installer did not display ``Rebooting...`` after
installing demo OS.  Moreover, the ``install.sh`` in ONIE updater
and powerpc demo installer have duplicate ``reboot`` command.  This
patch moves ``Rebooting...`` to ``exec_installer`` before excuting
``reboot``.

The ONIE updater and demo installer have been tested on Accton's
AS5712_54X (x86_64) and AS6710_32X (powerpc) platforms.