### PR TITLE
onie-fwpkg: fix shell string interpretation

### DIFF
--- a/rootconf/x86_64/sysroot-bin/onie-fwpkg
+++ b/rootconf/x86_64/sysroot-bin/onie-fwpkg
@@ -335,7 +335,7 @@ __print_pending_tbl_row()
 {
     local name=$1
     local size=$(stat -c "%s" "${onie_update_pending_dir}/$name")
-    local ds=$(stat -c "%y" "${onie_update_pending_dir}/$name" | head -c 19)
+    local ds="$(stat -c '%y' ${onie_update_pending_dir}/$name | head -c 19)"
     local version="$(sh ${onie_update_pending_dir}/$name -qi | grep 'image_version=' | sed -e 's/image_version=//')"
     if [ -r "${onie_update_attempts_dir}/$name" ] ; then
         local attempts=$(cat "${onie_update_attempts_dir}/$name")
@@ -411,7 +411,7 @@ __print_results_tbl_row()
     version=${version##*=}
     [ -n "$version" ] || version="Unknown"
 
-    local ds=$(stat -c "%y" "${onie_update_results_dir}/$name" | head -c 19)
+    local ds="$(stat -c '%y' ${onie_update_pending_dir}/$name | head -c 19)"
     printf "%-${result_col1}s|%-${result_col2}s|%-${result_col3}s|%s\n" "$name " " $version " " $status " " $ds"
 }
 


### PR DESCRIPTION
The string interpretation in Busybox was working fine, however using
Debian's /bin/dash had problems with resulting date string with
embedded spaces.  The busybox string quoting is a little lax compared
to other full shell implementations.

Since this script is intended to work with multiple /bin/sh
environments (Busybox in ONIE, /bin/sh on other Linux distros) we need
to fix up the string quoting to be more robust.

Testing:

- used the script from ONIE's busybox
- used the script on a Debian 7.0 workstation using /bin/dash