### PR TITLE
U-Boot: Enable CONFIG_API option

### DIFF
--- a/patches/u-boot/common/platform-common-env.patch
+++ b/patches/u-boot/common/platform-common-env.patch
@@ -1,6 +1,6 @@
 platform common env patch
 
-Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+Copyright (C) 2013,2014,2015,2016 Curt Brune <curt@cumulusnetworks.com>
 
 SPDX-License-Identifier:     GPL-2.0
 
@@ -8,10 +8,10 @@ Common environment and feature enables for all our U-Boot platforms.
 
 diff --git a/include/configs/common_config.h b/include/configs/common_config.h
 new file mode 100644
-index 0000000..e9e2135
+index 0000000..60c77a7
 --- /dev/null
 +++ b/include/configs/common_config.h
-@@ -0,0 +1,152 @@
+@@ -0,0 +1,156 @@
 +/*
 + * Author:  Curt Brune <curt@cumulusnetworks.com>
 + *
@@ -99,6 +99,10 @@ index 0000000..e9e2135
 +#define CONFIG_SYS_HZ		1000
 +
 +#define CONFIG_DOS_PARTITION    1               /* support DOS partitions */
++
++/* support U-Boot API applications */
++#define CONFIG_API
++#define CONFIG_SYS_MMC_MAX_DEVICE   1
 +
 +/*
 + * For booting Linux, the board info and command line data


### PR DESCRIPTION
This patch enables the CONFIG_API configuration option for all U-Boot
platforms. This allows folks to build C applications on top of U-Boot
device drivers.

Testing:

- Compiled ONIE successfully for the following U-Boot machines:

+ celestica/cel_redstone   (powerpc, u-boot 2013.01.01)
+ nxp/nxp_p2020rdbpca      (powerpc, u-boot 2013.01.01)
+ nxp/nxp_p2041rdb         (powerpc, u-boot 2015.10)
+ qemu_armv7a              (armv7,   u-boot 2013.01.01)
+ accton/accton_as4610_54  (armv7,   u-boot 2012.10)
+ accton/accton_as7710_32x (powerpc, u-boot fsl-sdk-v1.7)

For the qemu_armv7a machine I wrote a simple hello world application
that worked OK.

Closes: #383
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>