### PR TITLE
ONIE GRUB support u-boot-like boot commands

### DIFF
--- a/build-config/scripts/onie-mk-installer.sh
+++ b/build-config/scripts/onie-mk-installer.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2013,2014,2015 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014,2015,2016 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -147,11 +147,7 @@ export GRUB_CMDLINE_LINUX
 
 # variables for ONIE itself
 GRUB_ONIE_SERIAL_COMMAND=\$GRUB_SERIAL_COMMAND
-DEFAULT_CMDLINE="\$GRUB_CMDLINE_LINUX \$GRUB_CMDLINE_LINUX_DEFAULT \$GRUB_ONIE_PLATFORM_ARGS \$GRUB_ONIE_DEBUG_ARGS"
-GRUB_ONIE_CMDLINE_LINUX=\${GRUB_ONIE_CMDLINE_LINUX:-"\$DEFAULT_CMDLINE"}
-ONIE_CMDLINE="quiet \$GRUB_ONIE_CMDLINE_LINUX \\\$ONIE_EXTRA_CMDLINE_LINUX"
 export GRUB_ONIE_SERIAL_COMMAND
-export ONIE_CMDLINE
 
 ## End grub-variables
 EOF

--- a/demo/os/x86_64/lib/demo/common-blkdev
+++ b/demo/os/x86_64/lib/demo/common-blkdev
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 
 #  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015-2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -13,6 +14,10 @@ demo_mnt="/demo"
 # iteration.
 set_onie_next_boot()
 {
+    if [ ! -d "$demo_mnt/grub" ] ; then
+        # Do nothing if no GRUB installed in demo partition
+        return 0
+    fi
     if [ -d "/sys/firmware/efi/efivars" ] ; then
         # For the UEFI case we set the UEFI variable "BootNext" to
         # select ONIE as the next OS to boot.  The "BootNext" variable

--- a/installer/x86_64/grub.d/50_onie_grub
+++ b/installer/x86_64/grub.d/50_onie_grub
@@ -7,6 +7,9 @@
 
 # This file provides a GRUB menu entry for ONIE.
 #
+## DO NOT remove the following line:
+##   ONIE_SUPPORT_BOOTCMD_FEEDING
+#
 # Place this file in /etc/grub.d and grub-mkconfig will use this file
 # when generating a grub configuration file.
 #
@@ -57,6 +60,11 @@ fi
 diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
 add_diag_bootcmd()
 {
+    if [ -r "$onie_root_dir/grub/diag-bootcmd.cfg" ] ; then
+        cat $onie_root_dir/grub/diag-bootcmd.cfg >> $grub_cfg
+        return 0
+    fi
+
     cat <<EOF >> $grub_cfg
 diag_menu="$diag_label"
 EOF

--- a/installer/x86_64/grub.d/50_onie_grub
+++ b/installer/x86_64/grub.d/50_onie_grub
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2015-2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -54,6 +54,39 @@ fi
 # Step 2 -- Update ONIE's GRUB configuration in the ONIE-BOOT
 # partition.
 
+diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
+add_diag_bootcmd()
+{
+    cat <<EOF >> $grub_cfg
+diag_menu="$diag_label"
+EOF
+    if [ -d "/sys/firmware/efi/efivars" ] && [ -f "${uefi_root}/$onie_uefi_grub" ] ; then
+        # UEFI firmware
+        diag_uefi_grub=$(efibootmgr -v | grep $diag_label | sed -e 's/.*)\/File(//' -e 's/)//' -e 's/\\/\//g')
+        if [ -f "$uefi_root/$diag_uefi_grub" ] ; then
+            cat <<EOF >> $grub_cfg
+function diag_bootcmd {
+  set root='(hd0,gpt1)'
+  search --no-floppy --fs-uuid --set=root $uefi_uuid
+  echo    "Loading $diag_label \$onie_platform ..."
+  chainloader /$diag_uefi_grub
+  boot
+}
+EOF
+        fi
+    else
+        # legacy BIOS firmware
+        cat <<EOF >> $grub_cfg
+function diag_bootcmd {
+  search --no-floppy --label --set=root $diag_label
+  echo    "Loading $diag_label \$onie_platform ..."
+  chainloader ${default_chainloader}
+  boot
+}
+EOF
+    fi
+}
+
 tmp_mnt=
 onie_umount_partition()
 {
@@ -86,7 +119,6 @@ onie_root_dir="${tmp_mnt}/onie"
 # - If NOS/DIAG installer does not export GRUB_SERIAL_COMMAND and
 #   GRUB_CMDLINE_LINUX, ONIE will use the default/correct ones.
 if [ -z "$GRUB_ONIE_SERIAL_COMMAND" ] ||
-    [ -z "$ONIE_CMDLINE" ] ||
     [ -z "$GRUB_CMDLINE_LINUX" ] ; then
 . $onie_root_dir/grub/grub-variables
 fi
@@ -106,71 +138,36 @@ terminal_output serial
 EOF
 fi
 
+# Look for an ONIE compatible DIAG image and add a boot entry for it.
+cat <<EOF >> $grub_cfg
+# begin: diag boot command
+
+EOF
+if [ -n "$diag_label" ]  ; then
+    add_diag_bootcmd
+fi
+cat <<EOF >> $grub_cfg
+
+# end: diag boot command
+EOF
+
 # add the ONIE machine configuration data
 cat $onie_root_dir/grub/grub-machine.cfg >> $grub_cfg
 
 # add extra platform specific kernel command line options
 cat $onie_root_dir/grub/grub-extra.cfg >> $grub_cfg
 
+cat <<EOF >> $grub_cfg
+# begin: ONIE bootargs
+
+onie_initargs="$GRUB_CMDLINE_LINUX"
+onie_initargs_default="$GRUB_CMDLINE_LINUX_DEFAULT"
+onie_platformargs="$GRUB_ONIE_PLATFORM_ARGS"
+onie_debugargs="$GRUB_ONIE_DEBUG_ARGS"
+GRUB_ONIE_CMDLINE_LINUX="$GRUB_ONIE_CMDLINE_LINUX"
+
+# end: ONIE bootargs
+EOF
+
 # add ONIE configuration common to all ONIE boot modes
 cat $onie_root_dir/grub/grub-common.cfg >> $grub_cfg
-
-for mode in install rescue uninstall update embed ; do
-    case "$mode" in
-        install)
-            boot_message="ONIE: OS Install Mode ..."
-            ;;
-        rescue)
-            boot_message="ONIE: Rescue Mode ..."
-            ;;
-        uninstall)
-            boot_message="ONIE: OS Uninstall Mode ..."
-            ;;
-        update)
-            boot_message="ONIE: ONIE Update Mode ..."
-            ;;
-        embed)
-            boot_message="ONIE: ONIE Embed Mode ..."
-            ;;
-        *)
-            ;;
-    esac
-    (cat <<EOF
-menuentry "\$onie_menu_$mode" {
-        onie_entry_start
-        echo    "$boot_message"
-        linux   /onie/vmlinuz-\${onie_kernel_version}-onie $ONIE_CMDLINE boot_reason=$mode
-        initrd  /onie/initrd.img-\${onie_kernel_version}-onie
-        onie_entry_end
-}
-EOF
-    ) >> $grub_cfg
-done
-
-# Look for an ONIE compatible DIAG image and add a boot entry for it.
-diag_label=$(blkid | grep -- '-DIAG"' | sed -e 's/^.*LABEL="//' -e 's/".*$//')
-if [ -n "$diag_label" ]  ; then
-    if [ -d "/sys/firmware/efi/efivars" ] && [ -f "${uefi_root}/$onie_uefi_grub" ] ; then
-        # UEFI firmware
-        diag_uefi_grub=$(efibootmgr -v | grep $diag_label | sed -e 's/.*)\/File(//' -e 's/)//' -e 's/\\/\//g')
-        if [ -f "$uefi_root/$diag_uefi_grub" ] ; then
-            cat <<EOF >> $grub_cfg
-menuentry '$diag_label' {
-	set root='(hd0,gpt1)'
-	search --no-floppy --fs-uuid --set=root $uefi_uuid
-        echo    'Loading $diag_label $onie_platform ...'
-	chainloader /$diag_uefi_grub
-}
-EOF
-        fi
-    else
-        # legacy BIOS firmware
-        cat <<EOF >> $grub_cfg
-menuentry '$diag_label' {
-        search --no-floppy --label --set=root $diag_label
-        echo    'Loading $diag_label $onie_platform ...'
-        chainloader ${default_chainloader}
-}
-EOF
-    fi
-fi

--- a/installer/x86_64/grub/grub-common.cfg
+++ b/installer/x86_64/grub/grub-common.cfg
@@ -1,6 +1,7 @@
 ## Begin grub-common.cfg
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015-2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -21,6 +22,13 @@ export onie_menu_embed
 
 set fallback="${onie_menu_rescue}"
 
+# default ONIE boot reason
+onie_boot_reason="install"
+
+onie_quiet="quiet"
+onie_linux="/onie/vmlinuz-${onie_kernel_version}-onie"
+onie_initrd="/onie/initrd.img-${onie_kernel_version}-onie"
+
 function onie_entry_start {
   insmod gzio
   insmod ext2
@@ -37,6 +45,58 @@ function onie_entry_start {
 function onie_entry_end {
   echo "Version   : $onie_version"
   echo "Build Date: $onie_build_date"
+}
+
+function onie_bootcmd {
+  onie_entry_start
+  if [ "$onie_boot_reason" = "install" ] ; then
+    echo "ONIE: OS Install Mode ..."
+  elif [ "$onie_boot_reason" = "rescue" ] ; then
+    echo "ONIE: Rescue Mode ..."
+  elif [ "$onie_boot_reason" = "uninstall" ] ; then
+    echo "ONIE: OS Uninstall Mode ..."
+  elif [ "$onie_boot_reason" = "update" ] ; then
+    echo "ONIE: ONIE Update Mode ..."
+  elif [ "$onie_boot_reason" = "embed" ] ; then
+    echo "ONIE: ONIE Embed Mode ..."
+  else
+    echo "ERROR: Unsupported ONIE boot mode: $onie_boot_reason"
+    return 1
+  fi
+  if [ -z "$GRUB_ONIE_CMDLINE_LINUX" ] ; then
+    onie_args="$onie_quiet $onie_initargs $onie_initargs_default $onie_platformargs $onie_debugargs $ONIE_EXTRA_CMDLINE_LINUX"
+  else
+    onie_args="$GRUB_ONIE_CMDLINE_LINUX $ONIE_EXTRA_CMDLINE_LINUX"
+  fi
+  linux   $onie_linux $onie_args boot_reason=$onie_boot_reason
+  initrd  $onie_initrd
+  onie_entry_end
+  boot
+}
+
+function onie_install {
+  onie_boot_reason="install"
+  onie_bootcmd
+}
+
+function onie_rescue {
+  onie_boot_reason="rescue"
+  onie_bootcmd
+}
+
+function onie_uninstall {
+  onie_boot_reason="uninstall"
+  onie_bootcmd
+}
+
+function onie_update {
+  onie_boot_reason="update"
+  onie_bootcmd
+}
+
+function onie_embed {
+  onie_boot_reason="embed"
+  onie_bootcmd
 }
 
 function reset_onie_mode {
@@ -60,6 +120,32 @@ elif [ "$onie_mode" = "rescue" ] ; then
    set default="${onie_menu_rescue}"
    # clear rescue mode after one boot attempt
    reset_onie_mode
+fi
+
+menuentry "$onie_menu_install" {
+  onie_install
+}
+
+menuentry "$onie_menu_rescue" {
+  onie_rescue
+}
+
+menuentry "$onie_menu_uninstall" {
+  onie_uninstall
+}
+
+menuentry "$onie_menu_update" {
+  onie_update
+}
+
+menuentry "$onie_menu_embed" {
+  onie_embed
+}
+
+if [ -n "$diag_menu" ] ; then
+  menuentry "$diag_menu" {
+    diag_bootcmd
+  }
 fi
 
 ## End grub-common.cfg

--- a/installer/x86_64/grub/grub-common.cfg
+++ b/installer/x86_64/grub/grub-common.cfg
@@ -120,6 +120,11 @@ elif [ "$onie_mode" = "rescue" ] ; then
    set default="${onie_menu_rescue}"
    # clear rescue mode after one boot attempt
    reset_onie_mode
+elif [ "$onie_mode" = "diag" ] ; then
+   if [ -n "$diag_menu" ] ; then
+       set default="${diag_menu}"
+   fi
+   reset_onie_mode
 fi
 
 menuentry "$onie_menu_install" {

--- a/installer/x86_64/install-arch
+++ b/installer/x86_64/install-arch
@@ -1,7 +1,7 @@
 # x86_64 specific ONIE installer functions
 
 #  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014,2015,2016 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
 #
@@ -463,6 +463,11 @@ install_grub_config()
         exit 1
     }
 
+    # Restore the previous diag_bootcmd.cfg file
+    if [ "$preserve_diag_bootcmd" = "yes" ] ; then
+        cp /tmp/preserve_diag_bootcmd $diag_bootcmd_file
+    fi
+
     # import console config and linux cmdline
     . $boot_dir/onie/grub/grub-variables
 
@@ -628,6 +633,12 @@ install_onie()
         if [ -d $onie_update_dir ] ; then
             preserve_update_dir=yes
             cp -a $onie_update_dir /tmp/preserve-update
+        fi
+        if [ "$onie_boot_reason" != "embed" ] ; then
+            if [ -r $diag_bootcmd_file ] ; then
+                preserve_diag_bootcmd=yes
+                cp $diag_bootcmd_file /tmp/preserve_diag_bootcmd
+            fi
         fi
         umount $onie_boot_mnt > /dev/null 2>&1
     fi

--- a/rootconf/x86_64/sysroot-bin/onie-boot-mode
+++ b/rootconf/x86_64/sysroot-bin/onie-boot-mode
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015-2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -27,6 +28,7 @@ COMMAND LINE OPTIONS
 		uninstall -- ONIE OS uninstall mode
 		update    -- ONIE self update mode
 		embed     -- ONIE self update mode and embed ONIE
+		diag      -- Hardware Vendor's Diagnostic
 		none      -- Use system default boot mode
 
                 Some platforms may offer additional modes.  Check with
@@ -90,7 +92,7 @@ done
 
 if [ -n "$onie_mode" ] ; then
     case "$onie_mode" in
-        install|uninstall|rescue|update|embed)
+        install|uninstall|rescue|update|embed|diag)
             [ "$verbose" = "yes" ] && echo "Setting ONIE mode to: $onie_mode"
             # Set ONIE boot mode in grubenv
             onie_setenv onie_mode "$onie_mode"

--- a/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
+++ b/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
@@ -1,5 +1,5 @@
 #  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2015-2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -11,6 +11,7 @@ onie_config_dir="${onie_root_dir}/config"
 
 grub_root_dir="${onie_boot_mnt}/grub"
 grub_env_file="${grub_root_dir}/grubenv"
+diag_bootcmd_file="${onie_root_dir}/grub/diag-bootcmd.cfg"
 
 onie_update_dir="${onie_root_dir}/update"
 onie_update_pending_dir="${onie_update_dir}/pending"


### PR DESCRIPTION
The patchset intends to make ONIE GRUB:

1. Support u-boot-like boot commands that are useful for auto test programs.
2. Support boot command feeded by DIAG/NOS installer that can easily chage boot target between ONIE, DIAG and NOS.

The patchset is compatible with present DIAG/NOS installers.