### PR TITLE
kvm_x86_64: do not assign Ethernet management MAC addresses

### DIFF
--- a/machine/kvm_x86_64/machine.make
+++ b/machine/kvm_x86_64/machine.make
@@ -53,6 +53,9 @@ UEFI_ENABLE = yes
 # Enable building firmware updates
 FIRMWARE_UPDATE_ENABLE = yes
 
+# Do not modify Ethernet management MACs programmed by hypervisor.
+SKIP_ETHMGMT_MACS = yes
+
 #
 # Console parameters can be defined here (default values are in
 # build-config/arch/x86_64.make).


### PR DESCRIPTION
The default ONIE behaviour is to assign MAC addresses to the Ethernet
management interfaces sequentially from the board EEPROM's base MAC
address.

The kvm_x86_64 does not have an EEPROM, so traditionally the first MAC
came from whatever was found in eth0.  The subsequent interfaces were
assigned a MAC sequentially from that base MAC address.

This patch enables the SKIP_ETHMGMT_MACS feature, which skips the
programming of the Ethernet management MACs all together.  This
retains the MAC addresses assigned by the hypervisor.  See commit
4e389787cac21fc57b8857bebece72374bb1daef:

  commit 4e389787cac21fc57b8857bebece72374bb1daef
  Author: Curt Brune <curt@cumulusnetworks.com>
  Date:   Tue Apr 19 14:21:11 2016 -0700
   
      Allow Ethernet management MAC addresses to be pre-programmed

For the kvm_x86_64 machine, this puts the hypervisor in control of the
Ethernet management MAC addresses, which is desirable for
demonstration purposes.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>