### PR TITLE
regression: IPv6 neighbor discovery broken

### DIFF
--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -83,8 +83,8 @@ config_ethmgmt_fallback()
     local intf=$1
     shift
 
-    # Remove any previously configured IP address
-    ip addr flush $intf
+    # Remove any previously configured, IPv4 addresses
+    ip -f inet addr flush dev $intf
 
     # Assign sequential static IP to each detected interface
     local interface_base_ip=$(( $base_ip + $intf_counter ))


### PR DESCRIPTION
It looks like commit: https://github.com/opencomputeproject/onie/commit/a02b948cec3eaa6fcd7ea800d667d4afacfbbcf3 is the offending commit.

In particular, this line: https://github.com/opencomputeproject/onie/blob/master/rootconf/default/etc/init.d/networking.sh#L87

When an interface is flushed, all addresses are removed (including IPv6 link local).  In order for an IPv6 to come back, the interface must be downed and then brought back up.  In order for IPv6 neighbor discovery to work, ONIE must have received an IP address via:
* static from command line (GRUB or uboot)
* DHCPv4

For resolution, currently looking at ways to remove all non-link local addresses to resolve this bug.