### PR TITLE
If write over 16 bytes again, it will override with from first byte. …

### DIFF
--- a/machine/wnc/wnc_sst1_n1/busybox/patches/onie-syseeprom-rw-wnc.patch
+++ b/machine/wnc/wnc_sst1_n1/busybox/patches/onie-syseeprom-rw-wnc.patch
@@ -1,125 +1,136 @@
 diff --git a/miscutils/sys_eeprom_i2c.c b/miscutils/sys_eeprom_i2c.c
-index ed3235b..4ef918a 100644
+index 4ef918a..0eb73dc 100644
 --- a/miscutils/sys_eeprom_i2c.c
 +++ b/miscutils/sys_eeprom_i2c.c
-@@ -2,6 +2,7 @@
- #include "onie_tlvinfo.h"
- #include "sys_eeprom.h"
- #include "24cXX.h"
-+#include <linux/i2c-dev.h>
- 
- #if SYS_EEPROM_I2C_MEM_ADDR_BITS == 8
-     #define EEPROM_TYPE EEPROM_TYPE_8BIT_ADDR
-@@ -16,24 +17,48 @@
+@@ -17,10 +17,11 @@
   */
  int read_sys_eeprom(void *eeprom_data, int offset, int len)
  {
--    int ret = 0;
-+    //mcp2221 read cmd, two bytes header. Always write two bytes first before reaad().
-+    unsigned char start[2] =  {0x00, 0x00}; 
-+    int status;
-+    unsigned char rbuf[SYS_EEPROM_SIZE];
-+
-     struct eeprom e;
--    int i = 0;
-     u_int8_t *c;
-     int addr = SYS_EEPROM_OFFSET + offset;
--
-     c = eeprom_data;
--    if (eeprom_open(SYS_EEPROM_I2C_DEVICE, SYS_EEPROM_I2C_ADDR,
--		    EEPROM_TYPE, &e)) {
--	printf("ERROR: Cannot open I2C device\n");
--	return -1;
-+    int fd = open(SYS_EEPROM_I2C_DEVICE, O_RDWR);
-+    if (fd < 0) {
-+        printf("ERROR: open(%d) failed\n", fd);
-+        return -1;
-+    }
-+    //printf("\nSUCCESS: open(%d) passed\n", fd);
-+
-+    // SETTING EEPROM ADDR
-+    status = ioctl(fd, I2C_SLAVE, SYS_EEPROM_I2C_ADDR);
-+    if (status < 0)
-+    {
-+        printf("ERROR: ioctl(fd, I2C_SLAVE, 0x%02X) failed\n", SYS_EEPROM_I2C_ADDR);
-+        close(fd);
-+        return -1;
-+    }
-+
-+    //printf("\nSUCCESS: ioctl(fd, I2C_SLAVE=%d, 0x%02X) passed\n", I2C_SLAVE, SYS_EEPROM_I2C_ADDR);
-+    //printf ("Performing EEPROM Read operation\n\n");
-+
-+    if(write(fd,start,2)!=2){
-+        printf("ERROR: buffer pointer initialization of read() step 2+ failed\n");
-+        close(fd);
-+        return -1;
-     }
--    for (i = 0; i < len; i++) {
--	*c = eeprom_read_byte(&e, addr);
--	c++; addr++;
-+    if(read(fd,rbuf,(len+addr))!=(len+addr))
-+    {
-+        printf("EEPROM read error, return -1. \n");
-+        close(fd);
-+        return -1;
-     }
--    eeprom_close(&e);
--    return ret;
-+    memcpy(c,rbuf+addr,len);
-+    close(fd);
-+    return 0;
- }
+-    //mcp2221 read cmd, two bytes header. Always write two bytes first before reaad().
+-    unsigned char start[2] =  {0x00, 0x00}; 
++    //mcp2221 read cmd, two bytes header. Always write two bytes first before reaad() to decide what address to start read.
++    unsigned char start_addr[2] =  {0x00, 0x00}; // value format:{high byte, low byte}
+     int status;
+-    unsigned char rbuf[SYS_EEPROM_SIZE];
++    unsigned char buf[16] = {0};
++    int i;
  
- /*
-@@ -41,23 +66,37 @@ int read_sys_eeprom(void *eeprom_data, int offset, int len)
+     struct eeprom e;
+     u_int8_t *c;
+@@ -31,7 +32,6 @@ int read_sys_eeprom(void *eeprom_data, int offset, int len)
+         printf("ERROR: open(%d) failed\n", fd);
+         return -1;
+     }
+-    //printf("\nSUCCESS: open(%d) passed\n", fd);
+ 
+     // SETTING EEPROM ADDR
+     status = ioctl(fd, I2C_SLAVE, SYS_EEPROM_I2C_ADDR);
+@@ -42,21 +42,24 @@ int read_sys_eeprom(void *eeprom_data, int offset, int len)
+         return -1;
+     }
+ 
+-    //printf("\nSUCCESS: ioctl(fd, I2C_SLAVE=%d, 0x%02X) passed\n", I2C_SLAVE, SYS_EEPROM_I2C_ADDR);
+-    //printf ("Performing EEPROM Read operation\n\n");
+-
+-    if(write(fd,start,2)!=2){
+-        printf("ERROR: buffer pointer initialization of read() step 2+ failed\n");
+-        close(fd);
+-        return -1;
+-    }
+-    if(read(fd,rbuf,(len+addr))!=(len+addr))
++    for(i=0; i<len; i+=16)
+     {
+-        printf("EEPROM read error, return -1. \n");
+-        close(fd);
+-        return -1;
++        int read_num = (len-i)>15?16:(len-i);
++        start_addr[0] = (u_int8_t)((i+addr)/256);
++        start_addr[1] = i+addr;
++
++        if(write(fd,start_addr,2)!=2){
++            printf("ERROR: buffer pointer initialization of read() step 2+ failed\n");
++            close(fd);
++            return -1;
++        }
++        if (read(fd,buf,read_num) != read_num) {
++            printf("ERROR: read() failed\n");
++            close(fd);
++            return -1;
++        }
++        memcpy(c+i,buf,read_num);
+     }
+-    memcpy(c,rbuf+addr,len);
+     close(fd);
+     return 0;
+ }
+@@ -66,19 +69,20 @@ int read_sys_eeprom(void *eeprom_data, int offset, int len)
   */
  int write_sys_eeprom(void *eeprom_data, int len)
  {
--    int ret = 0;
-+    //mcp2221 write cmd, two bytes header. Always two bytes ahead datas. 
-+    //Second byte also can decide write start addrress. Here is 0x00, no address shift with EEPROM.
-+    unsigned char tmp[SYS_EEPROM_SIZE+2] = {0x00, 0x00};
-+
-     struct eeprom e;
--    int i = 0;
-     u_int8_t *c;
--    u_int16_t  addr = SYS_EEPROM_OFFSET;
--
-     c = eeprom_data;
--    for (i = 0; i < len; i++) {
--	if (eeprom_open(SYS_EEPROM_I2C_DEVICE, SYS_EEPROM_I2C_ADDR,
--			EEPROM_TYPE, &e)) {
--	    printf("ERROR: Cannot open I2C device\n");
--	    return -1;
--	}
--	eeprom_write_byte(&e, addr, *c);
--	eeprom_close(&e);
--	c++; addr++;
-+    int fd = open(SYS_EEPROM_I2C_DEVICE, O_RDWR);
-+    if (fd < 0) {
-+        printf("ERROR: open(%d) failed\n", fd);
-+        return -1;
-     }
-+    //printf("\nSUCCESS: open(%d) passed\n", fd);
+-    //mcp2221 write cmd, two bytes header. Always two bytes ahead datas. 
+-    //Second byte also can decide write start addrress. Here is 0x00, no address shift with EEPROM.
+-    unsigned char tmp[SYS_EEPROM_SIZE+2] = {0x00, 0x00};
++    //mcp2221 write cmd, two bytes for header.
++    //First two byte decide write start addrress with EEPROM. Here is 0x0000, no address shift by default.
++    unsigned char tmp[18] = {0};
++    unsigned int i;
  
--    return ret;
-+    int status;
-+    // SETTING EEPROM ADDR
-+    status = ioctl(fd, I2C_SLAVE, SYS_EEPROM_I2C_ADDR);
-+    if (status < 0)
-+    {
-+        printf("ERROR: ioctl(fd, I2C_SLAVE, 0x%02X) failed\n", SYS_EEPROM_I2C_ADDR);
-+        close(fd);
-+        return -1;
+     struct eeprom e;
+     u_int8_t *c;
+     c = eeprom_data;
++
+     int fd = open(SYS_EEPROM_I2C_DEVICE, O_RDWR);
+     if (fd < 0) {
+         printf("ERROR: open(%d) failed\n", fd);
+         return -1;
+     }
+-    //printf("\nSUCCESS: open(%d) passed\n", fd);
+ 
+     int status;
+     // SETTING EEPROM ADDR
+@@ -90,13 +94,40 @@ int write_sys_eeprom(void *eeprom_data, int len)
+         return -1;
+     }
+ 
+-    memcpy(tmp+2, c, len);
+-    if(write(fd,tmp, len+2) != (len+2))
++    //write 16 bytes everytime. first 2 bytes are write addresses.
++    for(i = 0; i < len; i+=16)
+     {
+-        printf("EEPROM write error, return -1. \n");
+-        close(fd);
+-        return -1;
++        int write_num = (len-i)>15?16:(len-i);
++        tmp[0] = (u_int8_t)(i/256);
++        tmp[1] = i;
++        memcpy(tmp+2, c+i, write_num);
++
++        if(write(fd,tmp,18)!=18){
++            printf("ERROR: buffer pointer initialization of read() step 2+ failed\n");
++            close(fd);
++            return -1;
++        }
 +    }
 +
-+    memcpy(tmp+2, c, len);
-+    if(write(fd,tmp, len+2) != (len+2))
++    /*
++    // for get and dump values if needed.
++    unsigned char buf[1] = {0};
++    for(i = 0; i<11; i++)
 +    {
-+        printf("EEPROM write error, return -1. \n");
-+        close(fd);
-+        return -1;
-+    }
-+    close(fd);
-+    return 0;
++        tmp[0] = (u_int8_t)(i/256);
++        tmp[1] = i & 0x00ff;
++
++        if(write(fd,tmp,2)!=2){
++        printf("ERROR: buffer pointer initialization of read() step 2+ failed\n");
++        }
++
++        if (read(fd,buf,1) != 1) {
++        printf("ERROR: read() failed\n");
++        }
++        printf("%d=0x%02X(%d) \r\n", i, buf[0],buf[0]);
+     }
++    */
++    
+     close(fd);
+     return 0;
  }


### PR DESCRIPTION
…Ex, when write 65 byte once, the 65th byte will write to 1st byte address.

Seems it will always write at (n%64) byte, where n is number of bytes to write, and happened with n>64.
Do not know what happened with usb to i2c chip now.
After force try, get a number 16, it will clear overwrite issue, 8 seems OK, too.