### PR TITLE
Debian Jessie requires libtool-bin package

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -373,7 +373,7 @@ machine-prefix:
 # Install required build packages for a x86_64 debian based build host
 DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools \
 				  gperf device-tree-compiler python-all-dev genisoimage \
-				  autoconf automake bison flex texinfo libtool \
+				  autoconf automake bison flex texinfo libtool libtool-bin \
 				  realpath gawk libncurses5 libncurses5-dev bc
 
 PHONY += debian-prepare-build-host


### PR DESCRIPTION
In Debian Jessie, *libtool* package (which used to include ```libtoolize``` and ```libtool``` along with aclocal macros) was broken up to have a separate package called libtool-bin which now contains ```libtool```.  This means in Jessie, we need to install both *libtool* and *libtool-bin* packages.

What's the best way to handle this as having *libtool-bin* in the required packages will cause an error during the *debian-prepare-build-host* target?