### PR TITLE
Allow Ethernet management MAC addresses to be pre-programmed

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 #>
 #
-#  Copyright (C) 2013,2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2016 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014,2015 Carlos Cardenas <carlos@cumulusnetworks.com>
 #  Copyright (C) 2014 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
@@ -183,6 +183,10 @@ endif
 
 # Switch ASIC vendor, should be set in machine.make
 SWITCH_ASIC_VENDOR ?= unknown
+
+# Should ONIE skip programming the Ethernet management interface MAC
+# addresses?  Can be set to "yes" in machine.make.
+SKIP_ETHMGMT_MACS ?= no
 
 TREE_STAMP  = $(STAMPDIR)/tree
 tree-stamp: $(TREE_STAMP)

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013,2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2016 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014-2015 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
 #  Copyright (C) 2014 Puneet <puneet@cumulusnetworks.com>
@@ -253,6 +253,7 @@ $(SYSROOT_COMPLETE_STAMP): $(SYSROOT_CHECK_STAMP)
 	$(Q) echo "onie_kernel_version=$(LINUX_RELEASE)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_firmware=$(FIRMWARE_TYPE)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_switch_asic=$(SWITCH_ASIC_VENDOR)" >> $(MACHINE_CONF)
+	$(Q) echo "onie_skip_ethmgmt_macs=$(SKIP_ETHMGMT_MACS)" >> $(MACHINE_CONF)
 	$(Q) cp $(LSB_RELEASE_FILE) $(SYSROOTDIR)/etc/lsb-release
 	$(Q) cp $(OS_RELEASE_FILE) $(SYSROOTDIR)/etc/os-release
 	$(Q) cp $(MACHINE_CONF) $(SYSROOTDIR)/etc/machine.conf

--- a/rootconf/default/bin/onie-sysinfo
+++ b/rootconf/default/bin/onie-sysinfo
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2016 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -65,19 +65,23 @@ get_part_num()
 
 get_ethaddr()
 {
-    
+
    if [ -n "$onie_eth_addr" ] ; then
        eth_addr="$onie_eth_addr"
-   fi
-   if [ -z "$eth_addr" ] ; then
-        if type get_ethaddr_platform | grep -q 'shell function' > /dev/null 2>&1 ; then
-            eth_addr=$(get_ethaddr_platform)
-        elif type get_ethaddr_arch | grep -q 'shell function' > /dev/null 2>&1 ; then
-            eth_addr=$(get_ethaddr_arch)
-        elif [ -r /sys/class/net/eth0/address ] ; then
-            # Print Ethernet address from eth0 interface
-            eth_addr=$(cat /sys/class/net/eth0/address)
-        fi
+   else
+       if [ "$onie_skip_ethmgmt_macs" = "no" ] ; then
+           if type get_ethaddr_platform | grep -q 'shell function' > /dev/null 2>&1 ; then
+               eth_addr=$(get_ethaddr_platform)
+           elif type get_ethaddr_arch | grep -q 'shell function' > /dev/null 2>&1 ; then
+               eth_addr=$(get_ethaddr_arch)
+           fi
+       fi
+       if [ -z "$eth_addr" ] ; then
+           if [ -r /sys/class/net/eth0/address ] ; then
+               # Print Ethernet address from eth0 interface
+               eth_addr=$(cat /sys/class/net/eth0/address)
+           fi
+       fi
     fi
 
     if [ -n "$eth_addr" ] ; then


### PR DESCRIPTION
Historically ONIE programs the Ethernet management MAC addresses from
those defined in the the TLV EEPROM (type codes 0x24 and 0x2A).  This
worked well on the initial embedded systems ONIE supported, where the
NIC did not have its own internal EEPROM.

Today, most x86 machines have Ethernet management NICs that already
have a MAC address assigned by the vendor.  Overriding that MAC
address with one from the ONIE TLV EEPROM is redundant and wasteful.

This patch provides a configuration mechanism that allows machines to
disable the historic ONIE behaviour.  When ONIE does not assign the
MAC address, the MAC address will be assigned by the NIC driver,
coming from the internal EEPROM of the NIC.

The historic behaviour is enabled by default and no existing machines
need to change their configurations.

To enable the new behaviour set the SKIP_ETHMGMT_MACS variable to
"yes" in machine.make:

  # Use MAC address programmed in Ethernet management NIC
  SKIP_ETHMGMT_MACS = yes

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>