### PR TITLE
Fixes so ONIE builds on OpenSUSE 13.2

### DIFF
--- a/build-config/make/demo.make
+++ b/build-config/make/demo.make
@@ -62,7 +62,8 @@ demo-sysroot-complete: $(DEMO_SYSROOT_COMPLETE_STAMP)
 $(DEMO_SYSROOT_COMPLETE_STAMP): $(SYSROOT_CPIO_XZ)
 	$(Q) rm -rf $(DEMO_SYSROOTDIR)
 	$(Q) echo "==== Copying existing ONIE sysroot ===="
-	$(Q) cp -a $(SYSROOTDIR) $(DEMO_SYSROOTDIR)
+	#Note - ignore error as the device nodes don't copy due to root permissions. We recreate those
+	$(Q) -- cp -a $(SYSROOTDIR) $(DEMO_SYSROOTDIR)
 	$(Q) cd $(DEMO_SYSROOTDIR) && rm $(DEMO_TRIM)
 	$(Q) sed -i -e '/onie/d' $(DEMO_SYSROOTDIR)/etc/syslog.conf
 	$(Q) cd $(DEMO_OS_DIR) && $(SCRIPTDIR)/install-rootfs.sh default $(DEMO_SYSROOTDIR)

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -183,9 +183,7 @@ $(SYSROOT_CHECK_STAMP): $(PACKAGES_INSTALL_STAMPS)
 	$(Q) mkdir -p $(CHECKROOT) && \
 	     $(CROSSBIN)/$(CROSSPREFIX)populate -r $(DEV_SYSROOT) \
 		-s $(SYSROOTDIR) -d $(CHECKDIR) && \
-		(cd $(SYSROOTDIR) && find . > $(SYSFILES)) && \
-		(cd $(CHECKDIR) && find . > $(CHECKFILES)) && \
-		diff -q $(SYSFILES) $(CHECKFILES) > /dev/null 2>&1 || { \
+		diff -qr $(SYSROOTDIR) $(CHECKDIR) > /dev/null 2>&1 || { \
 			(echo "ERROR: Missing files in SYSROOTDIR:" && \
 			 diff $(SYSFILES) $(CHECKFILES) ; \
 			 false) \


### PR DESCRIPTION
Hi,

This is minor....but figured I'd post it in case it's useful to others. 

I had a couple of issues building ONIE on my openSUSE 13.2 based machine that I finally got around to looking into:

1) The sysroot-check stage would fail. The find commands would find the same files but they would be ordered differently so when comparing it would fail. I replaced it using diff -qr for the directories and that works and is I think equivalent and simpler too.

2) When creating the demo installer image the cp of the main sysroot to the demo sysroot hits a bunch of errors in the device nodes due to file permissions (we're not root). This causes the Makefile to bomb out and means the demo installer doesn't get built. As the device nodes get recreated further down I figured ignoring the errors was OK.....not a pretty solution but it works and anything else seemed somewhat complicated :) 

These changes worked on a debian 8 and ubuntu 14.04 setup. 
