### PR TITLE
grub: reduce time took during making install boot mode sticky

### DIFF
--- a/build-config/make/demo.make
+++ b/build-config/make/demo.make
@@ -51,7 +51,9 @@ DEMO_TRIM = \
    etc/rc0.d/K25discover.sh	\
    etc/rc3.d/S50discover.sh	\
    etc/rc6.d/K25discover.sh	\
+   etc/rcS.d/S03boot-mode.sh	\
    etc/init.d/discover.sh	\
+   etc/init.d/boot-mode.sh	\
    bin/discover			\
    bin/uninstaller		\
    bin/onie-uninstaller		\

--- a/installer/x86_64/install-arch
+++ b/installer/x86_64/install-arch
@@ -499,6 +499,14 @@ install_grub()
     local location="$1"
     local boot_dev="$2"
     local boot_dir="$3"
+    if [ "$onie_firmware" = "coreboot" ] ; then
+        local grub_target="i386-coreboot"
+        local core_img="$boot_dir/grub/$grub_target/core.elf"
+    else
+        local grub_target="i386-pc"
+        local core_img="$boot_dir/grub/$grub_target/core.img"
+    fi
+    local grub_lib_dir="/usr/lib/grub/$grub_target"
 
     [ "$verbose" = "yes" ] && echo "Installing GRUB in device: $boot_dev, boot-directory: $boot_dir"
 
@@ -519,18 +527,14 @@ install_grub()
         # boot sector or a partitionless disk, not in case of
         # installation to MBR.
 
-        core_img="$boot_dir/grub/i386-pc/core.img"
         # remove immutable flag if file exists during an update.
         [ -f "$core_img" ] && chattr -i $core_img
     fi
 
-    grub_install_target=i386-pc
-    [ "${onie_firmware}" = "coreboot" ] && grub_install_target=i386-coreboot
-    grub_install_directory=/usr/lib/grub/${grub_install_target}
     grub_install_log=$(mktemp)
     grub-install \
-        --target=${grub_install_target} \
-        --directory=${grub_install_directory} \
+        --target="$grub_target" \
+        --directory="$grub_lib_dir" \
         --force \
         --boot-directory="$boot_dir" \
         --recheck \

--- a/rootconf/default/etc/init.d/boot-mode.sh
+++ b/rootconf/default/etc/init.d/boot-mode.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+#  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+cmd="$1"
+
+. /lib/onie/functions
+
+import_cmdline
+
+# We want rescue mode booting to be a one time operation.  After the
+# rescue mode we should reboot into the previous default boot entry.
+# How to do that is an architecture specific detail.
+#
+# An architecture must provide an override of this function.
+rescue_revert_default_arch()
+{
+    false
+}
+
+# We want install mode booting to be sticky, i.e. if you boot into
+# install mode you stay install mode until an installer runs
+# successfully.  How to do that is an architecture specific detail.
+#
+# An architecture must provide an override of this function.
+install_remain_sticky_arch()
+{
+    false
+}
+
+[ -r /lib/onie/boot-mode-arch ] || {
+    echo "Error: missing /lib/onie/boot-mode-arch file." > /dev/console
+    exit 1
+}
+. /lib/onie/boot-mode-arch
+
+do_start() {
+
+    # parse boot_reason
+    case "$onie_boot_reason" in
+        rescue)
+            # Delete the one time onie_boot_reason env variable.
+            rescue_revert_default_arch || {
+                echo "Error: problems clearing rescue boot mode" > /dev/console
+            }
+            exit 0
+            ;;
+        install)
+            install_remain_sticky_arch || {
+                echo "Error: problems making install boot mode sticky" > /dev/console
+            }
+            exit 0
+            ;;
+        *)
+
+    esac
+
+}
+
+case $cmd in
+    start)
+        do_start
+        ;;
+    *)
+
+esac

--- a/rootconf/default/etc/init.d/discover.sh
+++ b/rootconf/default/etc/init.d/discover.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -14,41 +15,11 @@ import_cmdline
 
 daemon="discover"
 
-# We want rescue mode booting to be a one time operation.  After the
-# rescue mode we should reboot into the previous default boot entry.
-# How to do that is an architecture specific detail.
-#
-# An architecture must provide an override of this function.
-rescue_revert_default_arch()
-{
-    false
-}
-
-# We want install mode booting to be sticky, i.e. if you boot into
-# install mode you stay install mode until an installer runs
-# successfully.  How to do that is an architecture specific detail.
-#
-# An architecture must provide an override of this function.
-install_remain_sticky_arch()
-{
-    false
-}
-
-[ -r /lib/onie/boot-mode-arch ] || {
-    echo "Error: missing /lib/onie/boot-mode-arch file." > /dev/console
-    exit 1
-}
-. /lib/onie/boot-mode-arch
-
 do_start() {
 
     # parse boot_reason
     case "$onie_boot_reason" in
         rescue)
-            # Delete the one time onie_boot_reason env variable.
-            rescue_revert_default_arch || {
-                echo "Error: problems clearing rescue boot mode" > /dev/console
-            }
             echo "$daemon: Rescue mode detected.  Installer disabled." > /dev/console
             echo "** Rescue Mode Enabled **" >> /etc/issue
             exit 0
@@ -65,9 +36,6 @@ do_start() {
             echo "** ONIE Update Mode Enabled **" >> /etc/issue
             ;;
         install)
-            install_remain_sticky_arch || {
-                echo "Error: problems making install boot mode sticky" > /dev/console
-            }
             # pass through to discover
             echo "$daemon: installer mode detected.  Running installer." > /dev/console
             echo "** Installer Mode Enabled **" >> /etc/issue

--- a/rootconf/default/etc/rcS.d/S03boot-mode.sh
+++ b/rootconf/default/etc/rcS.d/S03boot-mode.sh
@@ -1,0 +1,1 @@
+../init.d/boot-mode.sh

--- a/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
+++ b/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
@@ -1,4 +1,5 @@
 #  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -217,21 +218,35 @@ bios_boot_onie_install()
 {
     local onie_dev="$(onie_get_boot_dev)"
     local boot_dev="$(onie_get_boot_disk)"
+    [ -r /etc/machine.conf ] && . /etc/machine.conf
+    if [ "$onie_firmware" = "coreboot" ] ; then
+        local grub_target="i386-coreboot"
+        local core_img="$onie_boot_mnt/grub/$grub_target/core.elf"
+    else
+        local grub_target="i386-pc"
+        local core_img="$onie_boot_mnt/grub/$grub_target/core.img"
+    fi
+    local boot_mod_dir="$onie_boot_mnt/grub/$grub_target"
+    local grub_mod_dir="/usr/lib/grub/$grub_target"
 
     # Re-install ONIE GRUB in MBR and ONIE partition
-    local core_img="$onie_boot_mnt/grub/i386-pc/core.img"
     [ -f "$core_img" ] && chattr -i $core_img
-    grub-install --boot-directory="$onie_boot_mnt" --recheck "$boot_dev" || {
+    grub-install --target="$grub_target" --install-modules="" \
+        --boot-directory="$onie_boot_mnt" --recheck "$boot_dev" || {
         echo "ERROR: grub-install failed on: $boot_dev"
+        cp -a $grub_mod_dir/*.mod $boot_mod_dir
         exit 1
     }
     local grub_install_log=$(mktemp)
-    grub-install --force --boot-directory="$onie_boot_mnt" \
+    grub-install --target="$grub_target" --install-modules="" \
+        --force --boot-directory="$onie_boot_mnt" \
         --recheck "$onie_dev" > /$grub_install_log 2>&1 || {
         echo "ERROR: grub-install failed on: $onie_dev"
+        cp -a $grub_mod_dir/*.mod $boot_mod_dir
         cat $grub_install_log && rm -f $grub_install_log
         exit 1
     }
+    cp -a $grub_mod_dir/*.mod $boot_mod_dir
     rm -f $grub_install_log
     [ -f "$core_img" ] && chattr +i $core_img
 


### PR DESCRIPTION
The modules installed by grub during making install boot mode sticky
are the same.  The Modules are installed two times.  It takes 5 ~ 9
seconds to finish installing grub.  By the new way, instead of
re-installing modules, backup and restored modules take around one
second.

It also reduces the probability of grub corrupted by power cycle.
Please see commit ada8cb8.

The issue was reported in
https://github.com/opencomputeproject/onie/issues/250

This patch has been tested in Accton AS7712_32X.