### PR TITLE
demo NOS: demo two menu entries and add menu entry chainload NOS

### DIFF
--- a/demo/installer/x86_64/install.sh
+++ b/demo/installer/x86_64/install.sh
@@ -395,7 +395,8 @@ EOF
 
     # Add a menu entry for the DEMO OS
     demo_grub_entry="Demo $demo_type"
-    cat <<EOF >> $grub_cfg
+    if [ "$demo_type" = "DIAG" ] ; then
+        cat <<EOF >> $grub_cfg
 menuentry '$demo_grub_entry' {
         search --no-floppy --label --set=root $demo_volume_label
         echo    'Loading ONIE Demo $demo_type kernel ...'
@@ -404,6 +405,21 @@ menuentry '$demo_grub_entry' {
         initrd  /demo.initrd
 }
 EOF
+    else
+        i=1
+        while [ $i -le 2 ] ; do
+            cat <<EOF >> $grub_cfg
+menuentry '$demo_grub_entry #$i' {
+        search --no-floppy --label --set=root $demo_volume_label
+        echo    'Loading ONIE Demo $demo_type kernel ...'
+        linux   /demo.vmlinuz $GRUB_CMDLINE_LINUX \$ONIE_EXTRA_CMDLINE_LINUX DEMO_TYPE=$demo_type DEMO_MENU_ENTRY_NO=$i
+        echo    'Loading ONIE Demo $demo_type initial ramdisk ...'
+        initrd  /demo.initrd
+}
+EOF
+            i=$(( $i + 1 ))
+        done
+    fi
 
     # Add menu entries for ONIE -- use the grub fragment provided by the
     # ONIE distribution.

--- a/demo/os/default/etc/init.d/demo.sh
+++ b/demo/os/default/etc/init.d/demo.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -8,8 +9,12 @@
 . /lib/demo/platform.conf
 . /lib/demo/functions
 
-demo_type=$(demo_type_get)
+demo_import_cmdline
 
-echo "Welcome to the $machine DEMO $demo_type platform." > /etc/issue
-
-echo "Welcome to the $machine DEMO $demo_type platform." > /dev/console
+if [ -n "$demo_menu_entry_no" ] ; then
+    echo "Welcome to the $machine DEMO ${demo_type} platform #${demo_menu_entry_no}." > /etc/issue
+    echo "Welcome to the $machine DEMO ${demo_type} platform #${demo_menu_entry_no}." > /dev/console
+else
+    echo "Welcome to the $machine DEMO $demo_type platform." > /etc/issue
+    echo "Welcome to the $machine DEMO $demo_type platform." > /dev/console
+fi

--- a/demo/os/default/etc/profile
+++ b/demo/os/default/etc/profile
@@ -1,6 +1,7 @@
 # ONIE shell init file
 
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -9,9 +10,13 @@
 
 MACH=$(echo $machine | tr [a-z] [A-Z])
 
-demo_type=$(demo_type_get)
+demo_import_cmdline
 
-export PS1="${MACH}-${demo_type}:\w # "
+if [ -n "$demo_menu_entry_no" ] ; then
+    export PS1="${MACH}-${demo_type}-${demo_menu_entry_no}:\w # "
+else
+    export PS1="${MACH}-${demo_type}:\w # "
+fi
 
 # Local Variables:
 # mode: shell-script

--- a/demo/os/default/lib/demo/functions
+++ b/demo/os/default/lib/demo/functions
@@ -1,24 +1,25 @@
 # -*- shell-script -*-
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
 # Functions useful inside the DEMO OS
 
-# Find the DEMO type specified on the kernel command line
-demo_type_get()
+# Import kernel's /proc/cmdline variables
+demo_import_cmdline()
 {
-    demo_type="OS"
     for x in $(cat /proc/cmdline); do
         parm=${x%%=*}
         val=${x#*=}
         case $parm in
             DEMO_TYPE)
                 demo_type="${val}"
-                break
+                ;;
+            DEMO_MENU_ENTRY_NO)
+                demo_menu_entry_no="${val}"
                 ;;
         esac
     done
-    echo -n "$demo_type"
 }

--- a/demo/os/x86_64/etc/init.d/mount-demo.sh
+++ b/demo/os/x86_64/etc/init.d/mount-demo.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2014-15 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -13,7 +14,8 @@ mkdir -p $demo_mnt || {
     exit 1
 }
 
-demo_type=$(demo_type_get)
+demo_import_cmdline
+
 [ -n "$demo_type" ] || {
     echo "Error: Unable to find DEMO_TYPE on kernel command line"
     exit 1

--- a/installer/x86_64/grub.d/50_onie_grub
+++ b/installer/x86_64/grub.d/50_onie_grub
@@ -24,11 +24,21 @@
 
 # Step 1
 # Depends on UEFI GRUB or Legacy BIOS GRUB
-default_chainloader="+1"
-[ "${onie_firmware}" = "coreboot" ] && default_chainloader=/grub/i386-coreboot/core.elf
+
+if [ "${onie_firmware}" = "coreboot" ] ; then
+    default_chainloader=/grub/i386-coreboot/core.elf
+else
+    default_chainloader="+1"
+fi
+
 uefi_root=/boot/efi
 onie_uefi_grub=EFI/onie/grubx64.efi
-if [ -d "/sys/firmware/efi/efivars" ] && [ -r "${uefi_root}/$onie_uefi_grub" ] ; then
+if [ -d "/sys/firmware/efi/efivars" ] &&
+    [ -r "${uefi_root}/$onie_uefi_grub" ] ; then
+    running_uefi_grub=yes
+fi
+
+if [ "$running_uefi_grub" = "yes" ] ; then
     uefi_uuid=$(grub-probe --target=fs_uuid "${uefi_root}/$onie_uefi_grub") || {
         echo "ERROR: grub-probe failed" > /dev/stderr
         echo "ERROR: failing cmd: grub-probe --target=fs_uuid ${uefi_root}/$onie_uefi_grub" > /dev/stderr
@@ -68,7 +78,7 @@ add_diag_bootcmd()
     cat <<EOF >> $grub_cfg
 diag_menu="$diag_label"
 EOF
-    if [ -d "/sys/firmware/efi/efivars" ] && [ -f "${uefi_root}/$onie_uefi_grub" ] ; then
+    if [ "$running_uefi_grub" = "yes" ] ; then
         # UEFI firmware
         diag_uefi_grub=$(efibootmgr -v | grep $diag_label | sed -e 's/.*)\/File(//' -e 's/)//' -e 's/\\/\//g')
         if [ -f "$uefi_root/$diag_uefi_grub" ] ; then
@@ -93,6 +103,51 @@ function diag_bootcmd {
 }
 EOF
     fi
+}
+
+add_nos_chainload()
+{
+    nos_label="$NOS_BOOT_PARTITION_LABEL"
+    nos_chainload_menu="$NOS_CHAINLOAD_MENU"
+    nos_bootcmd_cfg="$onie_root_dir/grub/nos-bootcmd.cfg"
+    cat <<EOF > $nos_bootcmd_cfg
+# begin: nos-bootcmd.cfg
+
+EOF
+    if [ "$running_uefi_grub" = "yes" ] ; then
+        # UEFI firmware
+        nos_uefi_grub=$(efibootmgr -v | grep $nos_label | sed -e 's/.*)\/File(//' -e 's/)//' -e 's/\\/\//g')
+        if [ -f "$uefi_root/$nos_uefi_grub" ] ; then
+            cat <<EOF >> $nos_bootcmd_cfg
+function nos_chainload {
+  set root='(hd0,gpt1)'
+  search --no-floppy --fs-uuid --set=root $uefi_uuid
+  echo    "Loading $nos_label \$onie_platform ..."
+  chainloader /$nos_uefi_grub
+  boot
+}
+EOF
+        fi
+    else
+        # legacy BIOS firmware
+        cat <<EOF >> $nos_bootcmd_cfg
+function nos_chainload {
+  search --no-floppy --label --set=root $nos_label
+  echo    "Loading $nos_label \$onie_platform ..."
+  chainloader ${default_chainloader}
+  boot
+}
+EOF
+    fi
+    cat <<EOF >> $nos_bootcmd_cfg
+function insert_nos_menuentry {
+  menuentry "$nos_chainload_menu" {
+    nos_chainload
+  }
+}
+
+# end: nos-bootcmd.cfg
+EOF
 }
 
 tmp_mnt=
@@ -179,3 +234,11 @@ EOF
 
 # add ONIE configuration common to all ONIE boot modes
 cat $onie_root_dir/grub/grub-common.cfg >> $grub_cfg
+
+# add NOS chainload configuration if the following variables are defined:
+#   - NOS_BOOT_PARTITION_LABEL
+#   - NOS_CHAINLOAD_MENU
+if [ -n "$NOS_BOOT_PARTITION_LABEL" ] &&
+    [ -n "$NOS_CHAINLOAD_MENU" ] ; then
+    add_nos_chainload
+fi

--- a/installer/x86_64/grub/grub-common.cfg
+++ b/installer/x86_64/grub/grub-common.cfg
@@ -127,6 +127,17 @@ elif [ "$onie_mode" = "diag" ] ; then
    reset_onie_mode
 fi
 
+function insert_nos_menuentry {
+  # Do nothing
+  return 0
+}
+
+if [ -r "/onie/grub/nos-bootcmd.cfg" ] ; then
+  configfile /onie/grub/nos-bootcmd.cfg
+fi
+
+insert_nos_menuentry
+
 menuentry "$onie_menu_install" {
   onie_install
 }

--- a/installer/x86_64/install-arch
+++ b/installer/x86_64/install-arch
@@ -463,9 +463,14 @@ install_grub_config()
         exit 1
     }
 
-    # Restore the previous diag_bootcmd.cfg file
+    # Restore the previous diag-bootcmd.cfg file
     if [ "$preserve_diag_bootcmd" = "yes" ] ; then
         cp /tmp/preserve_diag_bootcmd $diag_bootcmd_file
+    fi
+
+    # Restore the previous nos-bootcmd.cfg file
+    if [ "$preserve_nos_bootcmd" = "yes" ] ; then
+        cp /tmp/preserve_nos_bootcmd $nos_bootcmd_file
     fi
 
     # import console config and linux cmdline
@@ -638,6 +643,10 @@ install_onie()
             if [ -r $diag_bootcmd_file ] ; then
                 preserve_diag_bootcmd=yes
                 cp $diag_bootcmd_file /tmp/preserve_diag_bootcmd
+            fi
+            if [ -r $nos_bootcmd_file ] ; then
+                preserve_nos_bootcmd=yes
+                cp $nos_bootcmd_file /tmp/preserve_nos_bootcmd
             fi
         fi
         umount $onie_boot_mnt > /dev/null 2>&1

--- a/rootconf/x86_64/sysroot-lib-onie/boot-mode-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/boot-mode-arch
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2015-2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -22,12 +22,13 @@ rescue_revert_default_arch()
 # successfully.
 install_remain_sticky_arch()
 {
+    rm -f $nos_bootcmd_file
     if [ "$(onie_get_running_firmware)" = "uefi" ] ; then
         uefi_boot_onie_install
     else
         bios_boot_onie_install
     fi
-    sync;sync
+    sync ; sync
 
     return 0
 }

--- a/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
+++ b/rootconf/x86_64/sysroot-lib-onie/onie-blkdev-common
@@ -12,6 +12,7 @@ onie_config_dir="${onie_root_dir}/config"
 grub_root_dir="${onie_boot_mnt}/grub"
 grub_env_file="${grub_root_dir}/grubenv"
 diag_bootcmd_file="${onie_root_dir}/grub/diag-bootcmd.cfg"
+nos_bootcmd_file="${onie_root_dir}/grub/nos-bootcmd.cfg"
 
 onie_update_dir="${onie_root_dir}/update"
 onie_update_pending_dir="${onie_update_dir}/pending"

--- a/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
@@ -1,7 +1,7 @@
 # x86_64 specific uninstall routine
 
 #  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2015-2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -176,6 +176,8 @@ uninstall_system()
             erase_part $blk_dev $part
         fi
     done
+
+    rm -f $nos_bootcmd_file
 
     if [ "$(onie_get_running_firmware)" = "uefi" ] ; then
         uefi_clean_up


### PR DESCRIPTION
For the patchset, I implement two features discussed in PR #308.
- Have the "NOS menu" appear on the ONIE GRUB menu.
- Add two entries, with different titles, that boot the same kernel+initrd with identical command line args.
