### PR TITLE
change default kernel version and uClibc version

### DIFF
--- a/build-config/make/kernel-download.make
+++ b/build-config/make/kernel-download.make
@@ -14,9 +14,9 @@
 #-------------------------------------------------------------------------------
 # Need the Linux kernel downloaded before building xtools
 
-LINUX_VERSION		?= 3.2
+LINUX_VERSION		?= 4.1
 LINUX_MAJOR_VERSION	= $(firstword $(subst ., ,$(LINUX_VERSION)))
-LINUX_MINOR_VERSION	?= 69
+LINUX_MINOR_VERSION	?= 2
 LINUX_RELEASE		?= $(LINUX_VERSION).$(LINUX_MINOR_VERSION)
 LINUX_TARBALL		?= linux-$(LINUX_RELEASE).tar.xz
 export LINUX_TARBALL

--- a/build-config/make/uclibc-download.make
+++ b/build-config/make/uclibc-download.make
@@ -9,7 +9,7 @@
 # This is a makefile fragment that defines the download of uClibc
 #
 
-UCLIBC_VERSION		?= 0.9.32.1
+UCLIBC_VERSION		?= 0.9.33.2
 UCLIBC_TARBALL		= uClibc-$(UCLIBC_VERSION).tar.xz
 UCLIBC_TARBALL_URLS	+= $(ONIE_MIRROR) http://www.uclibc.org/downloads
 UCLIBC_CONFIG		= $(realpath conf)/uclibc/$(UCLIBC_VERSION)/uclibc.$(ONIE_ARCH).config

--- a/machine/accton/accton_as4600_54t/machine.make
+++ b/machine/accton/accton_as4600_54t/machine.make
@@ -28,6 +28,13 @@ KERNEL_DTB = as4600_54t.dtb
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 259
 
+# Specify Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/accton/accton_as5600_52x/machine.make
+++ b/machine/accton/accton_as5600_52x/machine.make
@@ -33,6 +33,13 @@ KERNEL_DTB = as5600_52x.dtb
 # Accton Technology Corporation IANA number
 VENDOR_ID = 259
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/accton/accton_as5610_52x/machine.make
+++ b/machine/accton/accton_as5610_52x/machine.make
@@ -33,6 +33,13 @@ KERNEL_DTB = as5610_52x.dtb
 # Accton Technology Corporation IANA number
 VENDOR_ID = 259
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/accton/accton_as5700_96x/machine.make
+++ b/machine/accton/accton_as5700_96x/machine.make
@@ -26,6 +26,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.5
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 UBOOT_MACHINE = AS5700_96X
 KERNEL_DTB = as5700_96x.dtb
 

--- a/machine/accton/accton_as5710_54x/machine.make
+++ b/machine/accton/accton_as5710_54x/machine.make
@@ -26,6 +26,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.5
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 UBOOT_MACHINE = AS5710_54X
 KERNEL_DTB = as5710_54x.dtb
 

--- a/machine/accton/accton_as5712_54x/machine.make
+++ b/machine/accton/accton_as5712_54x/machine.make
@@ -29,6 +29,13 @@ I2CTOOLS_SYSEEPROM = no
 # Console parameters
 CONSOLE_DEV = 1
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/accton/accton_as6700_32x/machine.make
+++ b/machine/accton/accton_as6700_32x/machine.make
@@ -35,6 +35,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.5
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/accton/accton_as6701_32x/machine.make
+++ b/machine/accton/accton_as6701_32x/machine.make
@@ -28,6 +28,13 @@ KERNEL_DTB = as6701_32x.dtb
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 259
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/accton/accton_as6710_32x/machine.make
+++ b/machine/accton/accton_as6710_32x/machine.make
@@ -26,6 +26,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.5
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 UBOOT_MACHINE = AS6710_32X
 KERNEL_DTB = as6710_32x.dtb
 

--- a/machine/accton/accton_as6712_32x/machine.make
+++ b/machine/accton/accton_as6712_32x/machine.make
@@ -29,6 +29,13 @@ I2CTOOLS_SYSEEPROM = no
 # Console parameters
 CONSOLE_DEV = 1
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/accton/accton_as7710_32x/machine.make
+++ b/machine/accton/accton_as7710_32x/machine.make
@@ -25,6 +25,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.7
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 # Set the desired u-boot version.
 UBOOT_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/u-boot.git/snapshot
 UBOOT_VERSION		= fsl-sdk-v1.7

--- a/machine/accton/accton_as7712_32x_1/machine.make
+++ b/machine/accton/accton_as7712_32x_1/machine.make
@@ -27,6 +27,13 @@ I2CTOOLS_SYSEEPROM = no
 # Console parameters
 CONSOLE_DEV = 1
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/alphanetworks/alphanetworks_snh60a0_320f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snh60a0_320f/machine.make
@@ -36,3 +36,7 @@ CONSOLE_DEV = 1
 
 LINUX_VERSION		= 3.14
 LINUX_MINOR_VERSION	= 27
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+

--- a/machine/alphanetworks/alphanetworks_snq6070_320f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snq6070_320f/machine.make
@@ -19,6 +19,13 @@ KERNEL_DTB = snq6070_320f.dtb
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 31874
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/alphanetworks/alphanetworks_snq60a0_320f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snq60a0_320f/machine.make
@@ -28,6 +28,13 @@ I2CTOOLS_ENABLE = yes
 # Console parameters
 CONSOLE_DEV = 1
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/alphanetworks/alphanetworks_snx6070_486f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snx6070_486f/machine.make
@@ -19,6 +19,13 @@ KERNEL_DTB = snx6070_486f.dtb
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 31874
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/alphanetworks/alphanetworks_snx60a0_486f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snx60a0_486f/machine.make
@@ -28,6 +28,13 @@ I2CTOOLS_ENABLE = yes
 # Console parameters
 CONSOLE_DEV = 1
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/celestica/cel_redstone_xp/machine.make
+++ b/machine/celestica/cel_redstone_xp/machine.make
@@ -23,6 +23,14 @@ I2CTOOLS_ENABLE = yes
 PARTED_ENABLE = yes
 
 PARTITION_TYPE = gpt
+
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/centec/centec_e580_20q4z/machine.make
+++ b/machine/centec/centec_e580_20q4z/machine.make
@@ -18,6 +18,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.5
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 # Vendor ID -- IANA Private Enterprise Number:
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 27975 

--- a/machine/centec/centec_e580_48x2q4z/machine.make
+++ b/machine/centec/centec_e580_48x2q4z/machine.make
@@ -18,6 +18,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.5
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 # Vendor ID -- IANA Private Enterprise Number:
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 27975 

--- a/machine/centec/centec_e580_48x6q/machine.make
+++ b/machine/centec/centec_e580_48x6q/machine.make
@@ -18,6 +18,9 @@ LINUX_TARBALL_URLS	= http://git.freescale.com/git/cgit.cgi/ppc/sdk/linux.git/sna
 LINUX_RELEASE		= fsl-sdk-v1.5
 LINUX_TARBALL		= linux-$(LINUX_RELEASE).tar.bz2
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 # Vendor ID -- IANA Private Enterprise Number:
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 27975 

--- a/machine/dell/dell_s3000_c2338/machine.make
+++ b/machine/dell/dell_s3000_c2338/machine.make
@@ -30,6 +30,13 @@ CONSOLE_FLAG = 0
 
 EXTRA_CMDLINE_LINUX = i2c-ismt.bus_speed=100
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/dell/dell_s4000_c2338/machine.make
+++ b/machine/dell/dell_s4000_c2338/machine.make
@@ -30,6 +30,13 @@ CONSOLE_FLAG = 0
 
 EXTRA_CMDLINE_LINUX = i2c-ismt.bus_speed=100
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/dell/dell_s4810_on_p2020/machine.make
+++ b/machine/dell/dell_s4810_on_p2020/machine.make
@@ -16,6 +16,13 @@ endif
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 5324
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/dell/dell_s6000_s1220/machine.make
+++ b/machine/dell/dell_s6000_s1220/machine.make
@@ -21,6 +21,13 @@ VENDOR_ID = 674
 # This platform requires the PXE_EFI64 installer
 PXE_EFI64_ENABLE = yes
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/fsl_p2020rdbpca/machine.make
+++ b/machine/fsl_p2020rdbpca/machine.make
@@ -23,13 +23,6 @@ KERNEL_DTB = p2020rdb.dtb
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 33118
 
-# Set the desired kernel version.
-LINUX_VERSION		= 4.1
-LINUX_MINOR_VERSION	= 2
-
-# Set the desired uClibc version
-UCLIBC_VERSION = 0.9.33.2
-
 # Include kexec-tools
 KEXEC_ENABLE = yes
 

--- a/machine/im_n29xx_t40n/machine.make
+++ b/machine/im_n29xx_t40n/machine.make
@@ -25,6 +25,13 @@ I2CTOOLS_ENABLE = no
 # Default to msdos disk label for this platform
 PARTITION_TYPE = msdos
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/kvm_x86_64/machine.make
+++ b/machine/kvm_x86_64/machine.make
@@ -44,13 +44,6 @@ I2CTOOLS_ENABLE = no
 # Enable UEFI support
 UEFI_ENABLE = yes
 
-# Set the desired kernel version.
-LINUX_VERSION		= 4.1
-LINUX_MINOR_VERSION	= 2
-
-# Set the desired uClibc version
-UCLIBC_VERSION = 0.9.33.2
-
 #
 # Console parameters can be defined here (default values are in
 # build-config/arch/x86_64.make).

--- a/machine/mellanox/mlnx_x86/machine.make
+++ b/machine/mellanox/mlnx_x86/machine.make
@@ -37,6 +37,9 @@ LINUX_TARBALL = linux-3.10.0-54.0.1.el7.x86_64.tar.xz
 
 LINUX_CONFIG = conf/linux.x86_64.mellanox.config
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 MELLANOX_PXE_UPDATER_STAMP   = $(STAMPDIR)/mellanox-pxe-updater-stamp
 MELLANOX_NETBOOT_PXE_UPDATER = $(IMAGEDIR)/mellanox_net_boot_label.sh
 

--- a/machine/quanta/quanta_lb8d/machine.make
+++ b/machine/quanta/quanta_lb8d/machine.make
@@ -16,6 +16,13 @@ endif
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 7244
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/quanta/quanta_lb9/machine.make
+++ b/machine/quanta/quanta_lb9/machine.make
@@ -16,6 +16,13 @@ endif
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 7244
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/quanta/quanta_ly2/machine.make
+++ b/machine/quanta/quanta_ly2/machine.make
@@ -16,6 +16,13 @@ endif
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 7244
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/quanta/quanta_ly2r/machine.make
+++ b/machine/quanta/quanta_ly2r/machine.make
@@ -16,6 +16,13 @@ endif
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 7244
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/quanta/quanta_ly3/machine.make
+++ b/machine/quanta/quanta_ly3/machine.make
@@ -16,6 +16,13 @@ endif
 # http://www.iana.org/assignments/enterprise-numbers
 VENDOR_ID = 7244
 
+# Set Linux kernel version
+LINUX_VERSION		= 3.2
+LINUX_MINOR_VERSION	= 69
+
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:


### PR DESCRIPTION
This patch updates the default kernel version and uClibc version to:

  kernel: 4.1.2
  uClibc: 0.9.33.2

These will be the default versions to use for new machines.

The net result of this patch is a no-op -- no machine will compile any
differently because of this patch.  Future machines will pick up the
new default versions if nothing else is specified.

All current machines are left at the previous versions.  This was done
by editing the machine.make for each machine.

No machine was specifying the uClibc version, so each machine.make
picked up these lines:

  # Specify uClibc version
  UCLIBC_VERSION = 0.9.32.1

uClibc version 0.9.32.1 was the *previous* default version.

Some machines were already using a specific kernel version.  Those
machines were *not* modified.

For all machines that were relying on the old default kernel version,
the following lines were added to their machine.make:

  # Specify Linux kernel version
  LINUX_VERSION		= 3.2
  LINUX_MINOR_VERSION	= 69