### PR TITLE
AS4610 series i2c-0 can't find 0x30 slave device

### DIFF
--- a/machine/accton/accton_as4610_30/kernel/platform-as4610_30.patch
+++ b/machine/accton/accton_as4610_30/kernel/platform-as4610_30.patch
@@ -1314,7 +1314,7 @@ index 3e0f520..852b409 100755
  #elif defined(CONFIG_MACH_HR2)
  	.irqs = {214, 215, 216, 217, 218, 219},
 diff --git a/drivers/bcmdrivers/smbus/iproc_smbus.c b/drivers/bcmdrivers/smbus/iproc_smbus.c
-index 8ee9bf6..361684a 100644
+index 8ee9bf6..16db142 100644
 --- a/drivers/bcmdrivers/smbus/iproc_smbus.c
 +++ b/drivers/bcmdrivers/smbus/iproc_smbus.c
 @@ -1533,8 +1533,12 @@ static int iproc_smbus_block_init(struct iproc_smb_drv_int_data *dev)
@@ -1323,7 +1323,7 @@ index 8ee9bf6..361684a 100644
  
 -
      /* Set default clock frequency */
-+    #if defined(CONFIG_MACH_ACCTON_AS4610_30P)
++#if defined(CONFIG_MACH_ACCTON_AS4610_30)
 +    if (dev->adapter.nr == 0)
 +        iproc_smb_set_clk_freq(base_addr, I2C_SPEED_400KHz);
 +    else

--- a/machine/accton/accton_as4610_30/kernel/series
+++ b/machine/accton/accton_as4610_30/kernel/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit f32ec8d2da74f4d37138aec8864eb33b1cd6367c
+# This series applies on GIT commit 22b64f508d57bf7b33fe6d1da2ba25b7eb34d3b3
 platform-as4610_30.patch

--- a/machine/accton/accton_as4610_54/kernel/platform-as4610_54.patch
+++ b/machine/accton/accton_as4610_54/kernel/platform-as4610_54.patch
@@ -1314,7 +1314,7 @@ index 3e0f520..40a6673 100755
  #elif defined(CONFIG_MACH_HR2)
  	.irqs = {214, 215, 216, 217, 218, 219},
 diff --git a/drivers/bcmdrivers/smbus/iproc_smbus.c b/drivers/bcmdrivers/smbus/iproc_smbus.c
-index 8ee9bf6..e6d26e4 100644
+index 8ee9bf6..e5ddb16 100644
 --- a/drivers/bcmdrivers/smbus/iproc_smbus.c
 +++ b/drivers/bcmdrivers/smbus/iproc_smbus.c
 @@ -1533,8 +1533,12 @@ static int iproc_smbus_block_init(struct iproc_smb_drv_int_data *dev)
@@ -1323,7 +1323,7 @@ index 8ee9bf6..e6d26e4 100644
  
 -
      /* Set default clock frequency */
-+    #if defined(CONFIG_MACH_ACCTON_AS4610_54P)
++#if defined(CONFIG_MACH_ACCTON_AS4610_54)
 +    if (dev->adapter.nr == 0)
 +        iproc_smb_set_clk_freq(base_addr, I2C_SPEED_400KHz);
 +    else

--- a/machine/accton/accton_as4610_54/kernel/series
+++ b/machine/accton/accton_as4610_54/kernel/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit f32ec8d2da74f4d37138aec8864eb33b1cd6367c
+# This series applies on GIT commit fe33eb5d4d09a680586a222d315c711d8ff7daa9
 platform-as4610_54.patch

--- a/patches/kernel/3.2.69/arch-intel-centerton-pci-id.patch
+++ b/patches/kernel/3.2.69/arch-intel-centerton-pci-id.patch
@@ -11,10 +11,10 @@ This device ID is used by a number of drivers, including GPIO and
 Multifunction Devices.
 
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 1874c5e..66a3a9e 100644
+index d93f417..d35b1f4 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
-@@ -2481,6 +2481,7 @@
+@@ -2484,6 +2484,7 @@
  #define PCI_DEVICE_ID_INTEL_MRST_SD2	0x084F
  #define PCI_DEVICE_ID_INTEL_I960	0x0960
  #define PCI_DEVICE_ID_INTEL_I960RM	0x0962

--- a/patches/kernel/3.2.69/arch-powerpc-emulated-lwsync.patch
+++ b/patches/kernel/3.2.69/arch-powerpc-emulated-lwsync.patch
@@ -19,7 +19,7 @@ index 63f2a22..093359a 100644
  	struct ppc_emulated_entry math;
  #elif defined(CONFIG_8XX_MINIMAL_FPEMU)
 diff --git a/arch/powerpc/kernel/traps.c b/arch/powerpc/kernel/traps.c
-index 82dcd4d..01d703c 100644
+index 9844662..a689b66 100644
 --- a/arch/powerpc/kernel/traps.c
 +++ b/arch/powerpc/kernel/traps.c
 @@ -928,6 +928,14 @@ static int emulate_instruction(struct pt_regs *regs)
@@ -37,7 +37,7 @@ index 82dcd4d..01d703c 100644
  #ifdef CONFIG_PPC64
  	/* Emulate the mfspr rD, DSCR. */
  	if (((instword & PPC_INST_MFSPR_DSCR_MASK) == PPC_INST_MFSPR_DSCR) &&
-@@ -1532,6 +1540,7 @@ struct ppc_emulated ppc_emulated = {
+@@ -1542,6 +1550,7 @@ struct ppc_emulated ppc_emulated = {
  	WARN_EMULATED_SETUP(spe),
  	WARN_EMULATED_SETUP(string),
  	WARN_EMULATED_SETUP(unaligned),

--- a/patches/kernel/3.2.69/arch-powerpc-os-driven-pci-maxpayload-readreq-setup.patch
+++ b/patches/kernel/3.2.69/arch-powerpc-os-driven-pci-maxpayload-readreq-setup.patch
@@ -27,10 +27,10 @@ are powers of 2 starting at 128...
 7 -> 16,384
 
 diff --git a/arch/powerpc/kernel/pci-common.c b/arch/powerpc/kernel/pci-common.c
-index 9508bec..abb9e95 100644
+index 6ce6a23..63c2ab1 100644
 --- a/arch/powerpc/kernel/pci-common.c
 +++ b/arch/powerpc/kernel/pci-common.c
-@@ -1697,6 +1697,62 @@ struct device_node *pcibios_get_phb_of_node(struct pci_bus *bus)
+@@ -1696,6 +1696,62 @@ struct device_node *pcibios_get_phb_of_node(struct pci_bus *bus)
  	return of_node_get(hose->dn);
  }
  
@@ -93,7 +93,7 @@ index 9508bec..abb9e95 100644
  /**
   * pci_scan_phb - Given a pci_controller, setup and scan the PCI bus
   * @hose: Pointer to the PCI host controller instance structure
-@@ -1706,6 +1762,7 @@ void __devinit pcibios_scan_phb(struct pci_controller *hose)
+@@ -1705,6 +1761,7 @@ void __devinit pcibios_scan_phb(struct pci_controller *hose)
  	struct pci_bus *bus;
  	struct device_node *node = hose->dn;
  	int mode;
@@ -101,7 +101,7 @@ index 9508bec..abb9e95 100644
  
  	pr_debug("PCI: Scanning PHB %s\n",
  		 node ? node->full_name : "<NO NAME>");
-@@ -1739,6 +1796,24 @@ void __devinit pcibios_scan_phb(struct pci_controller *hose)
+@@ -1738,6 +1795,24 @@ void __devinit pcibios_scan_phb(struct pci_controller *hose)
  	if (mode == PCI_PROBE_NORMAL)
  		hose->last_busno = bus->subordinate = pci_scan_child_bus(bus);
  

--- a/patches/kernel/3.2.69/arch-powerpc-warn-unmapped-irq.patch
+++ b/patches/kernel/3.2.69/arch-powerpc-warn-unmapped-irq.patch
@@ -5,10 +5,10 @@ Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
 SPDX-License-Identifier:     GPL-2.0
 
 diff --git a/arch/powerpc/kernel/pci-common.c b/arch/powerpc/kernel/pci-common.c
-index 458ed3b..9508bec 100644
+index 12659ab..6ce6a23 100644
 --- a/arch/powerpc/kernel/pci-common.c
 +++ b/arch/powerpc/kernel/pci-common.c
-@@ -1112,6 +1112,13 @@ void __devinit pcibios_setup_bus_devices(struct pci_bus *bus)
+@@ -1111,6 +1111,13 @@ void __devinit pcibios_setup_bus_devices(struct pci_bus *bus)
  			ppc_md.pci_dma_dev_setup(dev);
  
  		/* Read default IRQs and fixup if necessary */

--- a/patches/kernel/3.2.69/driver-gpio-intel-ich.patch
+++ b/patches/kernel/3.2.69/driver-gpio-intel-ich.patch
@@ -1,4 +1,4 @@
-Back port gpio-ich.c driver for Intel Avoton 
+Back port gpio-ich.c driver for Intel Avoton
 See linux-stable commit : a7008ee1a423720e755e08f33b63669795c1f072
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig

--- a/patches/kernel/3.2.69/driver-run-time-cfi-byte-swapping.patch
+++ b/patches/kernel/3.2.69/driver-run-time-cfi-byte-swapping.patch
@@ -222,7 +222,7 @@ index 51cc3f5..c785284 100644
  #error No CFI endianness defined
  #endif
 diff --git a/include/linux/mtd/map.h b/include/linux/mtd/map.h
-index daad4e6..cc5613a 100644
+index 3887901..b8ca7de 100644
 --- a/include/linux/mtd/map.h
 +++ b/include/linux/mtd/map.h
 @@ -219,6 +219,10 @@ struct map_info {

--- a/patches/kernel/3.2.69/driver-support-intel-avoton-ethernet-with-broadcom-phy.patch
+++ b/patches/kernel/3.2.69/driver-support-intel-avoton-ethernet-with-broadcom-phy.patch
@@ -5,7 +5,7 @@ Copyright (C) 2014 david_yang <david_yang@accton.com>
 SPDX-License-Identifier:     GPL-2.0
 
 diff --git a/drivers/net/ethernet/intel/igb/e1000_82575.c b/drivers/net/ethernet/intel/igb/e1000_82575.c
-index 7881fb9..f772df0 100644
+index 7881fb9..833f86f 100644
 --- a/drivers/net/ethernet/intel/igb/e1000_82575.c
 +++ b/drivers/net/ethernet/intel/igb/e1000_82575.c
 @@ -146,6 +146,9 @@ static s32 igb_get_invariants_82575(struct e1000_hw *hw)
@@ -51,7 +51,7 @@ index f5fc572..88be58d 100644
  /* M88E1000 Specific Registers */
  #define M88E1000_PHY_SPEC_CTRL     0x10  /* PHY Specific Control Register */
 diff --git a/drivers/net/ethernet/intel/igb/e1000_hw.h b/drivers/net/ethernet/intel/igb/e1000_hw.h
-index 4519a13..25a0886 100644
+index 4519a13..ab7c843 100644
 --- a/drivers/net/ethernet/intel/igb/e1000_hw.h
 +++ b/drivers/net/ethernet/intel/igb/e1000_hw.h
 @@ -63,6 +63,9 @@ struct e1000_hw;
@@ -73,7 +73,7 @@ index 4519a13..25a0886 100644
  
  enum e1000_bus_type {
 diff --git a/drivers/net/ethernet/intel/igb/igb_main.c b/drivers/net/ethernet/intel/igb/igb_main.c
-index 222954d..4ac5f33 100644
+index b555be0..6704fff 100644
 --- a/drivers/net/ethernet/intel/igb/igb_main.c
 +++ b/drivers/net/ethernet/intel/igb/igb_main.c
 @@ -72,6 +72,9 @@ static const struct e1000_info *igb_info_tbl[] = {

--- a/patches/kernel/3.2.69/git-ignore.patch
+++ b/patches/kernel/3.2.69/git-ignore.patch
@@ -1,6 +1,7 @@
 Supplement the kernel's .gitignore
 
 Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+Copyright (C) 2015 david_yang <david_yang@accton.com>
 
 SPDX-License-Identifier:     GPL-2.0
 
@@ -19,6 +20,15 @@ index 57af07c..3eaa29a 100644
  /vmlinuz
  /System.map
  /Module.markers
+diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
+index ce1c5ff..3c79f85 100644
+--- a/arch/arm/boot/.gitignore
++++ b/arch/arm/boot/.gitignore
+@@ -3,3 +3,4 @@ zImage
+ xipImage
+ bootpImage
+ uImage
++*.dtb
 diff --git a/arch/powerpc/boot/.gitignore b/arch/powerpc/boot/.gitignore
 index 12da77e..652e35d 100644
 --- a/arch/powerpc/boot/.gitignore

--- a/patches/kernel/3.2.69/series
+++ b/patches/kernel/3.2.69/series
@@ -1,4 +1,4 @@
-# This series applies on GIT commit 8a76aa775d70ed7f79e50f2b44d1e9bec039b2b2
+# This series applies on GIT commit 0c01d4293c83777212ac0909c3351e538437b0dd
 git-ignore.patch
 arch-powerpc-emulated-lwsync.patch
 arch-powerpc-jtag.patch


### PR DESCRIPTION
There are two commits in the PR:

- linux-3.2.69: append *.dtb to arch/arm/boot/.gitignore
- Accton AS4610: fix scanning no i2c slave device in i2c-0 issue
