### PR TITLE
install mode: sync data to storage after making install boot mode sticky

### DIFF
--- a/rootconf/x86_64/sysroot-lib-onie/boot-mode-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/boot-mode-arch
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -26,6 +27,7 @@ install_remain_sticky_arch()
     else
         bios_boot_onie_install
     fi
+    sync;sync
 
     return 0
 }


### PR DESCRIPTION
Force to write data to storage after making install boot mode sticky.
It will prevent grub to be invalid after entering linux shell and power
off suddenly.

The issue was reported in
https://github.com/opencomputeproject/onie/issues/250

This patch has been tested in Accton AS5512_54X.