### PR TITLE
celestica: specify UCLIBC_VERSION 0.9.32.1

### DIFF
--- a/machine/celestica/cel_e1031/machine.make
+++ b/machine/celestica/cel_e1031/machine.make
@@ -39,6 +39,9 @@ CONSOLE_FLAG = 1
 LINUX_VERSION           = 3.2
 LINUX_MINOR_VERSION     = 69
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/celestica/cel_seastone/machine.make
+++ b/machine/celestica/cel_seastone/machine.make
@@ -35,6 +35,9 @@ PARTITION_TYPE = gpt
 LINUX_VERSION           = 3.2
 LINUX_MINOR_VERSION     = 69
 
+# Specify uClibc version
+UCLIBC_VERSION = 0.9.32.1
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:


### PR DESCRIPTION
Two recently added Celestica machines did not specify which
UCLIBC_VERSION to use and were picking up the default.

There is nothing wrong with this.  However, all the other Celestica
machines are specifying this:

  LINUX_VERSION           = 3.2
  LINUX_MINOR_VERSION     = 69

  UCLIBC_VERSION = 0.9.32.1

The current default UCLIBC_VERSION is 0.9.33.2, which is recommended
when using the default kernel version.

As all the Celestica machines are currently using the old kernel this
patch specifies the older UCLIBC_VERSION for these platforms:

- cel_e1031
- cel_seastone