### PR TITLE
image download location

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -190,6 +190,7 @@ url_run()
             ;;
     esac
 
+    rm -f $onie_installer
     return 1
 }
 

--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -11,7 +11,7 @@
 
 . /etc/machine.conf
 
-export onie_installer="/installer"
+export onie_installer="/var/tmp/installer"
 
 ONIE_RUN_DIR="/var/run/onie"
 


### PR DESCRIPTION
When ONIE downloads an image (either ONIE update or NOS installer) the
image is stored as the file /installer.

The root directory is in the initramfs and as such does not have a
well defined maximum size.  See this article about the differences
between the size of the initramfs sysroot and a tmpfs:

  http://opensource.dyc.edu/ramdisk-vs-ramfs

Usually this is not a problem.  However, for large-ish NOS installer
images on systems with limited RAM the initramfs fills up.

This patch moves the down load location to /var/tmp/installer.
/var/tmp is a tmpfs that is sized to 50% of the available RAM by
default.  On a system with 1GB of RAM the size of /var/tmp is:

  ONIE:/ # df /var/tmp
  Filesystem           1K-blocks      Used Available Use% Mounted on
  tmpfs                   510972         0    510972   0% /var/tmp

Testing:

Exercised installing the DEMO OS using the KVM machine type.