### PR TITLE
x86: add flashrom support

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -325,6 +325,10 @@ endif
 ifeq ($(KEXEC_ENABLE),yes)
   include make/kexec-tools.make
 endif
+ifeq ($(FLASHROM_ENABLE),yes)
+  include make/pciutils.make
+  include make/flashrom.make
+endif
 include make/images.make
 include make/demo.make
 

--- a/build-config/arch/x86_64.make
+++ b/build-config/arch/x86_64.make
@@ -139,6 +139,9 @@ DOSFSTOOLS_ENABLE = yes
 # Include kexec-tools
 KEXEC_ENABLE = yes
 
+# Include flashrom
+FLASHROM_ENABLE = yes
+
 # Update this if the GRUB configuration mechanism changes from one
 # release to the next.
 ONIE_CONFIG_VERSION = 1

--- a/build-config/make/flashrom.make
+++ b/build-config/make/flashrom.make
@@ -1,0 +1,111 @@
+#-------------------------------------------------------------------------------
+#
+#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+#
+#-------------------------------------------------------------------------------
+#
+# This is a makefile fragment that defines the build of flashrom
+#
+
+FLASHROM_VERSION		= 0.9.8
+FLASHROM_TARBALL		= flashrom-$(FLASHROM_VERSION).tar.bz2
+FLASHROM_TARBALL_URLS		+= $(ONIE_MIRROR) http://download.flashrom.org/releases/
+FLASHROM_BUILD_DIR		= $(MBUILDDIR)/flashrom
+FLASHROM_DIR			= $(FLASHROM_BUILD_DIR)/flashrom-$(FLASHROM_VERSION)
+
+FLASHROM_SRCPATCHDIR		= $(PATCHDIR)/flashrom
+FLASHROM_DOWNLOAD_STAMP		= $(DOWNLOADDIR)/flashrom-download
+FLASHROM_SOURCE_STAMP		= $(STAMPDIR)/flashrom-source
+FLASHROM_PATCH_STAMP		= $(STAMPDIR)/flashrom-patch
+FLASHROM_BUILD_STAMP		= $(STAMPDIR)/flashrom-build
+FLASHROM_INSTALL_STAMP		= $(STAMPDIR)/flashrom-install
+FLASHROM_STAMP			= $(FLASHROM_SOURCE_STAMP) \
+				  $(FLASHROM_PATCH_STAMP) \
+				  $(FLASHROM_BUILD_STAMP) \
+				  $(FLASHROM_INSTALL_STAMP)
+
+FLASHROM_PROGRAMS		= flashrom
+
+PHONY += flashrom flashrom-download flashrom-source flashrom-build \
+	 flashrom-install flashrom-clean flashrom-download-clean
+
+flashrom: $(FLASHROM_STAMP)
+
+DOWNLOAD += $(FLASHROM_DOWNLOAD_STAMP)
+flashrom-download: $(FLASHROM_DOWNLOAD_STAMP)
+$(FLASHROM_DOWNLOAD_STAMP): $(PROJECT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Getting upstream flashrom ===="
+	$(Q) $(SCRIPTDIR)/fetch-package $(DOWNLOADDIR) $(UPSTREAMDIR) \
+		$(FLASHROM_TARBALL) $(FLASHROM_TARBALL_URLS)
+	$(Q) touch $@
+
+SOURCE += $(FLASHROM_SOURCE_STAMP)
+flashrom-source: $(FLASHROM_SOURCE_STAMP)
+$(FLASHROM_SOURCE_STAMP): $(TREE_STAMP) $(FLASHROM_DOWNLOAD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Extracting upstream flashrom ===="
+	$(Q) $(SCRIPTDIR)/extract-package $(FLASHROM_BUILD_DIR) $(DOWNLOADDIR)/$(FLASHROM_TARBALL)
+	$(Q) touch $@
+
+# Disable all flashrom methods, except for 'internal' by default.
+# Individual platforms can define FLASHROM_MAKE_CONFIG_PLATFORM to
+# enable support for specific flashing methods, for example:
+#
+#   FLASHROM_MAKE_CONFIG_PLATFORM = CONFIG_XYZ=yes
+#
+# See the Makefile in the flashrom source directory for the complete
+# list of CONFIG_XYZ variables.
+#
+# Note: Leaving the Intel NIC EEPROMs enabled, as that could be useful
+# in manufacturing to program the MAC address for eth0.
+FLASHROM_MAKE_CONFIG = \
+	CC=$(CROSSPREFIX)gcc CFLAGS="-Wall -Wshadow $(ONIE_CFLAGS)" \
+	LDFLAGS="$(ONIE_LDFLAGS)" \
+	PREFIX=/usr DESTDIR=$(DEV_SYSROOT) \
+	CONFIG_SERPROG=no CONFIG_RAYER_SPI=no CONFIG_PONY_SPI=no \
+	CONFIG_NIC3COM=no CONFIG_GFXNVIDIA=no CONFIG_SATASII=no \
+	CONFIG_ATAHPT=no CONFIG_ATAVIA=no CONFIG_FT2232_SPI=no \
+	CONFIG_USBBLASTER_SPI=no CONFIG_MSTARDDC_SPI=no CONFIG_PICKIT2_SPI=no \
+	CONFIG_DRKAISER=no CONFIG_NICREALTEK=no CONFIG_NICNATSEMI=no \
+	CONFIG_OGP_SPI=no CONFIG_BUSPIRATE_SPI=no CONFIG_DEDIPROG=no \
+	CONFIG_SATAMV=no CONFIG_IT8212=no CONFIG_PRINT_WIKI=no \
+	$(FLASHROM_MAKE_CONFIG_PLATFORM)
+
+flashrom-build: $(FLASHROM_BUILD_STAMP)
+$(FLASHROM_BUILD_STAMP): $(FLASHROM_SOURCE_STAMP) $(PCIUTILS_INSTALL_STAMP) \
+				| $(DEV_SYSROOT_INIT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "====  Building flashrom-$(FLASHROM_VERSION) ===="
+	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(FLASHROM_DIR) \
+		$(FLASHROM_MAKE_CONFIG) all
+	$(Q) touch $@
+
+flashrom-install: $(FLASHROM_INSTALL_STAMP)
+$(FLASHROM_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(FLASHROM_BUILD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Installing flashrom programs in $(SYSROOTDIR) ===="
+	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(FLASHROM_DIR) \
+		$(FLASHROM_MAKE_CONFIG) install
+	$(Q) for file in $(FLASHROM_PROGRAMS); do \
+		cp -av $(DEV_SYSROOT)/usr/sbin/$$file $(SYSROOTDIR)/usr/sbin ; \
+	     done
+	$(Q) touch $@
+
+USERSPACE_CLEAN += flashrom-clean
+flashrom-clean:
+	$(Q) rm -rf $(FLASHROM_BUILD_DIR)
+	$(Q) rm -f $(FLASHROM_STAMP)
+	$(Q) echo "=== Finished making $@ for $(PLATFORM)"
+
+DOWNLOAD_CLEAN += flashrom-download-clean
+flashrom-download-clean:
+	$(Q) rm -f $(FLASHROM_DOWNLOAD_STAMP) $(DOWNLOADDIR)/$(FLASHROM_TARBALL)
+
+#-------------------------------------------------------------------------------
+#
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -83,6 +83,10 @@ ifeq ($(KEXEC_ENABLE),yes)
   PACKAGES_INSTALL_STAMPS += $(KEXEC_INSTALL_STAMP)
 endif
 
+ifeq ($(FLASHROM_ENABLE),yes)
+  PACKAGES_INSTALL_STAMPS += $(FLASHROM_INSTALL_STAMP)
+endif
+
 ifndef MAKE_CLEAN
 SYSROOT_NEW_FILES = $(shell \
 			test -d $(ROOTCONFDIR)/default && \
@@ -145,7 +149,7 @@ endif
 
 # sysroot-check does the following:
 #
-# - strip the ELF binaries (grub moduels and kernel)
+# - strip the ELF binaries (grub modules and kernel)
 #
 # - verifies that we have all the shared libraries required by the
 #   executables in our final sysroot.

--- a/build-config/make/pciutils.make
+++ b/build-config/make/pciutils.make
@@ -1,0 +1,101 @@
+#-------------------------------------------------------------------------------
+#
+#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+#
+#-------------------------------------------------------------------------------
+#
+# This is a makefile fragment that defines the build of pciutils
+#
+
+PCIUTILS_VERSION		= 3.2.1
+PCIUTILS_TARBALL		= pciutils-$(PCIUTILS_VERSION).tar.xz
+PCIUTILS_TARBALL_URLS		+= $(ONIE_MIRROR) https://www.kernel.org/pub/software/utils/pciutils
+PCIUTILS_BUILD_DIR		= $(MBUILDDIR)/pciutils
+PCIUTILS_DIR			= $(PCIUTILS_BUILD_DIR)/pciutils-$(PCIUTILS_VERSION)
+
+PCIUTILS_SRCPATCHDIR		= $(PATCHDIR)/pciutils
+PCIUTILS_DOWNLOAD_STAMP		= $(DOWNLOADDIR)/pciutils-download
+PCIUTILS_SOURCE_STAMP		= $(STAMPDIR)/pciutils-source
+PCIUTILS_PATCH_STAMP		= $(STAMPDIR)/pciutils-patch
+PCIUTILS_BUILD_STAMP		= $(STAMPDIR)/pciutils-build
+PCIUTILS_INSTALL_STAMP		= $(STAMPDIR)/pciutils-install
+PCIUTILS_STAMP			= $(PCIUTILS_SOURCE_STAMP) \
+				  $(PCIUTILS_PATCH_STAMP) \
+				  $(PCIUTILS_BUILD_STAMP) \
+				  $(PCIUTILS_INSTALL_STAMP)
+
+PCIUTILS_PROGRAMS		= pciutils
+
+PHONY += pciutils pciutils-download pciutils-source pciutils-patch \
+	pciutils-build pciutils-install pciutils-clean pciutils-download-clean
+
+PCIUTILS_LIBS = libpci.so libpci.so.3 libpci.so.$(PCIUTILS_VERSION)
+
+pciutils: $(PCIUTILS_STAMP)
+
+DOWNLOAD += $(PCIUTILS_DOWNLOAD_STAMP)
+pciutils-download: $(PCIUTILS_DOWNLOAD_STAMP)
+$(PCIUTILS_DOWNLOAD_STAMP): $(PROJECT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Getting upstream pciutils ===="
+	$(Q) $(SCRIPTDIR)/fetch-package $(DOWNLOADDIR) $(UPSTREAMDIR) \
+		$(PCIUTILS_TARBALL) $(PCIUTILS_TARBALL_URLS)
+	$(Q) touch $@
+
+SOURCE += $(PCIUTILS_SOURCE_STAMP)
+pciutils-source: $(PCIUTILS_SOURCE_STAMP)
+$(PCIUTILS_SOURCE_STAMP): $(TREE_STAMP) | $(PCIUTILS_DOWNLOAD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Extracting upstream pciutils ===="
+	$(Q) $(SCRIPTDIR)/extract-package $(PCIUTILS_BUILD_DIR) $(DOWNLOADDIR)/$(PCIUTILS_TARBALL)
+	$(Q) touch $@
+
+pciutils-patch: $(PCIUTILS_PATCH_STAMP)
+$(PCIUTILS_PATCH_STAMP): $(PCIUTILS_SRCPATCHDIR)/* $(PCIUTILS_SOURCE_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Patching pciutils ===="
+	$(Q) $(SCRIPTDIR)/apply-patch-series $(PCIUTILS_SRCPATCHDIR)/series $(PCIUTILS_DIR)
+	$(Q) touch $@
+
+ifndef MAKE_CLEAN
+PCIUTILS_NEW_FILES = $(shell test -d $(PCIUTILS_DIR) && test -f $(PCIUTILS_BUILD_STAMP) && \
+	              find -L $(PCIUTILS_DIR) -newer $(PCIUTILS_BUILD_STAMP) -type f -print -quit)
+endif
+
+pciutils-build: $(PCIUTILS_BUILD_STAMP)
+$(PCIUTILS_BUILD_STAMP): $(PCIUTILS_PATCH_STAMP) $(PCIUTILS_NEW_FILES) $(ZLIB_INSTALL_STAMP) \
+				| $(DEV_SYSROOT_INIT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "====  Building pciutils-$(PCIUTILS_VERSION) ===="
+	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(PCIUTILS_DIR) lib/libpci.so.$(PCIUTILS_VERSION) CROSS_COMPILE=$(CROSSPREFIX) \
+		HOST=onie-$(ARCH)-linux ZLIB=yes DNS=no SHARED=yes LIBKMOD=no PREFIX=/usr DESTDIR=$(DEV_SYSROOT)
+	$(Q) touch $@
+
+pciutils-install: $(PCIUTILS_INSTALL_STAMP)
+$(PCIUTILS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(PCIUTILS_BUILD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Installing pciutils in $(DEV_SYSROOT) ===="
+	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(PCIUTILS_DIR) install-lib CROSS_COMPILE=$(CROSSPREFIX) \
+		HOST=onie-$(ARCH)-linux ZLIB=yes DNS=no SHARED=yes LIBKMOD=no PREFIX=/usr DESTDIR=$(DEV_SYSROOT)
+	$(Q) for file in $(PCIUTILS_LIBS); do \
+		cp -av $(DEV_SYSROOT)/usr/lib/$$file $(SYSROOTDIR)/usr/lib/ ; \
+	     done
+	$(Q) touch $@
+
+USERSPACE_CLEAN += pciutils-clean
+pciutils-clean:
+	$(Q) rm -rf $(PCIUTILS_BUILD_DIR)
+	$(Q) rm -f $(PCIUTILS_STAMP)
+	$(Q) echo "=== Finished making $@ for $(PLATFORM)"
+
+DOWNLOAD_CLEAN += pciutils-download-clean
+pciutils-download-clean:
+	$(Q) rm -f $(PCIUTILS_DOWNLOAD_STAMP) $(DOWNLOADDIR)/$(PCIUTILS_TARBALL)
+
+#-------------------------------------------------------------------------------
+#
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/upstream/flashrom-0.9.8.tar.bz2.sha1
+++ b/upstream/flashrom-0.9.8.tar.bz2.sha1
@@ -1,0 +1,1 @@
+099de8c0939b6828be3dc75a073582ebb4bab92e  flashrom-0.9.8.tar.bz2

--- a/upstream/pciutils-3.2.1.tar.xz.sha1
+++ b/upstream/pciutils-3.2.1.tar.xz.sha1
@@ -1,0 +1,1 @@
+2009c441bfb78811c2991bde03b88c043654c195  pciutils-3.2.1.tar.xz


### PR DESCRIPTION
This patch adds the 'flashrom' utility and pciutils library to the
ONIE initramfs for x86 builds.  This tool is *very* handy on x86
systems for updating the BIOS firmware.

Adding the utility and library increases the size of the kvm_x86_64
image by ~100,000 bytes.

By default most flashrom methods except for 'internal' and Intel NIC
EEPROMs are disabled from the build.  Individual platforms can define
FLASHROM_MAKE_CONFIG_PLATFORM to enable support for specific flashing
methods, for example:

  FLASHROM_MAKE_CONFIG_PLATFORM = CONFIG_XYZ=yes

See the Makefile in the flashrom source directory for the complete
list of CONFIG_XYZ variables.

Note: Leaving the Intel NIC EEPROMs enabled, as that could be useful
in manufacturing to program the MAC address for eth0.