### PR TITLE
Pass -y to apt-get to avoid prompts

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -416,7 +416,7 @@ DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools util-linux \
 PHONY += debian-prepare-build-host
 debian-prepare-build-host:
 	$(Q) sudo apt-get update
-	$(Q) sudo apt-get install $(DEBIAN_BUILD_HOST_PACKAGES)
+	$(Q) sudo apt-get install -y $(DEBIAN_BUILD_HOST_PACKAGES)
 
 PHONY += test-onie
 SITE_CONFIG ?= $(TESTDIR)/site.conf


### PR DESCRIPTION
Hi,

This avoids the build getting stuck on APT prompting to confirm the list of packages to install. This happens when some dependencies of the requested packages are needed to fulfill the installation.

Cheers,
- Loïc Minier