### PR TITLE
Update OCE for image discovery waterfall: use RFC-3927 link-local IPv4 address #222

### DIFF
--- a/contrib/oce/config/onie-tests.json
+++ b/contrib/oce/config/onie-tests.json
@@ -92,6 +92,16 @@
         "76": {"name":"Uninstall from NOS","required-services":["hands"],"action":"uninstaller"},
         "77": {"name":"Rescue from UBoot","required-services":["hands"],"action":"rescuer"},
         "78": {"name":"Rescue from ONIE","required-services":["hands"],"action":"rescuer"},
-        "79": {"name":"Rescue from NOS","required-services":["hands"],"action":"rescuer"}
+        "79": {"name":"Rescue from NOS","required-services":["hands"],"action":"rescuer"},
+        "90": {"name":"ONIE - IPv4 RFC 3927 - Name 1","required-services":["http"],"action":"installer"},
+        "91": {"name":"ONIE - IPv4 RFC 3927 - Name 2","required-services":["http"],"action":"installer"},
+        "92": {"name":"ONIE - IPv4 RFC 3927 - Name 3","required-services":["http"],"action":"installer"},
+        "93": {"name":"ONIE - IPv4 RFC 3927 - Name 4","required-services":["http"],"action":"installer"},
+        "94": {"name":"ONIE - IPv4 RFC 3927 - Name 5","required-services":["http"],"action":"installer"},
+        "105": {"name":"ONIE Update - IPv4 RFC 3927 - Name 1","required-services":["http"],"action":"updater"},
+        "106": {"name":"ONIE Update - IPv4 RFC 3927 - Name 2","required-services":["http"],"action":"updater"},
+        "107": {"name":"ONIE Update - IPv4 RFC 3927 - Name 3","required-services":["http"],"action":"updater"},
+        "108": {"name":"ONIE Update - IPv4 RFC 3927 - Name 4","required-services":["http"],"action":"updater"},
+        "109": {"name":"ONIE Update - IPv4 RFC 3927 - Name 5","required-services":["http"],"action":"updater"}
     }
 }


### PR DESCRIPTION
Per #222, update OCE to properly test these newly added test cases.
