### PR TITLE
grub: fix race condition in grub build

### DIFF
--- a/patches/grub/disable-build-of-documentation.patch
+++ b/patches/grub/disable-build-of-documentation.patch
@@ -1,0 +1,17 @@
+GRUB2: Disable build of documentation
+
+ONIE does not require the building of the documentation
+
+diff --git a/Makefile.am b/Makefile.am
+index f02ae0a..23dae24 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,7 +1,7 @@
+ AUTOMAKE_OPTIONS = subdir-objects -Wno-portability
+ 
+ DEPDIR = .deps-util
+-SUBDIRS = grub-core/gnulib . grub-core po docs util/bash-completion.d
++SUBDIRS = grub-core/gnulib . grub-core po util/bash-completion.d
+ 
+ include $(top_srcdir)/conf/Makefile.common
+ include $(top_srcdir)/conf/Makefile.extra-dist

--- a/patches/grub/series
+++ b/patches/grub/series
@@ -1,3 +1,4 @@
-# This series applies on GIT commit 6f2068a6c21dc22f4b131a3882c2eb84c0d9aa61
+# This series applies on GIT commit 09790f53e84a6f96fdfe6a09947808d9e614886d
 version-string.patch
 set-default-graphics-mode-to-text.patch
+disable-build-of-documentation.patch


### PR DESCRIPTION
When running 'make all' with -j24 occasionally the build would fail
for the grub-install and grub-host-install targets.

The grub builds share a common source directory and are supposed to
use separate output directory.  That part was working fine.

The trouble was the build of the grub info pages (documentation)
happens in the source directory, instead of the separate binary output
directories.  The parallel builds would clobber each other building
the documentation.

The fix here is to remove the building of the grub documentation,
which we are not using anyway.

Testing:

Before the fix building an x86 machine from scratch would fail 1 out
of 5 times or so.  After the fix *all* x86 machines built from scratch
successfully.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>