### PR TITLE
[patches] correcting include of .config file.

### DIFF
--- a/patches/kernel/3.2.69/driver-iproc-common.patch
+++ b/patches/kernel/3.2.69/driver-iproc-common.patch
@@ -133,7 +133,10 @@ index 0000000..bbafe05
 +# Makefile for the Linux kernel modules.
 +#
 +
-+-include $(KERNEL_DIR)/.config
++ifeq ($(KERNELDIR),)
++KERNELDIR := ../../kernel/linux
++endif
++-include $(KERNELDIR)/.config
 +
 +export BCMDRIVERS_DIR:=$(src)
 +export DRIVERS_MMC_HOST_DIR := drivers/mmc/host/


### PR DESCRIPTION
Fixing #315 

Variable KERNEL_DIR is not defined anywhere.
Changing it to KERNELDIR and making sure it's exposed to this level.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>