### PR TITLE
Fix onie discover stopped while console XOFF is triggered

### DIFF
--- a/rootconf/default/bin/discover
+++ b/rootconf/default/bin/discover
@@ -184,7 +184,7 @@ while true ; do
     cat $onie_neigh_file > $onie_parms_file
     echo "$onie_disco" >>  $onie_parms_file
     sed -e 's/@@/ = /g' -e 's/##/\n/g' $onie_parms_file | logger -t discover -p ${syslog_onie}.info
-    exec_installer $onie_parms_file 2>&1 | tee $tee_log_file | logger -t onie-exec -p ${syslog_onie}.info
+    exec_installer $onie_parms_file 2>&1 | tee -a $tee_log_file | logger -t onie-exec -p ${syslog_onie}.info
     [ -r /var/run/install.rc ] && [ "$(cat /var/run/install.rc)" = "0" ] && exit 0
     # pause to avoid DoSing someone
     log_info_msg "Sleeping for $delay seconds "

--- a/rootconf/default/etc/init.d/console-logger.sh
+++ b/rootconf/default/etc/init.d/console-logger.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#  Copyright (C) 2016 Audi Hsu <audi.hsu@quantatw.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+##
+## redirect console_log_file and tee_log_file to /dev/console
+##
+
+. /lib/onie/functions
+
+touch $console_log_file && /usr/bin/tail -f $console_log_file > /dev/console &
+touch $tee_log_file && /usr/bin/tail -f $tee_log_file > /dev/console &

--- a/rootconf/default/etc/rcS.d/S30console-logger.sh
+++ b/rootconf/default/etc/rcS.d/S30console-logger.sh
@@ -1,0 +1,1 @@
+../init.d/console-logger.sh

--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -15,7 +15,9 @@ export onie_installer="/var/tmp/installer"
 
 ONIE_RUN_DIR="/var/run/onie"
 
-tee_log_file=/dev/console
+tee_log_file="/var/log/onie-tee.log"
+console_log_file="/var/log/onie-console.log"
+
 if [ "$onie_boot_reason" = "update" -o "$onie_boot_reason" = "embed" ] ; then
     filename_prefix="onie-updater"
     onie_operation="onie-update"
@@ -44,33 +46,33 @@ syslog_tag="onie"
 
 _log_msg()
 {
-	printf "$@" | tee $tee_log_file | logger -t $syslog_tag -p ${syslog_onie}.info
+	printf "$@" | tee -a $tee_log_file | logger -t $syslog_tag -p ${syslog_onie}.info
 }
 
 _log_console_msg()
 {
-	printf "$@" | tee /dev/console | logger -t $syslog_tag -p ${syslog_onie}.info
+	printf "$@" | tee -a $console_log_file | logger -t $syslog_tag -p ${syslog_onie}.info
 }
 
 _log_info_msg()
 {
-	printf "$@" | tee $tee_log_file | logger -t $syslog_tag -p ${syslog_onie}.info
+	printf "$@" | tee -a $tee_log_file | logger -t $syslog_tag -p ${syslog_onie}.info
 }
 
 _log_warn_msg()
 {
-	printf "$@" | tee $tee_log_file | logger -t ${syslog_tag}-warn -p ${syslog_onie}.warn
+	printf "$@" | tee -a $tee_log_file | logger -t ${syslog_tag}-warn -p ${syslog_onie}.warn
 }
 
 _log_err_msg()
 {
-	printf "$@" | tee $tee_log_file | logger -t ${syslog_tag}-error -p ${syslog_onie}.err
+	printf "$@" | tee -a $tee_log_file | logger -t ${syslog_tag}-error -p ${syslog_onie}.err
 }
 
 log_debug_msg()
 {
 	if [ "$onie_verbose" = "y" ]; then 
-	    printf "$@" | tee $tee_log_file | logger -t ${syslog_tag}-debug -p ${syslog_onie}.debug
+	    printf "$@" | tee -a $tee_log_file | logger -t ${syslog_tag}-debug -p ${syslog_onie}.debug
         fi
 }
 


### PR DESCRIPTION
This patch print logs to files, which was printed to /dev/console directly
    - tee_log_file to /var/log/onie-tee.log
    - _log_console_msg to /var/log/onie-console.log
    - /etc/rcS.d/S30console-logger.sh will tail these logs to /dev/console

Cause:
    While XOFF is trigger with console port somehow, onie discover will stop
searching installer after a while.

Reproduce:
    1. In console terminal, type CTRL+S to send XOFF
    2. telnet/ssh to DUT, and tail -f /var/log/onie.log
    3. The discover loop will stop searching after a while,
       since linux kernel console buffer is full.
