### PR TITLE
oce: build-onie.py use subprocess.check_call()

### DIFF
--- a/contrib/oce/build-onie.py
+++ b/contrib/oce/build-onie.py
@@ -163,7 +163,7 @@ def build(machine_or_vendor, dry_run=True, args='', targets=None):
                   format(args, machine_or_vendor, add_targets)
         print cmd
         if not dry_run:
-            subprocess.call(cmd, shell=True)
+            subprocess.check_call(cmd, shell=True)
 
     else:
         print 'Invalid Target: {0}'.format(machine_or_vendor)


### PR DESCRIPTION
In order to catch build failures use subprocess.check_call() instead
of subprocess.call().  check_call() will raise a CalledProcessError
exception if the underlying command exit code is non-zero.

This allows scripts that call build-onie.py to check its return code
and take appropriate actions.

Testing:

Ran build-onie.py with a bogus make argument using the --make-args
argument, such that the underlying make command would fail.
build-onie.py displayed a back trace and exited with a non-zero exit
code.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>