### PR TITLE
Update dropbear.sh

### DIFF
--- a/rootconf/default/etc/init.d/dropbear.sh
+++ b/rootconf/default/etc/init.d/dropbear.sh
@@ -28,9 +28,9 @@ get_keys() {
     get_keys_arch || {
         # If problems just make new keys in ramdisk
         # genereate rsa key
-        dropbearkey -t rsa -s 1024 -f $RSA_KEY > /dev/null 2>&1
+        dropbearkey -t rsa -s 2048 -f $RSA_KEY > /dev/null 2>&1
         # genereate dss key
-        dropbearkey -t dss -s 1024 -f $DSS_KEY > /dev/null 2>&1
+        dropbearkey -t dss -s 2048 -f $DSS_KEY > /dev/null 2>&1
     }
 }
 


### PR DESCRIPTION
Updated key-size to 2048 because 1024 is deprecated and is no longer recommended for usage.
