### PR TITLE
add '60_diag_chainload' to grub.d for generating diag chainload entry

### DIFF
--- a/demo/installer/x86_64/install.sh
+++ b/demo/installer/x86_64/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -272,17 +272,7 @@ EOF
 
 if [ "$demo_type" = "OS" ] ; then
     # If there is a diag image add a chainload entry for it.
-    diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
-    if [ -n "$diag_label" ] ; then
-        onie_platform="$(onie-sysinfo -p)"
-        cat <<EOF >> $grub_cfg
-menuentry '$diag_label $onie_platform' {
-        search --no-floppy --label --set=root $diag_label
-        echo    'Loading $diag_label $onie_platform ...'
-        chainloader +1
-}
-EOF
-    fi
+    /mnt/onie-boot/onie/grub.d/60_diag_chainload >> $grub_cfg
 fi
 
 # Add menu entries for ONIE -- use the grub fragment provided by the

--- a/installer/x86_64/grub.d/60_diag_chainload
+++ b/installer/x86_64/grub.d/60_diag_chainload
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# This file provides a GRUB menu entry for diag.
+#
+# Place this file in /etc/grub.d and grub-mkconfig will use this file
+# when generating a grub configuration file.
+
+# If there is a diag partition add a chainload entry to the host OS GRUB
+# configuration.  Everything sent to stdout will end up in the host OS
+# GRUB configuration.
+diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
+[ -z "$diag_label" ] && exit 0
+
+onie_platform="$(onie-sysinfo -p)"
+
+cat <<EOF
+menuentry '$diag_label $onie_platform' {
+        search --no-floppy --label --set=root $diag_label
+        echo    'Loading $diag_label $onie_platform ...'
+        chainloader +1
+}
+EOF

--- a/installer/x86_64/install-arch
+++ b/installer/x86_64/install-arch
@@ -1,7 +1,7 @@
 # x86_64 specific ONIE installer functions
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
 #
@@ -350,6 +350,7 @@ install_grub()
     export GRUB_CMDLINE_LINUX
 
     $boot_dir/onie/grub.d/50_onie_grub >> $grub_root_dir/grub.cfg
+    $boot_dir/onie/grub.d/60_diag_chainload >> $grub_root_dir/grub.cfg
 
 }
 

--- a/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
@@ -1,6 +1,7 @@
 # x86_64 specific uninstall routine
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -174,13 +175,7 @@ uninstall_system()
     diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
     if [ -n "$diag_label" ] &&
        [ -z "$(grep $diag_label $grub_root_dir/grub.cfg)" ] ; then
-        cat <<EOF >> $grub_root_dir/grub.cfg
-menuentry '$diag_label $onie_platform' {
-        search --no-floppy --label --set=root $diag_label
-        echo    'Loading $diag_label $onie_platform ...'
-        chainloader +1
-}
-EOF
+        $onie_boot_mnt/onie/grub.d/60_diag_chainload >> $grub_root_dir/grub.cfg
     fi
 
     # Return to install mode on the next boot


### PR DESCRIPTION
The diag chainload entry will disappear after doing the following
steps:

1. Run diag installer to install diag.
2. Enter ONIE uninstall mode to re-generate ONIE's ``grub.cfg``.
3. Run ONIE updater to upgrade ONIE on the box.

The patchset adds an extra script, ``60_diag_chainload``, to ``grub.d`` for generating diag chainload entry.  This script is used by demo OS installer, ONIE updater, and x86_64 ``uninstall-arch``.  NOS installer can call this script if it would like to keep hardware vendor's diag entry in NOS grub menu.

These patches have been tested on AS5712_54X platform.

I also update the trim list in ``demo.make`` to fix error message raised during demo OS rebooting.

Please help to review the patchset.  Thanks.