### PR TITLE
networking.sh

### DIFF
--- a/build-config/make/demo.make
+++ b/build-config/make/demo.make
@@ -1,6 +1,7 @@
 #-------------------------------------------------------------------------------
 #
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -47,10 +48,13 @@ endif
 
 # List of files to remove from base ONIE image for the demo.
 DEMO_TRIM = \
+   etc/rc0.d/K25discover.sh	\
    etc/rc3.d/S50discover.sh	\
+   etc/rc6.d/K25discover.sh	\
    etc/init.d/discover.sh	\
    bin/discover			\
    bin/uninstaller		\
+   bin/onie-uninstaller		\
    lib/onie/udhcp4_sd		
 
 PHONY += demo-sysroot-complete

--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -166,11 +166,23 @@ config_ethmgmt()
 # When starting the network at boot time configure the MAC addresses
 # for all the Ethernet management interfaces.
 if [ "$1" = "start" ] ; then
-    # Configure Ethernet management MAC addresses
     intf_list=$(net_intf)
     intf_counter=0
 
-    # Set MAC addr for all interfaces, but leave the interfaces down.
+    # Detect for any i2c interface first, check it;s ready, delay at most 3 seconds.
+    var=1
+    for var in 1 2 3
+	do
+		i2c_result=`i2cdetect -l`
+		if [ "$i2c_result" != "" ]; then
+			break
+		fi
+		sleep 1
+        let vat=var+1
+	done
+    #
+
+    # Configure Ethernet management MAC addresses
     base_mac=$(onie-sysinfo -e)
     for intf in $intf_list ; do
         new_mac="$(mac_add $base_mac $intf_counter)"


### PR DESCRIPTION
Modify networking.sh
Detect i2c before onie-sysinfo -e.
It can not get any TLV informations from EEPROM if i2c interface is not ready.
In my system, I'm sure i2c is not ready when networking.sh is running.
Maybe my own built-in r/w EEPROM driver is noot ready at that time.
But it works if I sleep 1 seconds before access EEPROM.
I don't know is there anyone have same issue with me.
Should I maintain this code which I added in my local side?
