### PR TITLE
Firmware update

### DIFF
--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -28,7 +28,8 @@ UPDATER_IMAGE		= $(IMAGEDIR)/onie-updater-$(ARCH)-$(MACHINE_PREFIX)
 ONIE_TOOLS_DIR	= $(abspath ../tools)
 ONIE_SYSROOT_TOOLS_LIST = \
 	lib/onie \
-	bin/onie-boot-mode
+	bin/onie-boot-mode \
+	bin/onie-fwpkg
 
 IMAGE_BIN_STAMP		= $(STAMPDIR)/image-bin
 IMAGE_UPDATER_STAMP	= $(STAMPDIR)/image-updater

--- a/demo/os/x86_64/bin/fwpkg
+++ b/demo/os/x86_64/bin/fwpkg
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# This script is just a simple wrapper around 'onie-fwpkg' from the
+# onie-tools package.
+
+# "Rebrand" the output of the ONIE tool program to match the name of
+# this script.
+
+export ONIE_FWPKG_PROGRAM_NAME=$(basename $(realpath $0))
+/mnt/onie-boot/onie/tools/bin/onie-fwpkg "$@"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -36,7 +36,7 @@ true ${onie_machine_rev=0}
 # assume it is 0.
 true ${onie_config_version=0}
 
-args="hvfx${args_arch}"
+args="hivfqx${args_arch}"
 
 usage()
 {
@@ -51,8 +51,14 @@ COMMAND LINE OPTIONS
 	-v
 		Be verbose.  Print what is happening.
 
+	-q
+		Be quiet.  Do not print what is happening.
+
 	-x
 		Extract image to a temporary directory.
+
+	-i
+		Dump image information.
 
 	-f
 		Force ONIE update opteration, bypassing any safety
@@ -64,6 +70,7 @@ EOF
 
 verbose=no
 force=no
+quiet=no
 while getopts "$args" a ; do
     case $a in
         h)
@@ -73,9 +80,19 @@ while getopts "$args" a ; do
         v)
             verbose=yes
             cmd_verbose=-v
+            quiet=no
             ;;
         f)
             force=yes
+            ;;
+        q)
+            quiet=yes
+            verbose=no
+            ;;
+        i)
+            # Dump the image information
+            cat ./machine.conf
+            exit 0
             ;;
         *)
             parse_arg_arch "$a" "$OPTARG" || {
@@ -118,11 +135,11 @@ fi
     exit 1
 }
 
-echo "ONIE: Version       : $image_version"
-echo "ONIE: Architecture  : $image_arch"
-echo "ONIE: Machine       : $image_machine"
-echo "ONIE: Machine Rev   : $image_machine_rev"
-echo "ONIE: Config Version: $image_config_version"
+[ "$quiet" = "no" ] && echo "ONIE: Version       : $image_version"
+[ "$quiet" = "no" ] && echo "ONIE: Architecture  : $image_arch"
+[ "$quiet" = "no" ] && echo "ONIE: Machine       : $image_machine"
+[ "$quiet" = "no" ] && echo "ONIE: Machine Rev   : $image_machine_rev"
+[ "$quiet" = "no" ] && echo "ONIE: Config Version: $image_config_version"
 
 xz -d -c onie-update.tar.xz | tar -xf -
 

--- a/installer/sharch_body.sh
+++ b/installer/sharch_body.sh
@@ -14,7 +14,23 @@
 ## Strings of the form %%VAR%% are replaced during construction.
 ##
 
-echo -n "Verifying image checksum ..."
+extract=no
+quiet=no
+args=":xq"
+while getopts "$args" a ; do
+    case $a in
+        x)
+            extract=yes
+            ;;
+        q)
+            quiet=yes
+            ;;
+        *)
+        ;;
+    esac
+done
+
+[ "$quiet" = "no" ] && echo -n "Verifying image checksum ..."
 sha1=$(sed -e '1,/^exit_marker$/d' "$0" | sha1sum | awk '{ print $1 }')
 
 payload_sha1=%%IMAGE_SHA1%%
@@ -27,7 +43,7 @@ if [ "$sha1" != "$payload_sha1" ] ; then
     exit 1
 fi
 
-echo " OK."
+[ "$quiet" = "no" ] && echo " OK."
 
 tmp_dir=
 clean_up() {
@@ -46,22 +62,10 @@ if [ "$(id -u)" = "0" ] ; then
     mount -t tmpfs tmpfs-installer $tmp_dir || clean_up 1
 fi
 cd $tmp_dir
-echo -n "Preparing image archive ..."
+[ "$quiet" = "no" ] && echo -n "Preparing image archive ..."
 sed -e '1,/^exit_marker$/d' $archive_path | tar xf - || clean_up 1
-echo " OK."
+[ "$quiet" = "no" ] && echo " OK."
 cd $cur_wd
-
-extract=no
-args=":x"
-while getopts "$args" a ; do
-    case $a in
-        x)
-            extract=yes
-            ;;
-        *)
-        ;;
-    esac
-done
 
 if [ "$extract" = "yes" ] ; then
     # stop here

--- a/installer/x86_64/install-arch
+++ b/installer/x86_64/install-arch
@@ -616,11 +616,15 @@ install_onie()
 
     onie_boot_dev="${onie_dev}$blk_suffix$onie_boot_part"
 
-    # Preserve the grubenv file if it exists
+    # Preserve a few precious files if they exist
     if mount -o defaults,rw -t $onie_boot_fs_type $onie_boot_dev $onie_boot_mnt > /dev/null 2>&1 ; then
         if [ -r $grub_env_file ] ; then
             preserve_grubenv=yes
             cp $grub_env_file /tmp/grubenv
+        fi
+        if [ -d $onie_update_dir ] ; then
+            preserve_update_dir=yes
+            cp -a $onie_update_dir /tmp/preserve-update
         fi
         umount $onie_boot_mnt > /dev/null 2>&1
     fi
@@ -684,14 +688,14 @@ install_onie()
         cp /tmp/grubenv $grub_env_file
     fi
 
+    # Restore the previous update directory
+    if [ "$preserve_update_dir" = "yes" ] ; then
+        cp -a /tmp/preserve-update $onie_update_dir
+    fi
+
     # Return to default boot mode on the next boot.  Use this
     # installer's version of onie-boot-mode.
     $onie_root_dir/tools/bin/onie-boot-mode -q -o none
-
-    umount $onie_boot_mnt || {
-        echo "Error: Unable to umount ${onie_boot_mnt}"
-        exit 1
-    }
 
     if [ -n "$post_install_hook" ]; then
         eval $post_install_hook || {

--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -9,30 +9,60 @@
 . /lib/onie/functions
 syslog_tag=onie-exec
 
+install_result="/var/run/install.rc"
+
+# If the NOS install returns success then reboot.
+finish_nos_install()
+{
+    local result="$1"
+    local URL="$2"
+    local update_image="$3"
+
+    if [ $result -eq 0 ] ; then
+        log_console_msg "NOS install successful: $URL"
+        log_console_msg "Rebooting..."
+        reboot && return 0
+    fi
+    return 1
+}
+
+finish_update_install()
+{
+    local result="$1"
+    local URL="$2"
+    local update_image="$3"
+
+    if [ $result -eq 0 ] ; then
+        log_console_msg "Firmware update install successful: $URL"
+        log_console_msg "Rebooting..."
+        reboot && return 0
+    fi
+    return 1
+}
+
+# Allow architectures to override finish_nos_install() and
+# finish_update_install().
+[ -r /lib/onie/exec-installer-arch ] && . /lib/onie/exec-installer-arch
+
 check_installer()
 {
-    [ -r $onie_installer ] || {
-        log_failure_msg "Unable to find installer: $onie_installer"
-        return 1
-    }
-
-    # Check whether image passed by 'install_url', 'update_url', or 'discover'
-    # whose format matches to boot reason or not.
-    is_updater=$(if grep -q ONIE-UPDATER-COOKIE $onie_installer ; then \
-        echo "yes" ; else echo "no" ; fi)
+    # Check whether the image type passed by 'onie-nos-install',
+    # 'onie-self-update' or 'discover' is compatible with the current
+    # boot reason.
+    local image_type="$1"
 
     case $onie_boot_reason in
         update | embed)
-            [ "$is_updater" = "yes" ] && return 0
-            log_failure_msg "ONIE Updater: Invalid ONIE update image format."
+            [ "$image_type" = "$onie_image_type_update" ] && return 0
+            log_failure_msg "ONIE Update: Invalid ONIE update image format."
             ;;
         rescue)
             # Allow to run either NOS installer or ONIE updater at the situation
             return 0
             ;;
         install)
-            [ "$is_updater" = "no" ] && return 0
-            log_failure_msg "NOS Installer: Expecting install image, but found ONIE updater image format."
+            [ "$image_type" = "$onie_image_type_nos" ] && return 0
+            log_failure_msg "NOS Installer: Expecting install image, but found ONIE update image format."
             ;;
         *)
             log_failure_msg "Unknown boot reason: ${onie_boot_reason}"
@@ -48,7 +78,14 @@ run_installer()
     # escape any % characters for printing with printf
     print_exec_url=$(echo -n $onie_exec_url | sed -e 's/%/%%/g')
     log_console_msg "Executing installer: $print_exec_url"
-    check_installer || return 1
+
+    [ -r $onie_installer ] || {
+        log_failure_msg "Unable to find installer: $onie_installer"
+        return 1
+    }
+
+    image_type=$(get_image_type $onie_installer)
+    check_installer $image_type || return 1
 
     chmod +x $onie_installer
     # Send installer execution output to stdout or /dev/console
@@ -56,10 +93,22 @@ run_installer()
     if [ "$tee_path" = "/dev/null" ] || [ -z "$tee_path" ] ; then
         tee_path=/dev/console
     fi
-    { $onie_installer; echo "$?" > /var/run/install.rc; } 2>&1 | tee $tee_path | logger $log_stderr -t os-install -p ${syslog_onie}.info
-    [ "$(cat /var/run/install.rc)" = "0" ] && echo "Rebooting..." && reboot && return 0
+    { $onie_installer; echo "$?" > $install_result; } 2>&1 | tee $tee_path | logger $log_stderr -t os-install -p ${syslog_onie}.info
+
+    case $image_type in
+        "$onie_image_type_nos")
+            finish_nos_install "$(cat $install_result)" "$onie_exec_url" "$onie_installer" && return 0
+            ;;
+        "$onie_image_type_update")
+            finish_update_install "$(cat $install_result)" "$onie_exec_url" "$onie_installer" && return 0
+            ;;
+        *)
+            log_failure_msg "Unexpected image type: $image_type"
+            ;;
+    esac
 
     # installer should not return
+    log_failure_msg "Unable to install image: $print_exec_url"
     return 1
 }
 
@@ -351,6 +400,27 @@ local_fs_run()
     return 1
 }
 
+firmware_update_run()
+{
+    local fw_rc=1
+    for image in $(ls $onie_update_pending_dir) ; do
+        if url_run "$onie_update_pending_dir/$image" ; then
+            fw_rc=0
+        else
+            fw_rc=1
+            break
+        fi
+    done
+
+    if [ $fw_rc -eq 0 ] ; then
+        # Firmware update(s) found and processed.
+        log_console_msg "Rebooting..."
+        reboot && return 0
+    fi
+    
+    return 1
+}
+
 ##
 ## Script starts here
 ##
@@ -391,9 +461,14 @@ if [ -n "$onie_cli_static_update_url" ] ; then
     exit 1
 fi
 
-# Next try static URL from u-boot
+# Next try static URL from kernel command line
 if [ -n "$onie_static_url" ] ; then
     url_run "$onie_static_url" && exit 0
+fi
+
+# Next look for pending firmware updates
+if [ -d "$onie_update_pending_dir" ] ; then
+    firmware_update_run && exit 0
 fi
 
 # Next try locally attached filesystems

--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -9,7 +9,7 @@
 ## This assumes the shell is ash/dash.
 ##
 
-. /etc/machine.conf
+[ -r /etc/machine.conf ] && . /etc/machine.conf
 
 export onie_installer="/var/tmp/installer"
 
@@ -433,6 +433,39 @@ mac_add()
     done
     echo $b | cut -b 1-17
     return 0
+}
+
+# Magic cookie required to be present in the header of all ONIE update
+# images.
+onie_updater_cookie="ONIE-UPDATER-COOKIE"
+
+# ONIE image types
+onie_image_type_update="update"
+onie_image_type_nos="nos"
+
+# Return the type of installer image, either a firmware update or NOS
+# installer.
+get_image_type()
+{
+    # ONIE updater images *must* contain the string
+    # "ONIE-UPDATER-COOKIE" within the first 100 lines of the image.
+    if head -n 100 $1 | grep -q "$onie_updater_cookie" ; then
+        echo -n $onie_image_type_update
+    else
+        echo -n $onie_image_type_nos
+    fi
+}
+
+# Prompt the user for a yes/no confirmation question
+prompt_yes_no()
+{
+    msg_str="$1"
+    echo -n "$msg_str (y/N)? "
+    read ans
+    if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
+	return 0
+    fi
+    return 1
 }
 
 # Local Variables:

--- a/rootconf/x86_64/sysroot-bin/onie-fwpkg
+++ b/rootconf/x86_64/sysroot-bin/onie-fwpkg
@@ -1,0 +1,601 @@
+#!/bin/sh
+
+#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Allow callers to "rebrand" the output of this script.
+this_script=${ONIE_FWPKG_PROGRAM_NAME:-$(basename $(realpath $0))}
+
+lib_dir="$(dirname $(realpath $0))/../lib/onie"
+
+args="hvfq"
+
+usage()
+{
+    cat <<EOF
+usage:
+
+  $this_script [-hvf] add <package file_name> | remove <package_name> |
+                      purge | show-pending [name] | show-results [name] |
+                      show [name] | show-log
+
+Command line tool for managing ONIE firmware update packages.  The
+default is to show any currently pending firmware update packages.
+
+This tool accepts one of the following commands. If no command is
+specified the default command is 'show-pending'.
+
+
+  add <file name>
+
+    The 'add' command takes a required file name argument.  The file
+    name must specify a valid ONIE firmware update package.
+
+    The command stages the firmware update package for processing
+    during the next ONIE-update sequence.
+
+    It is an error to attempt to add an already existing firmware
+    update package.
+
+
+  remove <package name>
+
+    The 'remove' command takes a required ONIE firmware update package
+    name argument.  The package name refers to a previously staged firmware
+    update package.
+
+    The command unstages the firmware update package and any
+    associated state files.  This includes any previous install
+    failure attempts and results.
+
+    For a list of pending firmware updates use the 'show-pending'
+    command described below.
+
+  purge
+
+    The 'purge' command removes *all* pending firmware update packages
+    and associated state.  Think of this as "rm *" for all firmware
+    update packages and associated state.
+
+
+  show-pending [name]
+
+    The 'show-pending' command takes an optional firmware update
+    [name].
+
+    If the name is not specified the command lists all pending
+    firmware update packages and any associated install attempt state.
+
+    Install attempt state includes any previous install failure
+    attempts.
+
+    If [name] is specified the 'show-pending' command dumps all
+    available information about the firmware update package.
+
+
+  show-results [name]
+
+    The 'show-results' command takes an optional firmware update
+    [name].
+
+    If firmware update [name] is not specified the command lists all
+    available result files.
+
+    If firmware update [name] is specified the command output all
+    available result information for the firmware update.
+
+
+  show [name] -- this is the default command
+
+    The 'show' command takes an optional firmware update [name].
+
+    This command combines the output of the 'show-pending' and
+    'show-results' command.
+
+
+  show-log
+
+    The 'show-log' command dumps the entire contents of the ONIE
+    firmware update log to stdout.
+
+
+COMMAND LINE OPTIONS
+
+	-h
+		Help.  Print this message.
+
+	-v
+		Be verbose.  Print what is happening.
+
+	-q
+		Be quiet.  Supress informational printing.
+
+	-f
+		Force the operation.  Automatically answer 'yes' to
+		any confirmation questions.
+EOF
+}
+
+verbose=no
+quiet=no
+cmd_verbose=
+force=no
+while getopts "$args" a ; do
+    case $a in
+        h)
+            usage
+            exit 0
+            ;;
+        v)
+            verbose=yes
+            cmd_verbose=-v
+            quiet=no
+            ;;
+        q)
+            quiet=yes
+            verbose=no
+            cmd_verbose=
+            ;;
+        f)
+            force=yes
+            ;;
+        *)
+            echo "Unknown argument: $a"
+            usage
+            exit 1
+    esac
+done
+shift $(( $OPTIND - 1 ))
+
+[ -r "$lib_dir/onie-blkdev-common" ] || {
+    echo "ERROR: Unable to find onie-blkdev-common"
+    exit 1
+}
+. $lib_dir/onie-blkdev-common
+
+[ -r "$lib_dir/functions" ] || {
+    echo "ERROR: Unable to find functions shell script library"
+    exit 1
+}
+. $lib_dir/functions
+
+# Command handlers begin here
+
+# Helper routine to clean out all files associated with an update
+remove_update()
+{
+    local name="$1"
+
+    local exists=no
+
+    # Removing any files related to the firmware update package
+    [ -f "${onie_update_pending_dir}/$name" ] && {
+        [ "$quiet" != "yes" ] && echo "Removing pending firmware update: $name"
+        rm -f $cmd_verbose "${onie_update_pending_dir}/$name"
+        exists=yes
+    }
+
+    [ -f "${onie_update_attempts_dir}/$name" ] && {
+        [ "$quiet" != "yes" ] && echo "Removing firmware update attempts status: $name"
+        rm -f $cmd_verbose "${onie_update_attempts_dir}/$name"
+        exists=yes
+    }
+
+    [ -f "${onie_update_results_dir}/$name" ] && {
+        [ "$quiet" != "yes" ] && echo "Removing firmware update results: $name"
+        rm -f $cmd_verbose "${onie_update_results_dir}/$name"
+        exists=yes
+    }
+
+    if [ "$exists" = "no" ] ; then
+        [ "$quiet" != "yes" ] && echo "Warning: No files exist for update: $name"
+    fi
+
+}
+
+# The 'add' command handler.
+# $1 - filename of firmware update [required].
+#
+# The command stages the firmware update package for processing during
+cmd_add()
+{
+    local file="$1"
+
+    # Sanity checking:
+    # 1. does file exist ?
+    # 2. does file contain $onie_updater_cookie ?
+    # 3. does destination file already exist ?
+
+    [ -r "$file" ] || {
+        echo "ERROR: Unable to read input file: $file"
+        exit 1
+    }
+
+    local image_type=$(get_image_type $file)
+    [ "$image_type" = "$onie_image_type_update" ] || {
+        echo "ERROR: Input file is not an ONIE firmware update package: $file"
+        exit 1
+    }
+
+    local name=$(basename "$file")
+    local pending="${onie_update_pending_dir}/$name"
+
+    [ -f "$pending" ] && {
+        echo "ERROR: Firmware update package '$name' is already staged."
+        echo "For more info on the currently staged firmware update run:"
+        echo "  $this_script show-pending $name"
+        echo "To remove the currently staged firmware update run:"
+        echo "  $this_script remove $name"
+        exit 1
+    }
+
+    # OK to stage the update.
+
+    # Removing any old attempts and results files.
+    remove_update "$name"
+
+    # Stage the update
+    [ "$quiet" != "yes" ] && echo "Staging firmware update: $file"
+    cp $cmd_verbose $file $pending && return 0
+
+    return 1
+}
+
+# The 'remove' command handler.
+# $1 - name of firmware update to remove [required].
+#
+# The command unstages the firmware update package and any associated
+# state files.
+cmd_remove()
+{
+    local name="$1"
+
+    local pending="${onie_update_pending_dir}/$name"
+
+    # Remove any associated files.
+    remove_update "$name" && return 0
+
+    return 1
+}
+
+# The 'purge' command handler.
+#
+# The command unstages all pending firmware update packages and any
+# associated state files.
+cmd_purge()
+{
+
+    if [ "$force" != "yes" ] ; then
+        prompt_yes_no "Removing all pending firmware updates" || {
+            echo "Skipping purge."
+            return 1
+        }
+    fi
+
+    [ "$quiet" != "yes" ] && echo "Purging all pending firmware updates."
+    for d in $onie_update_pending_dir $onie_update_attempts_dir $onie_update_results_dir ; do
+        for f in $(ls $d) ; do
+            cmd_remove "$f"
+        done
+    done
+
+    return 0
+}
+
+# default to length of header columns
+pending_col1=4
+pending_col2=7
+pending_col3=10
+pending_col4=14
+pending_col5=20
+
+__gather_pending_col_widths()
+{
+    # Find max column widths for 'name' and 'version'.
+    local name=$1
+
+    if [ ${#name} -gt $pending_col1 ] ; then
+        pending_col1=${#name}
+    fi
+    local version="$(sh ${onie_update_pending_dir}/$name -qi | grep 'image_version=' | sed -e 's/image_version=//')"
+    if [ ${#version} -gt $pending_col2 ] ; then
+        pending_col2=${#version}
+    fi
+}
+
+__finalize_pending_col_widths()
+{
+    # column 1 needs 1 extra space. all others need 2
+    pending_col1=$(( $pending_col1 + 1 ))
+    pending_col2=$(( $pending_col2 + 2 ))
+}
+
+__print_pending_tbl_sep()
+{
+    printf "%${pending_col1}s+" | sed -e 's/ /=/g'
+    printf "%${pending_col2}s+" | sed -e 's/ /=/g'
+    printf "%${pending_col3}s+" | sed -e 's/ /=/g'
+    printf "%${pending_col4}s+" | sed -e 's/ /=/g'
+    printf "%${pending_col5}s\n" | sed -e 's/ /=/g'
+}
+
+__print_pending_tbl_header()
+{
+    printf "%-${pending_col1}s|%-${pending_col2}s|%-${pending_col3}s|%-${pending_col4}s|%s\n" "Name " " Version " " Attempts " "Size (Bytes)" " Date"
+    __print_pending_tbl_sep
+}
+
+__print_pending_tbl_footer()
+{
+    __print_pending_tbl_sep
+}
+
+__print_pending_tbl_row()
+{
+    local name=$1
+    local size=$(stat -c "%s" "${onie_update_pending_dir}/$name")
+    local ds=$(stat -c "%y" "${onie_update_pending_dir}/$name" | head -c 19)
+    local version="$(sh ${onie_update_pending_dir}/$name -qi | grep 'image_version=' | sed -e 's/image_version=//')"
+    if [ -r "${onie_update_attempts_dir}/$name" ] ; then
+        local attempts=$(cat "${onie_update_attempts_dir}/$name")
+    else
+        local attempts=0
+    fi
+    printf "%-${pending_col1}s|%-${pending_col2}s|%+${pending_col3}s|%+${pending_col4}s|%s\n" "$name " " $version " " $attempts " "$size " " $ds"
+}
+
+# default to length of header columns
+result_col1=4
+result_col2=7
+result_col3=10
+result_col4=20
+
+__gather_results_col_widths()
+{
+    # Find max column widths for 'name' and 'version'.
+    local name=$1
+
+    if [ ${#name} -gt $result_col1 ] ; then
+        result_col1=${#name}
+    fi
+
+    local version=$(grep image_version "${onie_update_results_dir}/$name")
+    version=${version##*=}
+    [ -n "$version" ] || version="Unknown"
+    if [ ${#version} -gt $result_col2 ] ; then
+        result_col2=${#version}
+    fi
+}
+
+__finalize_results_col_widths()
+{
+    # column 1 needs 1 extra space. all others need 2
+    result_col1=$(( $result_col1 + 1 ))
+    result_col2=$(( $result_col2 + 2 ))
+}
+
+__print_results_tbl_sep()
+{
+    printf "%${result_col1}s+" | sed -e 's/ /=/g'
+    printf "%${result_col2}s+" | sed -e 's/ /=/g'
+    printf "%${result_col3}s+" | sed -e 's/ /=/g'
+    printf "%${result_col4}s\n" | sed -e 's/ /=/g'
+}
+
+__print_results_tbl_header()
+{
+    printf "%-${result_col1}s|%-${result_col2}s|%-${result_col3}s|%s\n" "Name " " Version " " Result " " Date"
+    __print_results_tbl_sep
+}
+
+__print_results_tbl_footer()
+{
+    __print_results_tbl_sep
+}
+
+__print_results_tbl_row()
+{
+    local name=$1
+
+    local status=$(grep onie_update_status_code "${onie_update_results_dir}/$name")
+    status=${status##*=}
+    [ -z "$status" ] && status=1
+    if [ $status -eq 0 ] ; then
+        status="Success"
+    else
+        status="Fail"
+    fi
+
+    local version=$(grep image_version "${onie_update_results_dir}/$name")
+    version=${version##*=}
+    [ -n "$version" ] || version="Unknown"
+
+    local ds=$(stat -c "%y" "${onie_update_results_dir}/$name" | head -c 19)
+    printf "%-${result_col1}s|%-${result_col2}s|%-${result_col3}s|%s\n" "$name " " $version " " $status " " $ds"
+}
+
+# The 'show-pending' command handler.
+# $1 - name of firmware update to display [optional].
+#
+# The command displays information about pending firmware updates.
+cmd_show_pending()
+{
+    local name="$1"
+
+    [ "$quiet" != "yes" ] && echo "** Pending firmware update information:"
+    if [ -n "$name" ] ; then
+        # dump detailed information about this update
+        local pending="${onie_update_pending_dir}/$name"
+        [ -r "$pending" ] || {
+            echo "No pending firmware update '$name' found.  Skipping..."
+            return 0
+        }
+        __gather_pending_col_widths $name
+        __finalize_pending_col_widths
+        __print_pending_tbl_header
+        __print_pending_tbl_row $name
+        __print_pending_tbl_footer
+
+        echo
+        echo "Additional image information:"
+        # Dump information contained in the update image
+        /bin/sh "$pending" -qi
+    else
+        # dump summary information about all pending updates
+        local pending="$(ls $onie_update_pending_dir)"
+        if [ -n "$pending" ] ; then
+            for f in $(ls $onie_update_pending_dir) ; do
+                __gather_pending_col_widths $f
+            done
+            __finalize_pending_col_widths
+            __print_pending_tbl_header
+            for f in $(ls $onie_update_pending_dir) ; do
+                __print_pending_tbl_row $f
+            done
+            __print_pending_tbl_footer
+            [ "$quiet" != "yes" ] && {
+                echo
+                echo "For more detailed information run: $this_script show-pending <update_name>"
+            }
+        else
+            [ "$quiet" != "yes" ] && echo "No pending firmware updates present."
+        fi
+    fi
+
+    return 0
+}
+
+# The 'show-results' command handler.
+# $1 - name of firmware update results to display [optional].
+#
+# The command displays results for completed firmware updates.
+cmd_show_results()
+{
+    local name="$1"
+
+    [ "$quiet" != "yes" ] && echo "** Firmware update results information:"
+    if [ -n "$name" ] ; then
+        # dump detailed results for this update
+        local results="${onie_update_results_dir}/$name"
+        [ -r "$results" ] || {
+            echo "No results for firmware update '$name' found.  Skipping..."
+            return 0
+        }
+        __gather_results_col_widths $name
+        __finalize_results_col_widths
+        __print_results_tbl_header
+        __print_results_tbl_row "$name"
+        __print_results_tbl_footer
+
+        echo
+        echo "Additional firmware update results information:"
+        # Dump information contained in the results file
+        cat $results
+    else
+        # dump summary results information
+        local results="$(ls $onie_update_results_dir)"
+        if [ -n "$results" ] ; then
+            for f in $(ls $onie_update_results_dir) ; do
+                __gather_results_col_widths $f
+            done
+            __finalize_results_col_widths
+            __print_results_tbl_header
+            for f in $(ls $onie_update_results_dir) ; do
+                __print_results_tbl_row "$f"
+            done
+            __print_results_tbl_footer
+            [ "$quiet" != "yes" ] && {
+                echo
+                echo "For more detailed information run: $this_script show-results <update_name>"
+            }
+        else
+            [ "$quiet" != "yes" ] && echo "No firmware update results present."
+        fi
+    fi
+
+    return 0
+}
+
+# The 'show' command handler.
+# $1 - name of firmware update to display [optional].
+#
+# The command displays information about firmware update packages.
+cmd_show()
+{
+    local name="$1"
+
+    cmd_show_pending $name
+    [ "$quiet" != "yes" ] && echo
+    cmd_show_results $name
+
+    return 0
+}
+
+# The 'show-log' command handler.
+#
+# The command dumps the entire contents of the ONIE firmware update
+# log to stdout.
+cmd_show_log()
+{
+    if [ -r "$onie_update_log" ] ; then
+        cat "$onie_update_log"
+    else
+        echo "Firmware update log unavailable."
+    fi
+
+    return 0
+}
+
+
+# Process command arguments
+cmd=$1
+# optional argument
+name="$2"
+
+if [ -z "$cmd" ] ; then
+    # Default to 'show' if no command is specified.
+    cmd_show
+    exit 0
+fi
+
+case "$cmd" in
+    add)
+        [ -z "$name" ] && {
+            echo "ERROR: This command requires a firmware update file name."
+            echo "Run '$this_script -h' for complete details."
+            exit 1
+        }
+        cmd_add "$name"
+        ;;
+    remove)
+        [ -z "$name" ] && {
+            echo "ERROR: This command requires a firmware update file name."
+            echo "Run '$this_script -h' for complete details."
+            exit 1
+        }
+        cmd_remove "$name"
+        ;;
+    purge)
+        cmd_purge
+        ;;
+    show)
+        cmd_show "$name"
+        ;;
+    show-pending)
+        cmd_show_pending "$name"
+        ;;
+    show-results)
+        cmd_show_results "$name"
+        ;;
+    show-log)
+        cmd_show_log
+        ;;
+    *)
+        echo "Unknown command: $cmd"
+        usage
+        exit 1
+
+esac
+
+exit 0

--- a/rootconf/x86_64/sysroot-lib-onie/exec-installer-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/exec-installer-arch
@@ -1,0 +1,101 @@
+# Installer helpers for x86_64 architectures
+
+#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+. /lib/onie/onie-blkdev-common
+
+# Log file for firmware updates
+max_log_lines=1000
+
+# Maximum number of attempts to install a firmware update.
+max_fw_attempts=5
+
+log_fw_update()
+{
+    ts=$(date +"%Y-%m-%d %T")
+    printf "ONIE: $@ \n" > /dev/console
+    # Keep log file below $max_log_lines
+    if [ -r "$onie_update_log" ] ; then
+        line_count="$(wc -l $onie_update_log | awk '{print $1}')"
+        if [ $line_count -gt $max_log_lines ] ; then
+            # keep half of $max_log_lines
+            tail -n "$(( $max_log_lines / 2 ))" ${onie_update_log} > ${onie_update_log}.tmp
+            mv ${onie_update_log}.tmp ${onie_update_log}
+        fi
+    fi
+    printf "$ts ONIE: $@ \n" >> $onie_update_log
+}
+
+#  After the update is complete, create a log of the update status
+#  result for later viewing.
+finish_update_install()
+{
+    local result="$1"
+    local URL="$2"
+    local update_image="$3"
+
+    local fw_update=no
+    if [ -r "$URL" ] ; then
+        # The update is a local file.
+        if [ "$(dirname $URL)" = "$onie_update_pending_dir" ] ; then
+            # Processing firmware update from pending directory
+            fw_update=yes
+        fi
+    fi
+
+    local update_name="$(basename $URL)"
+    local results_file="${onie_update_results_dir}/$update_name"
+    local attempts_file="${onie_update_attempts_dir}/$update_name"
+    local image_version="$(sh $update_image -qi | grep 'image_version=' | sed -e 's/image_version=//')"
+
+    # Dump information about the update process into the results file.
+    (cat <<EOF
+onie_update_status_code=$result
+onie_update_image_url=$URL
+$(sh $update_image -qi)
+EOF
+) > $results_file
+
+    if [ $result -eq 0 ] ; then
+        log_fw_update "Success: Firmware update URL: $URL"
+        log_fw_update "Success: Firmware update version: $image_version"
+        if [ "$fw_update" = "yes" ] ; then
+            # remove the pending update image and any past attempt file
+            rm -f $URL $attempts_file
+            # do not automatically reboot as there be more pending updates
+            return 0
+        else
+            # Legacy / ordinary post update handling
+            log_console_msg "Rebooting..."
+            reboot && return 0
+        fi
+    else
+        log_fw_update "ERROR: Firmware update URL: $URL"
+        log_fw_update "ERROR: Firmware update version: $image_version"
+        if [ "$fw_update" = "yes" ] ; then
+            # Increment retry count
+            if [ -r "$attempts_file" ] ; then
+                attempts="$(cat $attempts_file)"
+            else
+                attempts=0
+            fi
+            attempts=$(( $attempts + 1 ))
+            if [ $attempts -ge $max_fw_attempts ] ; then
+                # remove the pending update to prevent further
+                # update attempts.
+                log_fw_update "ERROR: Firmware update failed $attempts attempts, removing update."
+                rm -f $URL $attempts_file
+            else
+                echo $attempts > $attempts_file
+            fi
+        fi
+    fi
+    return 1
+}
+
+# Local Variables:
+# mode: shell-script
+# eval: (sh-set-shell "/bin/sh" t nil)
+# End:

--- a/rootconf/x86_64/sysroot-lib-onie/init-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/init-arch
@@ -55,7 +55,8 @@ EOF
 
 init_onie_boot
 
-mkdir -p $onie_config_dir
+mkdir -p $onie_config_dir $onie_update_pending_dir \
+    $onie_update_attempts_dir $onie_update_results_dir
 
 # Handle UEFI systems
 init_uefi() {

--- a/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
+++ b/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
@@ -11,6 +11,13 @@ onie_config_dir="${onie_root_dir}/config"
 grub_root_dir="${onie_boot_mnt}/grub"
 grub_env_file="${grub_root_dir}/grubenv"
 
+onie_update_dir="${onie_root_dir}/update"
+onie_update_pending_dir="${onie_update_dir}/pending"
+onie_update_attempts_dir="${onie_update_dir}/attempts"
+onie_update_results_dir="${onie_update_dir}/results"
+onie_update_log="$onie_update_dir/update.log"
+
+
 # gfdisk types and GPT UUIDs from gptfdisk-0.8.8/parttypes.cc
 uefi_esp_gfdisk_type="0xEF00"
 grub_boot_gfdisk_type="0xEF02"


### PR DESCRIPTION
This patchset adds the following:

- an additional update image discovery mechanism.  The discovery process will now also look in a well known, persistent directory on the `ONIE-BOOT` partition.

- a new CLI command, `onie-fwpkg`, for managing ONIE update images and the well known, persistent directory on the ONIE-BOOT partition.
