### PR TITLE
[im_n29xx_t40n] install/update messages cleanup.

### DIFF
--- a/machine/imt/im_n29xx_t40n/installer/install-platform
+++ b/machine/imt/im_n29xx_t40n/installer/install-platform
@@ -173,8 +173,10 @@ install_onie()
     if [ "$preserve_update_dir" = "yes" ] ; then
         rm -rf $onie_update_dir
         cp -a /tmp/preserve-update $onie_update_dir
-        mv $onie_update_dir/bootfiles/* $onie_boot_mnt
-        rmdir $onie_update_dir/bootfiles
+        if [ -d $onie_update_dir/bootfiles ] ; then
+            mv $onie_update_dir/bootfiles/* $onie_boot_mnt 2>/dev/null
+            rmdir $onie_update_dir/bootfiles
+        fi
     fi
 
     # Return to default boot mode on the next boot.  Use this


### PR DESCRIPTION
Fixing #316

On Interface Masters platforms /boot is shared for
ONIE and NOS grub files. Hence scripts are doing back up of
content if any. On busybox wild card characters are specific
and complaining on '*' in empty directory.
Fix is to move output of 'mv' command to /dev/null.
Functionality is still correct for backing up and restoring grub
content.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>