### PR TITLE
Improve eth0 link up detection

### DIFF
--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -135,8 +135,9 @@ config_ethmgmt_fallback()
 
 }
 
-# Check if the specified interface is operationally "up".  Try for 5
-# seconds and then give up.
+# Check the operational state of the specified interface before trying
+# DHCP.  From linux/Documentation/networking/operstates.txt, the
+# appropriate states are "up" and "unknown" for DHCP.
 check_link_up()
 {
     local intf=$1
@@ -145,7 +146,8 @@ check_link_up()
     _log_info_msg "Info: ${intf}:  Checking link... "
     local i=0
     [ -r $operstate ] && while [ $i -lt 100 ] ; do
-        if [ "$(cat $operstate)" = "up" ] ; then
+        intf_operstate="$(cat $operstate)"
+        if [ "$intf_operstate" = "up" -o "$intf_operstate" = "unknown" ] ; then
             _log_info_msg "up.\n"
             return 0
         fi


### PR DESCRIPTION
The link up detection mechanism inspects the "operstate" of the
network interface in question.  Some Ethernet drivers do not fully
implement the "operstate" -- as such, the appropriate states for
determining link-up for DHCP are "up" and "unknown".

Quoting linux/Documentation/networking/operstates.txt:

  IF_OPER_UNKNOWN (0):
   Interface is in unknown state, neither driver nor userspace has set
   operational state. Interface must be considered for user data as
   setting operational state has not been implemented in every driver.

  ...

  A routing daemon or dhcp client just needs to care for IFF_RUNNING
  or waiting for operstate to go IF_OPER_UP/IF_OPER_UNKNOWN before
  considering the interface / querying a DHCP address.