### PR TITLE
[patches]  correcting include of .config file.

### DIFF
--- a/patches/kernel/3.2.69/driver-iproc-common.patch
+++ b/patches/kernel/3.2.69/driver-iproc-common.patch
@@ -127,13 +127,11 @@ new file mode 100755
 index 0000000..bbafe05
 --- /dev/null
 +++ b/drivers/bcmdrivers/Makefile
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,28 @@
 +# File: bcmdrivers/Makefile
 +#
 +# Makefile for the Linux kernel modules.
 +#
-+
-+-include $(KERNEL_DIR)/.config
 +
 +export BCMDRIVERS_DIR:=$(src)
 +export DRIVERS_MMC_HOST_DIR := drivers/mmc/host/


### PR DESCRIPTION
Fixing #315

Variable KERNEL_DIR is not defined anywhere and could cause import of
/.config file.
After discussion agreed to remove it completely.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>