### PR TITLE
Add switch-silicon-vendor to onie-sysinfo

### DIFF
--- a/rootconf/default/bin/onie-sysinfo
+++ b/rootconf/default/bin/onie-sysinfo
@@ -91,7 +91,7 @@ get_ethaddr()
 [ -r $lib_dir/sysinfo-arch ]     && . $lib_dir/sysinfo-arch
 [ -r $lib_dir/sysinfo-platform ] && . $lib_dir/sysinfo-platform
 
-args="hsevimrpcfdatP"
+args="hsSevimrpcfdatP"
 
 usage()
 {
@@ -142,6 +142,9 @@ COMMAND LINE OPTIONS
 	-t
 		ONIE partition type
 
+	-S
+		ONIE silicon switch vendor
+
 	-a
 		Dump all information.
 EOF
@@ -159,6 +162,7 @@ arch=no
 config_version=no
 build_date=no
 partition_type=no
+switch_asic=no
 all=no
 
 [ $# -eq 0 ] && platform=yes
@@ -171,6 +175,9 @@ while getopts "$args" a ; do
             ;;
         s)
             sn=yes
+            ;;
+        S)
+            switch_asic=yes
             ;;
         e)
             mac=yes
@@ -244,7 +251,7 @@ if [ "$mac" = "yes" ] || [ "$all" = "yes" ] ; then
     print_val $val
 fi
 
-for v in version vendor_id machine machine_rev platform arch config_version partition_type build_date ; do
+for v in version vendor_id machine machine_rev platform arch config_version partition_type build_date switch_asic ; do
     eval dump='$'$v
     if [ "$dump" = "yes" ] || [ "$all" = "yes" ] ; then
         eval val='$onie'_$v


### PR DESCRIPTION
Add switch silicon vendor string to be part of the onie-sysinfo
output when using '-a' or when using '-S'.

Signed-off-by: Carlos Cardenas <carlos@cumulusnetworks.com>