### PR TITLE
grub: build GRUB2 i386-pc and x86_64-efi for target and host

### DIFF
--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -342,11 +342,11 @@ $(RECOVERY_ISO_STAMP): $(RECOVERY_INITRD_STAMP) $(RECOVERY_CONF_DIR)/grub-pxe.cf
 pxe-efi64: $(PXE_EFI64_STAMP)
 $(PXE_EFI64_STAMP): $(GRUB_HOST_INSTALL_STAMP) $(RECOVERY_ISO_STAMP) $(RECOVERY_CONF_DIR)/grub-embed.cfg
 	$(Q) echo "==== Create $(MACHINE_PREFIX) ONIE PXE EFI64 Recovery Image ===="
-	$(Q) cd $(GRUB_HOST_INSTALL_DIR)/usr/lib/grub/x86_64-efi && \
+	$(Q) cd $(GRUB_HOST_INSTALL_UEFI_DIR)/usr/lib/grub/x86_64-efi && \
 		ls *.mod|sed -e 's/\.mod//g'|egrep -v '(ehci|at_keyboard)' > $(PXE_EFI64_GRUB_MODS)
-	$(Q) $(GRUB_HOST_INSTALL_DIR)/usr/bin/grub-mkimage --format=x86_64-efi	\
+	$(Q) $(GRUB_HOST_INSTALL_UEFI_DIR)/usr/bin/grub-mkimage --format=x86_64-efi	\
 	    --config=$(RECOVERY_CONF_DIR)/grub-embed.cfg			\
-	    --directory=$(GRUB_HOST_INSTALL_DIR)/usr/lib/grub/x86_64-efi	\
+	    --directory=$(GRUB_HOST_INSTALL_UEFI_DIR)/usr/lib/grub/x86_64-efi	\
 	    --output=$(PXE_EFI64_IMAGE) --memdisk=$(RECOVERY_ISO_IMAGE)		\
 	    $$(cat $(PXE_EFI64_GRUB_MODS))
 	$(Q) touch $@


### PR DESCRIPTION
This patch updates the grub.make fragment to build GRUB2 for the
following scenarios:

- GRUB2 i386-pc for the target platform
- GRUB2 x86_64-efi for the target platform
- GRUB2 i386-pc for the build host
- GRUB2 x86_64-efi for the build host

The i386-pc and x86_64-efi are both built for the target platform in
order to support run time detection and installation of ONIE on either
legacy BIOS or UEFI firmware.  Having both sets of tools available
allows the ONIE installer to install the correct binaries at run time.

The i386-pc and x86_64-efi are both built for the build host in
order to support the creation of a single .ISO image that will work
with either legacy BIOS or UEFI firmware.