### PR TITLE
add check for partition name

### DIFF
--- a/contrib/oce/test-nos.sh
+++ b/contrib/oce/test-nos.sh
@@ -169,6 +169,15 @@ check_for_diag()
                     else
                         echo "***Diag $p does not have the correct attribute flags"
                     fi
+
+                    # if found, check partition name
+                    partname=$(sgdisk -i $part /dev/$blk | grep 'Partition name')
+                    partname=${partname##*: }
+                    if [ $(echo "$partname" | egrep -e '-DIAG') ] ; then
+                        echo "Partition name $partname is valid"
+                    else
+                        echo "***Partition name is named incorrectly"
+                    fi
                 done
             fi
         else #not x86_64


### PR DESCRIPTION
ONIE requires diagnostics partitions to follow 3 requirements as specified in [specifications](https://github.com/opencomputeproject/onie/wiki/Design-Spec-x86-NOS-Interface#gpt-partition-table). This patch adds support for verifying the partition name regex, where prior to this - only the file system name regex and attribution flag was verified.