### PR TITLE
kvm_x86_64: allow some flexibility for install disk

### DIFF
--- a/machine/kvm_x86_64/installer.conf
+++ b/machine/kvm_x86_64/installer.conf
@@ -10,10 +10,25 @@ description="KVM, VM-X86_64"
 # Default ONIE block device
 install_device_platform()
 {
-    # For the VM demo just hard code the path.  For a real hardware
-    # system a more involved disk discovery and probe approach is
-    # recommended.
-    echo /dev/vda
+    # For the VM demo it depends how the VM is configured.  Look for
+    # two common configurations and then give up.
+
+    # Virtual IO block device
+    if grep -q vda /proc/partitions ; then
+        echo /dev/vda
+        return 0
+    fi
+
+    # SATA, SCSI, USB block device
+    if grep -q sda /proc/partitions ; then
+        echo /dev/sda
+        return 0
+    fi
+
+    echo "ERROR: Unable to determine install block device" > /dev/console
+    echo "Configure your VM to use a SATA controller for the hard disk" > /dev/console
+    echo /dev/sda
+
 }
 
 # Local Variables:


### PR DESCRIPTION
Previously the kvm_x86_64 machine defaulted to using /dev/vda for
installing ONIE.  This was fine as long as the VM is configured to use
a virtual IO block device for the storage medium.  This works great
with QEMU.

Some hypervisors do not support virtual IO block devices.  However,
SATA controller are commonly supported.  In order to be more flexible
in the choice of hypervisor this patch let's the installer choose
either /dev/vda or /dev/sda at runtime for installing ONIE.

Testing:

Installed the ONIE image using a virtio disk controller and using a
SATA disk controller.