### PR TITLE
x86_64 install-arch: move 'onie_boot_dev' to proper place

### DIFF
--- a/installer/x86_64/install-arch
+++ b/installer/x86_64/install-arch
@@ -1,7 +1,7 @@
 # x86_64 specific ONIE installer functions
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
 #
@@ -398,6 +398,8 @@ install_onie()
 
     mkdir -p $onie_boot_mnt
 
+    onie_boot_dev="${onie_dev}$blk_suffix$onie_boot_part"
+
     # Preserve the grubenv file if it exists
     if mount -o defaults,rw -t $onie_boot_fs_type $onie_boot_dev $onie_boot_mnt > /dev/null 2>&1 ; then
         if [ -r $grub_env_file ] ; then
@@ -408,7 +410,6 @@ install_onie()
     fi
 
     # Create file system on ONIE-BOOT partition
-    onie_boot_dev="${onie_dev}$blk_suffix$onie_boot_part"
     [ "$verbose" = "yes" ] && echo "Creating $onie_boot_fs_type file system on: $onie_boot_dev"
     mkfs.$onie_boot_fs_type -q -L $onie_boot_label $onie_boot_dev || {
         echo "Error: Unable to create $onie_boot_fs_type file system on: $onie_boot_dev"


### PR DESCRIPTION
``onie_boot_dev`` is not defined before preserving ``grub_env``.
Move the statement of assigning ``onie_boot_dev`` to the place prior
to preserve ``grub_env``.