### PR TITLE
Sort files lists before comparing

### DIFF
--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -186,8 +186,8 @@ $(SYSROOT_CHECK_STAMP): $(PACKAGES_INSTALL_STAMPS)
 	$(Q) mkdir -p $(CHECKROOT) && \
 	     $(CROSSBIN)/$(CROSSPREFIX)populate -r $(DEV_SYSROOT) \
 		-s $(SYSROOTDIR) -d $(CHECKDIR) && \
-		(cd $(SYSROOTDIR) && find . > $(SYSFILES)) && \
-		(cd $(CHECKDIR) && find . > $(CHECKFILES)) && \
+		(cd $(SYSROOTDIR) && find . | LC_ALL=C sort > $(SYSFILES)) && \
+		(cd $(CHECKDIR) && find . | LC_ALL=C sort > $(CHECKFILES)) && \
 		diff -q $(SYSFILES) $(CHECKFILES) > /dev/null 2>&1 || { \
 			(echo "ERROR: Missing files in SYSROOTDIR:" && \
 			 diff $(SYSFILES) $(CHECKFILES) ; \


### PR DESCRIPTION
Hi,

Directory listing is not guaranteed to be ordered; to compare directory listings these need to be sorted first. 

This also throws in a LC_ALL=C before the sort to make sure behavior is consistent across locales as sort is locale specific. The overall logic would work whatever the locale since both sorts are run with the same locale, but this guarantees identical on disk intermediate files and consistent failure messages whatever the locale.

Cheers,
- Loïc Minier