### PR TITLE
onie-fwpkg: fix firmware update status output

### DIFF
--- a/rootconf/x86_64/sysroot-bin/onie-fwpkg
+++ b/rootconf/x86_64/sysroot-bin/onie-fwpkg
@@ -411,7 +411,7 @@ __print_results_tbl_row()
     version=${version##*=}
     [ -n "$version" ] || version="Unknown"
 
-    local ds="$(stat -c '%y' ${onie_update_pending_dir}/$name | head -c 19)"
+    local ds="$(stat -c '%y' ${onie_update_results_dir}/$name | head -c 19)"
     printf "%-${result_col1}s|%-${result_col2}s|%-${result_col3}s|%s\n" "$name " " $version " " $status " " $ds"
 }
 


### PR DESCRIPTION
The update status output function of onie-fwpkg command contains a
typo.  Instead of dumping firmware update results, it tries to dump
*pending* firmware updates.

This patch fixes the typo and correctly dumps the update results.