### PR TITLE
virtual machine: support multiple disk devices

### DIFF
--- a/rootconf/default/etc/init.d/makedev.sh
+++ b/rootconf/default/etc/init.d/makedev.sh
@@ -96,14 +96,19 @@ vdevs=$(ls -d /sys/block/vd[a-z] 2&> /dev/null) && {
     for d in $vdevs ; do
         dev=$(basename $d)
         major=$(sed -e 's/:.*$//' $d/dev)
+        minor=$(sed -e 's/^.*://' $d/dev)
         rm -f /dev/$dev
-        mknod /dev/$dev b $major 0 || {
+        mknod /dev/$dev b $major $minor || {
             log_failure_msg "Problems creating /dev/$dev block device."
             continue
         }
-        for minor in $(seq 8) ; do
-            rm -f /dev/${dev}$minor
-            mknod /dev/${dev}$minor b $major $minor || {
+        minor_start=$(( $minor + 1 ))
+        minor_end=$(( $minor + 15 ))
+        dev_idx=0
+        for minor_idx in $(seq $minor_start 1 $minor_end) ; do
+            dev_idx=$(( $dev_idx + 1 ))
+            rm -f /dev/${dev}$dev_idx
+            mknod /dev/${dev}$dev_idx b $major $minor_idx || {
                 log_failure_msg "Problems creating /dev/$dev block device."
                 continue
             }


### PR DESCRIPTION
Previously the ONIE boot process only created /dev device nodes for
the first virtual disk device.  Running the virtual machine with
multiple disk drives did not work properly as the minor numbers for
the /dev device nodes were wrong.

This patch fixes up that problem by reading the proper minor device
numbers from sysfs for the virtual block devices.

This was tested by using qemu to start a machine with multiple disk
drives.