### PR TITLE
[imt][test] adding Niagara 29XX family DUT config.

### DIFF
--- a/contrib/oce/config/imt_im_n29xx_t40n_r0.json
+++ b/contrib/oce/config/imt_im_n29xx_t40n_r0.json
@@ -1,0 +1,13 @@
+{
+    "name": "Interface Masters Niagara 29XX DUT Configuration",
+    "mac_address": "00:13:95:12:9A:68",
+    "ip_cidr": "192.168.157.100/24",
+    "options": {
+        "onie_machine": "n29xx_t40n",
+        "onie_machine_rev": 0,
+        "onie_arch": "x86_64",
+        "onie_vendor": "im",
+        "onie_installer": "onie-installer-x86_64-im_n29xx_t40n-r0",
+        "onie_updater": "onie-updater-x86_64-im_n29xx_t40n-r0"
+    }
+}


### PR DESCRIPTION
Tests are run on Niagara 29XX family defices using the following
commands:
$ cd onie/contrib/oce
$ ./test-onie.py -I eth0 -d config/imt_im_n29xx_t40n_r0.json -t X

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>