### PR TITLE
x86: Add an onie-tool command to show ONIE version information

### DIFF
--- a/build-config/scripts/onie-mk-tools.sh
+++ b/build-config/scripts/onie-mk-tools.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+#
+# Script to create a tarball of "ONIE tools", which are made available
+# to the NOS.
+#
+
+arch=$1
+tools_dir=$2
+output_file=$3
+sysroot=$4
+
+shift 4
+
+# The tools originate from two locations:
+#
+# 1. Some CPU architecture independent tools are from the $sysroot of
+#    the ONIE installer image directly.  These tools are unmodified
+#    copies of what is in the ONIE runtime image.
+#
+# 2. CPU dependent tools are from an architecture specific directory
+#    located within the ONIE repo $tools_dir.  These tools are *not*
+#    present in the ONIE runtime image.
+
+[ -d "${tools_dir}/${arch}" ] || {
+    echo "ERROR: arch tools directory '${tools_dir}/${arch}' does not exist."
+    exit 1
+}
+
+touch $output_file || {
+    echo "ERROR: unable to create output file: $output_file"
+    exit 1
+}
+rm -f $output_file
+
+[ -d "$sysroot" ] || {
+    echo "ERROR: sysroot directory '$sysroot' does not exist."
+    exit 1
+}
+
+[ $# -gt 0 ] || {
+    echo "Error: No ONIE sysroot tool files found"
+    exit 1
+}
+
+tmp_dir=
+clean_up()
+{
+    rm -rf $tmp_dir
+}
+
+trap clean_up EXIT
+
+# make the tools tarball
+# contents:
+#   - /bin  -- shell scripts
+#   - /lib  -- shell script fragments
+
+echo -n "Building ONIE tools archive ."
+tmp_dir=$(mktemp --directory)
+cp -a "${tools_dir}/${arch}"/* $tmp_dir
+echo -n "."
+for f in $* ; do
+    tdir="${tmp_dir}/$(dirname $f)"
+    mkdir -p $tdir || exit 1
+    cp -a "${sysroot}/$f" $tdir || exit 1
+    echo -n "."
+done
+
+# Bundle data into a tar file
+tar -C $tmp_dir -cJf $output_file $(ls $tmp_dir) || exit 1
+echo -n "."
+
+rm -rf $tmp_dir
+echo " Done."
+
+echo "Success:  ONIE tools tar archive is ready: ${output_file}"

--- a/tools/x86_64/bin/onie-version
+++ b/tools/x86_64/bin/onie-version
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#
+# SPDX-License-Identifier:     GPL-2.0
+
+# This script is part of the onie-tools package, intended for use by a
+# NOS to display information about the ONIE environment.  The script
+# leverages the ONIE build information from the grub-machine.cfg file.
+
+grub_dir="$(dirname $(realpath $0))/../../grub"
+
+grub_machine_cfg="${grub_dir}/grub-machine.cfg"
+
+if [ -r "$grub_machine_cfg" ] ; then
+    . "$grub_machine_cfg"
+    grep = $grub_machine_cfg | sed -e 's/onie_//' -e 's/=.*$//' | while read var ; do
+        eval val='$'onie_$var
+        printf "%-20s: %s\n" "ONIE ${var}" "$val"
+    done
+else
+    echo "Warning: ONIE version information not available" > /dev/stderr
+fi


### PR DESCRIPTION
Closes #161

On x86 the /mnt/onie-boot/onie/tools directory houses scripts (and
script fragments) usable by an installed NOS to interact with ONIE.

This patch adds the following:

- moves the onie-tool tarball creation logic from the images.make
  Makefile fragment into a helper script, called by images.make.

- adds a new tool, onie-version, for displaying ONIE version
  information from the NOS.

To use the ONIE tools a NOS is expected to:

- mount the ONIE-BOOT partition somewhere, e.g.

   tmpdir=$(mktemp -d)
   mount LABEL=ONIE-BOOT $tmpdir

- run the scripts in (ONIE-BOOT)/onie/tools/bin


Testing:

Exercised the new tool using the kvm_x86_64 machine and the demo NOS.