### PR TITLE
exec_installer: escape any % characters for printing with printf

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -143,8 +143,10 @@ wget_run()
     header_operation="ONIE-OPERATION: $onie_operation"
     header_version="ONIE-VERSION: $onie_version"
 
-    log_debug_msg "Running wget with: $user_agent $wget_args $URL\n"
-    log_info_msg "Fetching $URL ..."
+    # escape any % characters for printing with printf
+    print_exec_url=$(echo -n $URL | sed -e 's/%/%%/g')
+    log_debug_msg "Running wget with: $user_agent $wget_args $print_exec_url\n"
+    log_info_msg "Fetching $print_exec_url ..."
     wget -U "$user_agent" $wget_args       \
         --header "$header_serial_num"   \
         --header "$header_eth_addr"     \


### PR DESCRIPTION
Fixing the printing issue:

    ONIE: Using DHCPv4 addr: eth0: 192.168.1.21 / 255.255.255.0
    ONIE: Starting ONIE Service Discovery
    Info: Fetching http://fe80::20c:29ff:fee4:ecfa0.000000e+00th0/onie-installer-x86_64-accton_wedge_16x-r0 ...
    Info: Fetching http://fe80::20c:29ff:fee4:ecfa0.000000e+00th0/onie-installer-x86_64-accton_wedge_16x ...
    Info: Fetching http://fe80::20c:29ff:fee4:ecfa0.000000e+00th0/onie-installer-accton_wedge_16x ...
    Info: Fetching http://fe80::20c:29ff:fee4:ecfa0.000000e+00th0/onie-installer-x86_64 ...
    Info: Fetching http://fe80::20c:29ff:fee4:ecfa0.000000e+00th0/onie-installer ...

Tested in Accton Wedge_16X