### PR TITLE
workaround solution for halt issue on Inventec D6254QS and DCS7032Q28…

### DIFF
--- a/machine/inventec/inventec_d6254qs/busybox/patches/series
+++ b/machine/inventec/inventec_d6254qs/busybox/patches/series
@@ -1,1 +1,2 @@
 onie-syseeprom-write-delay.patch
+workaround-halt-issue.patch

--- a/machine/inventec/inventec_d6254qs/busybox/patches/workaround-halt-issue.patch
+++ b/machine/inventec/inventec_d6254qs/busybox/patches/workaround-halt-issue.patch
@@ -1,0 +1,31 @@
+workaround solution for halt issue
+
+diff --git a/init/halt.c b/init/halt.c
+index 7974adb..b4612fd 100644
+--- a/init/halt.c
++++ b/init/halt.c
+@@ -99,11 +99,11 @@ int halt_main(int argc, char **argv) MAIN_EXTERNALLY_VISIBLE;
+ int halt_main(int argc UNUSED_PARAM, char **argv)
+ {
+ 	static const int magic[] = {
+-		RB_HALT_SYSTEM,
+-		RB_POWER_OFF,
++		RB_AUTOBOOT,
++		RB_AUTOBOOT,
+ 		RB_AUTOBOOT
+ 	};
+-	static const smallint signals[] = { SIGUSR1, SIGUSR2, SIGTERM };
++	static const smallint signals[] = {SIGTERM , SIGTERM, SIGTERM };
+ 
+ 	int delay = 0;
+ 	int which, flags, rc;
+@@ -156,7 +156,7 @@ int halt_main(int argc UNUSED_PARAM, char **argv)
+ 				 * 6 == reboot */
+ 				execlp(CONFIG_TELINIT_PATH,
+ 						CONFIG_TELINIT_PATH,
+-						which == 2 ? "6" : "0",
++						"6" ,
+ 						(char *)NULL
+ 				);
+ 				bb_perror_msg_and_die("can't execute '%s'",
+

--- a/machine/inventec/inventec_dcs7032q28/busybox/patches/series
+++ b/machine/inventec/inventec_dcs7032q28/busybox/patches/series
@@ -1,1 +1,2 @@
 onie-syseeprom-write-delay.patch
+workaround-halt-issue.patch

--- a/machine/inventec/inventec_dcs7032q28/busybox/patches/workaround-halt-issue.patch
+++ b/machine/inventec/inventec_dcs7032q28/busybox/patches/workaround-halt-issue.patch
@@ -1,0 +1,31 @@
+workaround solution for halt issue
+
+diff --git a/init/halt.c b/init/halt.c
+index 7974adb..b4612fd 100644
+--- a/init/halt.c
++++ b/init/halt.c
+@@ -99,11 +99,11 @@ int halt_main(int argc, char **argv) MAIN_EXTERNALLY_VISIBLE;
+ int halt_main(int argc UNUSED_PARAM, char **argv)
+ {
+ 	static const int magic[] = {
+-		RB_HALT_SYSTEM,
+-		RB_POWER_OFF,
++		RB_AUTOBOOT,
++		RB_AUTOBOOT,
+ 		RB_AUTOBOOT
+ 	};
+-	static const smallint signals[] = { SIGUSR1, SIGUSR2, SIGTERM };
++	static const smallint signals[] = {SIGTERM , SIGTERM, SIGTERM };
+ 
+ 	int delay = 0;
+ 	int which, flags, rc;
+@@ -156,7 +156,7 @@ int halt_main(int argc UNUSED_PARAM, char **argv)
+ 				 * 6 == reboot */
+ 				execlp(CONFIG_TELINIT_PATH,
+ 						CONFIG_TELINIT_PATH,
+-						which == 2 ? "6" : "0",
++						"6" ,
+ 						(char *)NULL
+ 				);
+ 				bb_perror_msg_and_die("can't execute '%s'",
+


### PR DESCRIPTION
On Inventec D6254QS and DCS7302Q28 platform, if "halt" , "poweroff" command are issued, DUT cannot power on.  we give the workaround soutiion as follows:

halt , poweroff command  behaves like  "reboot" command