### PR TITLE
kexec-tools: back port upstream patch for better device tree handling

### DIFF
--- a/build-config/make/kexec-tools.make
+++ b/build-config/make/kexec-tools.make
@@ -29,7 +29,7 @@ KEXEC_STAMP		= $(KEXEC_SOURCE_STAMP) \
 			  $(KEXEC_BUILD_STAMP) \
 			  $(KEXEC_INSTALL_STAMP)
 
-PHONY += kexec-tools kexec-tools-download kexec-tools-source \
+PHONY += kexec-tools kexec-tools-download kexec-tools-source kexec-tools-patch \
 	 kexec-tools-configure kexec-tools-build kexec-tools-install kexec-tools-clean \
 	 kexec-tools-download-clean
 
@@ -54,12 +54,19 @@ $(KEXEC_SOURCE_STAMP): $(TREE_STAMP) | $(KEXEC_DOWNLOAD_STAMP)
 	$(Q) $(SCRIPTDIR)/extract-package $(KEXEC_BUILD_DIR) $(DOWNLOADDIR)/$(KEXEC_TARBALL)
 	$(Q) touch $@
 
+kexec-tools-patch: $(KEXEC_PATCH_STAMP)
+$(KEXEC_PATCH_STAMP): $(KEXEC_SOURCE_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "====  Patching kexec-tools-$(KEXEC_VERSION) ===="
+	$(Q) $(SCRIPTDIR)/apply-patch-series $(KEXEC_SRCPATCHDIR)/series $(KEXEC_DIR)
+	$(Q) touch $@
+
 # For PowerPC add booke support
 powerpc_KEXEC_CONFIG_OPTS = --with-booke
 
 kexec-tools-configure: $(KEXEC_CONFIGURE_STAMP)
 $(KEXEC_CONFIGURE_STAMP): $(ZLIB_INSTALL_STAMP) \
-				$(KEXEC_SOURCE_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+				$(KEXEC_PATCH_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure kexec-tools-$(KEXEC_VERSION) ===="
 	$(Q) cd $(KEXEC_DIR) && PATH='$(CROSSBIN):$(PATH)'	\

--- a/patches/kexec-tools/0001-Improve-device-tree-directory-sorting.patch
+++ b/patches/kexec-tools/0001-Improve-device-tree-directory-sorting.patch
@@ -1,0 +1,84 @@
+From 0e1030b345b9e7c1c64b85dde32a282a19b825f0 Mon Sep 17 00:00:00 2001
+From: Curt Brune <curt@cumulusnetworks.com>
+Date: Tue, 24 Nov 2015 18:17:10 -0800
+Subject: [PATCH 1/1] Improve device tree directory sorting
+
+Previously when sorting the device tree directory entries, if both
+device tree entries contained the '@' character then comparison was
+made based on the length of the strings.
+
+This did not work in all cases and could result in odd orderings.
+
+This patch modifies the comparison function for the case when both
+strings contain the '@' character.
+
+First a lexical comparison is made between the prefix portions of the
+strings *before* the '@' character.
+
+Next, if the prefixes are equal, the lengths of the suffixes *after*
+the '@' character are compared.  This preserves the intent of the
+original code.
+
+Next, if the suffix lengths are equal, a lexical comparison of the
+suffixes is made.
+
+This is still not strictly correct, as ideally the portion after the
+'@' should be compared numerically.  However, determining what base to
+use for all case is difficult.
+
+Signed-off-by: Curt Brune <curt@cumulusnetworks.com>
+Signed-off-by: Simon Horman <horms@verge.net.au>
+---
+ kexec/arch/ppc/fs2dt.c | 21 +++++++++++++++++----
+ 1 file changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/kexec/arch/ppc/fs2dt.c b/kexec/arch/ppc/fs2dt.c
+index 4121c7d..6e77379 100644
+--- a/kexec/arch/ppc/fs2dt.c
++++ b/kexec/arch/ppc/fs2dt.c
+@@ -30,6 +30,7 @@
+ #include <stdio.h>
+ #include "../../kexec.h"
+ #include "kexec-ppc.h"
++#include "types.h"
+ 
+ #define MAXPATH			1024	/* max path name length */
+ #define NAMESPACE		16384	/* max bytes for property names */
+@@ -296,6 +297,8 @@ static int comparefunc(const void *dentry1, const void *dentry2)
+ {
+ 	char *str1 = (*(struct dirent **)dentry1)->d_name;
+ 	char *str2 = (*(struct dirent **)dentry2)->d_name;
++	char *p1, *p2;
++	int res = 0, max_len;
+ 
+ 	/*
+ 	 * strcmp scans from left to right and fails to idetify for some
+@@ -303,11 +306,21 @@ static int comparefunc(const void *dentry1, const void *dentry2)
+ 	 * Therefore, we get the wrong sorted order like memory@10000000 and
+ 	 * memory@f000000.
+ 	 */
+-	if (strchr(str1, '@') && strchr(str2, '@') &&
+-		(strlen(str1) > strlen(str2)))
+-		return 1;
++	if ((p1 = strchr(str1, '@')) && (p2 = strchr(str2, '@'))) {
++		max_len = max(p1 - str1, p2 - str2);
++		if ((res = strncmp(str1, str2, max_len)) == 0) {
++			/* prefix is equal - compare part after '@' by length */
++			p1++; p2++;
++			res = strlen(p1) - strlen(p2);
++			if (res == 0)
++				/* equal length, compare by strcmp() */
++				res = strcmp(p1,p2);
++		}
++        } else {
++		res = strcmp(str1, str2);
++        }
+ 
+-	return strcmp(str1, str2);
++	return res;
+ }
+ 
+ /*
+-- 
+1.9.1
+

--- a/patches/kexec-tools/series
+++ b/patches/kexec-tools/series
@@ -1,0 +1,2 @@
+# This series applies on GIT commit db8668ed563d446839f25150fb1ba24721d7c4be
+0001-Improve-device-tree-directory-sorting.patch


### PR DESCRIPTION
Back port upstream patch for better device tree handling:
https://git.kernel.org/cgit/utils/kernel/kexec/kexec-tools.git/commit/?id=0e1030b345b9e7c1c64b85dde32a282a19b825f0

With this patch in place for PowerPC systems one can kexec without specifying a .dtb file, simply reusing the device tree from the running ONIE kernel.
