### PR TITLE
image discovery waterfall: add well known server name

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013-2015 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014 Matt Peterson <matt-github@peterson.org>
 #  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
 #
@@ -198,7 +198,7 @@ url_run()
 http_download()
 {
     # Build list of HTTP servers to try
-    http_servers=
+    http_servers="$onie_server_name"
 
     # HTTP server IP only
     if [ -n "$onie_disco_wwwsrv" ] ; then
@@ -299,7 +299,7 @@ waterfall()
     wf_paths="$wf_paths $onie_default_filenames"
 
     # TFTP waterfall
-    tftp_servers="$onie_disco_siaddr $onie_disco_tftp $onie_disco_tftpsiaddr"
+    tftp_servers="$onie_server_name $onie_disco_siaddr $onie_disco_tftp $onie_disco_tftpsiaddr"
     for s in $tftp_servers ; do
         for p in $wf_paths ; do
             url_run "tftp://$s/$p" && return 0

--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -1,7 +1,7 @@
 ##
 ## Useful functions and variables for boot time.
 
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -34,6 +34,9 @@ ${filename_prefix}-${onie_machine}
 ${filename_prefix}-${onie_arch}
 ${filename_prefix}
 "
+
+# Default ONIE server name
+onie_server_name="onie-server"
 
 syslog_onie="local0"
 syslog_tag="onie"


### PR DESCRIPTION
This patch adds a "well known" hostname to the list of servers used
during the image discovery waterfall process.  The default ONIE server
name is "onie-server".

This server name is added to the list of servers used during the HTTP
waterfall and TFTP waterfall.

Fixes #203

Quoting the issue:

  This gives flexibility in deployments where the users have control
  over the DNS server, but not over the DHCP server.

  For example a user could set their laptop to the host name
  "onie-server" when making a DHCP request -- as is common in simple
  lab environments and home routers, the host name "onie-server" will
  be added to the local DNS domain. Then the user can start up a
  simple python based ONIE server on the laptop and ONIE will find the
  image via the host name "onie-server".

Testing Done:

Tested both the HTTP and TFTP waterfalls using the fsl_p2020rdbpca
(powerpc) reference platform.

1. The demo OS installer image was placed at the root of an HTTP
server, whose hostname was "onie-server", using one of the default OS
installer image names.  The HTTP image discovery process correctly
located, downloaded and installed the image.

2. The demo OS installer image was placed at the root of an TFTP
server, whose hostname was "onie-server", using one of the default OS
installer image names.  The TFTP image discovery process correctly
located, downloaded and installed the image.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>