### PR TITLE
grub: build x86_64-efi if UEFI_ENABLE=yes or PXE_EFI64_ENABLE=yes

### DIFF
--- a/build-config/scripts/onie-mk-iso.sh
+++ b/build-config/scripts/onie-mk-iso.sh
@@ -70,14 +70,16 @@ RECOVERY_ISO_IMAGE=${11}
     echo "ERROR: Does not look like valid GRUB i386-pc bin directory: $GRUB_HOST_BIN_I386_DIR"
     exit 1
 }
-[ -r "${GRUB_HOST_LIB_UEFI_DIR}/efinet.mod" ] || {
-    echo "ERROR: Does not look like valid GRUB x86_64-efi library directory: $GRUB_HOST_LIB_UEFI_DIR"
-    exit 1
-}
-[ -x "${GRUB_HOST_BIN_UEFI_DIR}/grub-mkimage" ] || {
-    echo "ERROR: Does not look like valid GRUB x86_64-efi bin directory: $GRUB_HOST_BIN_UEFI_DIR"
-    exit 1
-}
+if [ "$UEFI_ENABLE" = "yes" ] ; then
+    [ -r "${GRUB_HOST_LIB_UEFI_DIR}/efinet.mod" ] || {
+        echo "ERROR: Does not look like valid GRUB x86_64-efi library directory: $GRUB_HOST_LIB_UEFI_DIR"
+        exit 1
+    }
+    [ -x "${GRUB_HOST_BIN_UEFI_DIR}/grub-mkimage" ] || {
+        echo "ERROR: Does not look like valid GRUB x86_64-efi bin directory: $GRUB_HOST_BIN_UEFI_DIR"
+        exit 1
+    }
+fi
 [ -r "$RECOVERY_XORRISO_OPTIONS" ] || {
     echo "ERROR: Unable to read xorriso options file: $RECOVERY_XORRISO_OPTIONS"
     exit 1


### PR DESCRIPTION
Refine ``grub.make`` to build x86_64-efi grub tools if
``UEFI_ENABLE=yes`` or ``PXE_EFI64_ENABLE=yes``.  It will reduce the
build time and ISO image size if EFI features are disabled.

Cases tested:

- UEFI_ENABLE=yes, PXE_EFI64_ENABLE=yes
- UEFI_ENABLE=yes, PXE_EFI64_ENABLE=no
- UEFI_ENABLE=no, PXE_EFI64_ENABLE=yes
- UEFI_ENABLE=no, PXE_EFI64_ENABLE=no