### PR TITLE
Accton platforms: update u-boot patch

### DIFF
--- a/machine/accton/accton_as5700_96x/u-boot/platform-accton-as5700_96x.patch
+++ b/machine/accton/accton_as5700_96x/u-boot/platform-accton-as5700_96x.patch
@@ -4578,7 +4578,7 @@ index e8613be..f3bedb0 100644
  
  static struct cpu_type cpu_type_unknown = CPU_TYPE_ENTRY(Unknown, Unknown, 0);
 diff --git a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
-index 6265e52..644ed40 100644
+index 2c71089..5a5945c 100644
 --- a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 +++ b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 @@ -305,7 +305,7 @@ static void set_timing_cfg_0(fsl_ddr_cfg_regs_t *ddr,
@@ -4632,7 +4632,7 @@ index 6265e52..644ed40 100644
  	if (popts->dic_override)
  		dic = popts->dic;
  	/*
-@@ -1346,9 +1351,10 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
+@@ -1350,9 +1355,10 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
  		wrlvl_mrd = 0x6;
  		/* tWL_ODTEN 128 */
  		wrlvl_odten = 0x7;
@@ -4646,7 +4646,7 @@ index 6265e52..644ed40 100644
  		/* tWL_DQSEN min = 25 nCK, we set it 32 */
  		wrlvl_dqsen = 0x5;
  		/*
-@@ -1597,8 +1603,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1601,8 +1607,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  				| ((ea & 0xFFF) << 0)	/* ending address MSB */
  				);
  		} else {
@@ -4657,7 +4657,7 @@ index 6265e52..644ed40 100644
  		}
  
  		debug("FSLDDR: cs[%d]_bnds = 0x%08x\n", i, ddr->cs[i].bnds);
-@@ -1650,5 +1656,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1654,5 +1660,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  
  	set_ddr_sdram_rcw(ddr, popts, common_dimm);
  
@@ -24927,10 +24927,10 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS5700_96X.h b/include/configs/AS5700_96X.h
 new file mode 100644
-index 0000000..7a09e6d
+index 0000000..a4a499b
 --- /dev/null
 +++ b/include/configs/AS5700_96X.h
-@@ -0,0 +1,687 @@
+@@ -0,0 +1,658 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -25227,9 +25227,6 @@ index 0000000..7a09e6d
 +#define CONFIG_SYS_NS16550_REG_SIZE	1
 +#define CONFIG_SYS_NS16550_CLK		(get_bus_freq(0)/2)
 +
-+#define CONFIG_SYS_BAUDRATE_TABLE	\
-+	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200}
-+
 +#define CONFIG_SYS_NS16550_COM1	(CONFIG_SYS_CCSRBAR+0x11C500)
 +#define CONFIG_SYS_NS16550_COM2	(CONFIG_SYS_CCSRBAR+0x11C600)
 +#define CONFIG_SYS_NS16550_COM3	(CONFIG_SYS_CCSRBAR+0x11D500)
@@ -25238,13 +25235,7 @@ index 0000000..7a09e6d
 +/* Use the HUSH parser */
 +#define CONFIG_SYS_HUSH_PARSER
 +
-+/* pass open firmware flat tree */
-+#define CONFIG_OF_LIBFDT
-+#define CONFIG_OF_BOARD_SETUP
-+#define CONFIG_OF_STDOUT_VIA_ALIAS
-+
 +/* new uImage format support */
-+#define CONFIG_FIT
 +#define CONFIG_FIT_VERBOSE	/* enable fit_format_{error,warning}() */
 +
 +/* I2C */
@@ -25362,7 +25353,6 @@ index 0000000..7a09e6d
 +#define CONFIG_E1000
 +
 +#define CONFIG_PCI_SCAN_SHOW		/* show pci devices on startup */
-+#define CONFIG_DOS_PARTITION
 +#endif	/* CONFIG_PCI */
 +
 +#ifdef CONFIG_FMAN_ENET
@@ -25388,8 +25378,6 @@ index 0000000..7a09e6d
 +/*
 + * Environment
 + */
-+#define CONFIG_LOADS_ECHO		/* echo on for serial download */
-+#define CONFIG_SYS_LOADS_BAUD_CHANGE	/* allow baudrate change */
 +
 +/*
 + * Command line configuration.
@@ -25441,7 +25429,6 @@ index 0000000..7a09e6d
 +#define CONFIG_GENERIC_MMC
 +#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_FAT
-+#define CONFIG_DOS_PARTITION
 +#endif
 +
 +/*
@@ -25452,18 +25439,6 @@ index 0000000..7a09e6d
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
 +#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
-+#ifdef CONFIG_CMD_KGDB
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+/* Print Buffer Size */
-+#define CONFIG_SYS_PBSIZE	(CONFIG_SYS_CBSIZE + \
-+				sizeof(CONFIG_SYS_PROMPT)+16)
-+#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
-+/* Boot Argument Buffer Size */
-+#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
-+#define CONFIG_SYS_HZ		1000		/* decrementer freq 1ms ticks */
 +
 +/*
 + * For booting Linux, the board info and command line data
@@ -25487,10 +25462,6 @@ index 0000000..7a09e6d
 +
 +/* default location for tftp and bootm */
 +#define CONFIG_LOADADDR		1000000
-+
-+/*#define CONFIG_BOOTDELAY	5*/	/* -1 disables auto-boot */
-+
-+#define CONFIG_BAUDRATE	115200
 +
 +#define __USB_PHY_TYPE	utmi
 +
@@ -30417,84 +30388,6 @@ index 76b3ca6..3a166d9 100644
 +#endif
 +
 +#endif	/* __CONFIG_H */
-diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..46308b8 100644
---- a/include/configs/common_config.h
-+++ b/include/configs/common_config.h
-@@ -26,7 +26,7 @@
- #ifndef COMMON_CONFIG_H__
- #define COMMON_CONFIG_H__
- 
--#include "configs/onie_common_config.h"
-+#include "onie_common_config.h"
- 
- /*
-  * Commands common to onie installation platforms.
-@@ -75,16 +75,19 @@
- #define CONFIG_CMDLINE_EDITING		/* Command-line editing */
- #define CONFIG_AUTO_COMPLETE		/* add autocompletion support */
- 
--#define CONFIG_SYS_CBSIZE	2048	/* Console I/O Buffer Size */
--/* Print Buffer Size */
--#define CONFIG_SYS_PBSIZE (CONFIG_SYS_CBSIZE+sizeof(CONFIG_SYS_PROMPT)+16)
--#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
--/* Boot Argument Buffer Size */
--#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
--/* decrementer freq: 1ms ticks */
--#define CONFIG_SYS_HZ		1000
-+#if defined(CONFIG_CMD_KGDB)
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+
-+
-+
-+
-+
-+
-+
- 
--#define CONFIG_DOS_PARTITION    1               /* support DOS partitions */
- 
- /*
-  * For booting Linux, the board info and command line data
-@@ -104,8 +107,8 @@
- #define CONFIG_BOOTP_SUBNETMASK
- #define CONFIG_BOOTP_OPTIONS
- 
--#define CONFIG_LOADS_ECHO	1	/* echo on for serial download */
--#define CONFIG_SYS_LOADS_BAUD_CHANGE	1	/* allow baudrate change */
-+
-+
- 
- /* Use the HUSH parser */
- #define CONFIG_SYS_HUSH_PARSER
-@@ -124,16 +127,16 @@
- #define CONFIG_SYS_PCIE3_NAME	"Slot 3"
- #endif
- 
--/* pass open firmware flat tree */
--#define CONFIG_OF_LIBFDT		1
--#define CONFIG_OF_BOARD_SETUP		1
--#define CONFIG_OF_STDOUT_VIA_ALIAS	1
- 
--#define CONFIG_FIT			1
- 
--/* common baudrates */
--#define CONFIG_SYS_BAUDRATE_TABLE	\
--	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 115200}
-+
-+
-+
-+
-+
-+
-+
-+
- 
- #define CONFIG_ENV_SIZE		0x2000
- 
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as5700_96x/u-boot/series
+++ b/machine/accton/accton_as5700_96x/u-boot/series
@@ -1,1 +1,2 @@
+# This series applies on GIT commit e6aee6ad3c7942b8d6d93d18895a2990fd22dcf6
 platform-accton-as5700_96x.patch

--- a/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
+++ b/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
@@ -4578,7 +4578,7 @@ index e8613be..f3bedb0 100644
  
  static struct cpu_type cpu_type_unknown = CPU_TYPE_ENTRY(Unknown, Unknown, 0);
 diff --git a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
-index 6265e52..644ed40 100644
+index 2c71089..5a5945c 100644
 --- a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 +++ b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 @@ -305,7 +305,7 @@ static void set_timing_cfg_0(fsl_ddr_cfg_regs_t *ddr,
@@ -4632,7 +4632,7 @@ index 6265e52..644ed40 100644
  	if (popts->dic_override)
  		dic = popts->dic;
  	/*
-@@ -1346,9 +1351,10 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
+@@ -1350,9 +1355,10 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
  		wrlvl_mrd = 0x6;
  		/* tWL_ODTEN 128 */
  		wrlvl_odten = 0x7;
@@ -4646,7 +4646,7 @@ index 6265e52..644ed40 100644
  		/* tWL_DQSEN min = 25 nCK, we set it 32 */
  		wrlvl_dqsen = 0x5;
  		/*
-@@ -1597,8 +1603,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1601,8 +1607,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  				| ((ea & 0xFFF) << 0)	/* ending address MSB */
  				);
  		} else {
@@ -4657,7 +4657,7 @@ index 6265e52..644ed40 100644
  		}
  
  		debug("FSLDDR: cs[%d]_bnds = 0x%08x\n", i, ddr->cs[i].bnds);
-@@ -1650,5 +1656,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1654,5 +1660,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  
  	set_ddr_sdram_rcw(ddr, popts, common_dimm);
  
@@ -24927,10 +24927,10 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS5710_54X.h b/include/configs/AS5710_54X.h
 new file mode 100644
-index 0000000..809e4e7
+index 0000000..02c2a8d
 --- /dev/null
 +++ b/include/configs/AS5710_54X.h
-@@ -0,0 +1,687 @@
+@@ -0,0 +1,658 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -25227,9 +25227,6 @@ index 0000000..809e4e7
 +#define CONFIG_SYS_NS16550_REG_SIZE	1
 +#define CONFIG_SYS_NS16550_CLK		(get_bus_freq(0)/2)
 +
-+#define CONFIG_SYS_BAUDRATE_TABLE	\
-+	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200}
-+
 +#define CONFIG_SYS_NS16550_COM1	(CONFIG_SYS_CCSRBAR+0x11C500)
 +#define CONFIG_SYS_NS16550_COM2	(CONFIG_SYS_CCSRBAR+0x11C600)
 +#define CONFIG_SYS_NS16550_COM3	(CONFIG_SYS_CCSRBAR+0x11D500)
@@ -25238,13 +25235,7 @@ index 0000000..809e4e7
 +/* Use the HUSH parser */
 +#define CONFIG_SYS_HUSH_PARSER
 +
-+/* pass open firmware flat tree */
-+#define CONFIG_OF_LIBFDT
-+#define CONFIG_OF_BOARD_SETUP
-+#define CONFIG_OF_STDOUT_VIA_ALIAS
-+
 +/* new uImage format support */
-+#define CONFIG_FIT
 +#define CONFIG_FIT_VERBOSE	/* enable fit_format_{error,warning}() */
 +
 +/* I2C */
@@ -25362,7 +25353,6 @@ index 0000000..809e4e7
 +#define CONFIG_E1000
 +
 +#define CONFIG_PCI_SCAN_SHOW		/* show pci devices on startup */
-+#define CONFIG_DOS_PARTITION
 +#endif	/* CONFIG_PCI */
 +
 +#ifdef CONFIG_FMAN_ENET
@@ -25388,8 +25378,6 @@ index 0000000..809e4e7
 +/*
 + * Environment
 + */
-+#define CONFIG_LOADS_ECHO		/* echo on for serial download */
-+#define CONFIG_SYS_LOADS_BAUD_CHANGE	/* allow baudrate change */
 +
 +/*
 + * Command line configuration.
@@ -25441,7 +25429,6 @@ index 0000000..809e4e7
 +#define CONFIG_GENERIC_MMC
 +#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_FAT
-+#define CONFIG_DOS_PARTITION
 +#endif
 +
 +/*
@@ -25452,18 +25439,6 @@ index 0000000..809e4e7
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
 +#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
-+#ifdef CONFIG_CMD_KGDB
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+/* Print Buffer Size */
-+#define CONFIG_SYS_PBSIZE	(CONFIG_SYS_CBSIZE + \
-+				sizeof(CONFIG_SYS_PROMPT)+16)
-+#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
-+/* Boot Argument Buffer Size */
-+#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
-+#define CONFIG_SYS_HZ		1000		/* decrementer freq 1ms ticks */
 +
 +/*
 + * For booting Linux, the board info and command line data
@@ -25487,10 +25462,6 @@ index 0000000..809e4e7
 +
 +/* default location for tftp and bootm */
 +#define CONFIG_LOADADDR		1000000
-+
-+/*#define CONFIG_BOOTDELAY	5*/	/* -1 disables auto-boot */
-+
-+#define CONFIG_BAUDRATE	115200
 +
 +#define __USB_PHY_TYPE	utmi
 +
@@ -30417,84 +30388,6 @@ index 76b3ca6..3a166d9 100644
 +#endif
 +
 +#endif	/* __CONFIG_H */
-diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..46308b8 100644
---- a/include/configs/common_config.h
-+++ b/include/configs/common_config.h
-@@ -26,7 +26,7 @@
- #ifndef COMMON_CONFIG_H__
- #define COMMON_CONFIG_H__
- 
--#include "configs/onie_common_config.h"
-+#include "onie_common_config.h"
- 
- /*
-  * Commands common to onie installation platforms.
-@@ -75,16 +75,19 @@
- #define CONFIG_CMDLINE_EDITING		/* Command-line editing */
- #define CONFIG_AUTO_COMPLETE		/* add autocompletion support */
- 
--#define CONFIG_SYS_CBSIZE	2048	/* Console I/O Buffer Size */
--/* Print Buffer Size */
--#define CONFIG_SYS_PBSIZE (CONFIG_SYS_CBSIZE+sizeof(CONFIG_SYS_PROMPT)+16)
--#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
--/* Boot Argument Buffer Size */
--#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
--/* decrementer freq: 1ms ticks */
--#define CONFIG_SYS_HZ		1000
-+#if defined(CONFIG_CMD_KGDB)
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+
-+
-+
-+
-+
-+
-+
- 
--#define CONFIG_DOS_PARTITION    1               /* support DOS partitions */
- 
- /*
-  * For booting Linux, the board info and command line data
-@@ -104,8 +107,8 @@
- #define CONFIG_BOOTP_SUBNETMASK
- #define CONFIG_BOOTP_OPTIONS
- 
--#define CONFIG_LOADS_ECHO	1	/* echo on for serial download */
--#define CONFIG_SYS_LOADS_BAUD_CHANGE	1	/* allow baudrate change */
-+
-+
- 
- /* Use the HUSH parser */
- #define CONFIG_SYS_HUSH_PARSER
-@@ -124,16 +127,16 @@
- #define CONFIG_SYS_PCIE3_NAME	"Slot 3"
- #endif
- 
--/* pass open firmware flat tree */
--#define CONFIG_OF_LIBFDT		1
--#define CONFIG_OF_BOARD_SETUP		1
--#define CONFIG_OF_STDOUT_VIA_ALIAS	1
- 
--#define CONFIG_FIT			1
- 
--/* common baudrates */
--#define CONFIG_SYS_BAUDRATE_TABLE	\
--	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 115200}
-+
-+
-+
-+
-+
-+
-+
-+
- 
- #define CONFIG_ENV_SIZE		0x2000
- 
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as5710_54x/u-boot/series
+++ b/machine/accton/accton_as5710_54x/u-boot/series
@@ -1,1 +1,2 @@
+# This series applies on GIT commit 9d0e4ad6f2bc6e25245c09b97fa775116fd151de
 platform-accton-as5710_54x.patch

--- a/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
+++ b/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
@@ -4601,7 +4601,7 @@ index e8613be..f3bedb0 100644
  
  static struct cpu_type cpu_type_unknown = CPU_TYPE_ENTRY(Unknown, Unknown, 0);
 diff --git a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
-index 6265e52..b3a061c 100644
+index 2c71089..81971d6 100644
 --- a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 +++ b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 @@ -375,7 +375,7 @@ static void set_timing_cfg_3(fsl_ddr_cfg_regs_t *ddr,
@@ -4638,7 +4638,7 @@ index 6265e52..b3a061c 100644
  		| (qd_en << 9)
  		| (unq_mrs_en << 8)
  		| ((obc_cfg & 0x1) << 6)
-@@ -1346,9 +1350,9 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
+@@ -1350,9 +1354,9 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
  		wrlvl_mrd = 0x6;
  		/* tWL_ODTEN 128 */
  		wrlvl_odten = 0x7;
@@ -4651,7 +4651,7 @@ index 6265e52..b3a061c 100644
  		/* tWL_DQSEN min = 25 nCK, we set it 32 */
  		wrlvl_dqsen = 0x5;
  		/*
-@@ -1597,8 +1601,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1601,8 +1605,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  				| ((ea & 0xFFF) << 0)	/* ending address MSB */
  				);
  		} else {
@@ -4662,7 +4662,7 @@ index 6265e52..b3a061c 100644
  		}
  
  		debug("FSLDDR: cs[%d]_bnds = 0x%08x\n", i, ddr->cs[i].bnds);
-@@ -1650,5 +1654,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1654,5 +1658,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  
  	set_ddr_sdram_rcw(ddr, popts, common_dimm);
  
@@ -37451,10 +37451,10 @@ index a29f6a6..f26a80d 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/ACCTON_AS6700_32X-R0.h b/include/configs/ACCTON_AS6700_32X-R0.h
 new file mode 100644
-index 0000000..2ed0c8b
+index 0000000..709a680
 --- /dev/null
 +++ b/include/configs/ACCTON_AS6700_32X-R0.h
-@@ -0,0 +1,879 @@
+@@ -0,0 +1,850 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -37823,9 +37823,6 @@ index 0000000..2ed0c8b
 +#define CONFIG_SYS_NS16550_REG_SIZE	1
 +#define CONFIG_SYS_NS16550_CLK		(get_bus_freq(0)/2)
 +
-+#define CONFIG_SYS_BAUDRATE_TABLE	\
-+	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200}
-+
 +#define CONFIG_SYS_NS16550_COM1	(CONFIG_SYS_CCSRBAR+0x11C500)
 +#define CONFIG_SYS_NS16550_COM2	(CONFIG_SYS_CCSRBAR+0x11C600)
 +#define CONFIG_SYS_NS16550_COM3	(CONFIG_SYS_CCSRBAR+0x11D500)
@@ -37834,13 +37831,7 @@ index 0000000..2ed0c8b
 +/* Use the HUSH parser */
 +#define CONFIG_SYS_HUSH_PARSER
 +
-+/* pass open firmware flat tree */
-+#define CONFIG_OF_LIBFDT
-+#define CONFIG_OF_BOARD_SETUP
-+#define CONFIG_OF_STDOUT_VIA_ALIAS
-+
 +/* new uImage format support */
-+#define CONFIG_FIT
 +#define CONFIG_FIT_VERBOSE	/* enable fit_format_{error,warning}() */
 +
 +/* I2C */
@@ -38088,7 +38079,6 @@ index 0000000..2ed0c8b
 +#define CONFIG_E1000
 +
 +#define CONFIG_PCI_SCAN_SHOW		/* show pci devices on startup */
-+#define CONFIG_DOS_PARTITION
 +#endif	/* CONFIG_PCI */
 +
 +/* SATA */
@@ -38108,7 +38098,6 @@ index 0000000..2ed0c8b
 +
 +#define CONFIG_LBA48
 +#define CONFIG_CMD_SATA
-+#define CONFIG_DOS_PARTITION
 +#define CONFIG_CMD_EXT2
 +#endif
 +
@@ -38135,8 +38124,6 @@ index 0000000..2ed0c8b
 +/*
 + * Environment
 + */
-+#define CONFIG_LOADS_ECHO		/* echo on for serial download */
-+#define CONFIG_SYS_LOADS_BAUD_CHANGE	/* allow baudrate change */
 +
 +/*
 + * Command line configuration.
@@ -38184,7 +38171,6 @@ index 0000000..2ed0c8b
 +#define CONFIG_GENERIC_MMC
 +#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_FAT
-+#define CONFIG_DOS_PARTITION
 +#endif
 +
 +/*
@@ -38195,18 +38181,6 @@ index 0000000..2ed0c8b
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
 +#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
-+#ifdef CONFIG_CMD_KGDB
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+/* Print Buffer Size */
-+#define CONFIG_SYS_PBSIZE	(CONFIG_SYS_CBSIZE + \
-+				sizeof(CONFIG_SYS_PROMPT)+16)
-+#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
-+/* Boot Argument Buffer Size */
-+#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
-+#define CONFIG_SYS_HZ		1000		/* decrementer freq 1ms ticks */
 +
 +/*
 + * For booting Linux, the board info and command line data
@@ -38230,11 +38204,6 @@ index 0000000..2ed0c8b
 +
 +/* default location for tftp and bootm */
 +#define CONFIG_LOADADDR     2000000
-+
-+/* -1 disables auto-boot */
-+#define CONFIG_BOOTDELAY 3
-+
-+#define CONFIG_BAUDRATE	115200
 +
 +#define __USB_PHY_TYPE	utmi
 +
@@ -38302,6 +38271,8 @@ index 0000000..2ed0c8b
 +/* ONIE */
 +#include "common_config.h"
 +
++#undef CONFIG_CMD_JFFS2
++
 +#define CONFIG_SYS_EEPROM_LOAD_ENV_MAC
 +#define CONFIG_CMD_SYS_EEPROM
 +#define CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS 2
@@ -38336,10 +38307,10 @@ index 0000000..2ed0c8b
 +#endif	/* __CONFIG_H */
 diff --git a/include/configs/ACCTON_AS6700_32X-R1.h b/include/configs/ACCTON_AS6700_32X-R1.h
 new file mode 100644
-index 0000000..873c69a
+index 0000000..6a6d65b
 --- /dev/null
 +++ b/include/configs/ACCTON_AS6700_32X-R1.h
-@@ -0,0 +1,880 @@
+@@ -0,0 +1,851 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -38709,9 +38680,6 @@ index 0000000..873c69a
 +#define CONFIG_SYS_NS16550_REG_SIZE	1
 +#define CONFIG_SYS_NS16550_CLK		(get_bus_freq(0)/2)
 +
-+#define CONFIG_SYS_BAUDRATE_TABLE	\
-+	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200}
-+
 +#define CONFIG_SYS_NS16550_COM1	(CONFIG_SYS_CCSRBAR+0x11C500)
 +#define CONFIG_SYS_NS16550_COM2	(CONFIG_SYS_CCSRBAR+0x11C600)
 +#define CONFIG_SYS_NS16550_COM3	(CONFIG_SYS_CCSRBAR+0x11D500)
@@ -38720,13 +38688,7 @@ index 0000000..873c69a
 +/* Use the HUSH parser */
 +#define CONFIG_SYS_HUSH_PARSER
 +
-+/* pass open firmware flat tree */
-+#define CONFIG_OF_LIBFDT
-+#define CONFIG_OF_BOARD_SETUP
-+#define CONFIG_OF_STDOUT_VIA_ALIAS
-+
 +/* new uImage format support */
-+#define CONFIG_FIT
 +#define CONFIG_FIT_VERBOSE	/* enable fit_format_{error,warning}() */
 +
 +/* I2C */
@@ -38974,7 +38936,6 @@ index 0000000..873c69a
 +#define CONFIG_E1000
 +
 +#define CONFIG_PCI_SCAN_SHOW		/* show pci devices on startup */
-+#define CONFIG_DOS_PARTITION
 +#endif	/* CONFIG_PCI */
 +
 +/* SATA */
@@ -38994,7 +38955,6 @@ index 0000000..873c69a
 +
 +#define CONFIG_LBA48
 +#define CONFIG_CMD_SATA
-+#define CONFIG_DOS_PARTITION
 +#define CONFIG_CMD_EXT2
 +#endif
 +
@@ -39021,8 +38981,6 @@ index 0000000..873c69a
 +/*
 + * Environment
 + */
-+#define CONFIG_LOADS_ECHO		/* echo on for serial download */
-+#define CONFIG_SYS_LOADS_BAUD_CHANGE	/* allow baudrate change */
 +
 +/*
 + * Command line configuration.
@@ -39070,7 +39028,6 @@ index 0000000..873c69a
 +#define CONFIG_GENERIC_MMC
 +#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_FAT
-+#define CONFIG_DOS_PARTITION
 +#endif
 +
 +/*
@@ -39081,18 +39038,6 @@ index 0000000..873c69a
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
 +#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
-+#ifdef CONFIG_CMD_KGDB
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+/* Print Buffer Size */
-+#define CONFIG_SYS_PBSIZE	(CONFIG_SYS_CBSIZE + \
-+				sizeof(CONFIG_SYS_PROMPT)+16)
-+#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
-+/* Boot Argument Buffer Size */
-+#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
-+#define CONFIG_SYS_HZ		1000		/* decrementer freq 1ms ticks */
 +
 +/*
 + * For booting Linux, the board info and command line data
@@ -39116,11 +39061,6 @@ index 0000000..873c69a
 +
 +/* default location for tftp and bootm */
 +#define CONFIG_LOADADDR     2000000
-+
-+/* -1 disables auto-boot */
-+#define CONFIG_BOOTDELAY 3
-+
-+#define CONFIG_BAUDRATE	115200
 +
 +#define __USB_PHY_TYPE	utmi
 +
@@ -39187,6 +39127,8 @@ index 0000000..873c69a
 +
 +/* ONIE */
 +#include "common_config.h"
++
++#undef CONFIG_CMD_JFFS2
 +
 +#define CONFIG_SYS_EEPROM_LOAD_ENV_MAC
 +#define CONFIG_CMD_SYS_EEPROM
@@ -44353,93 +44295,6 @@ index 76b3ca6..3a166d9 100644
 +#endif
 +
 +#endif	/* __CONFIG_H */
-diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..9d0d47d 100644
---- a/include/configs/common_config.h
-+++ b/include/configs/common_config.h
-@@ -26,7 +26,7 @@
- #ifndef COMMON_CONFIG_H__
- #define COMMON_CONFIG_H__
- 
--#include "configs/onie_common_config.h"
-+#include "onie_common_config.h"
- 
- /*
-  * Commands common to onie installation platforms.
-@@ -51,7 +51,7 @@
- #define CONFIG_CMD_IMI		/* iminfo			*/
- #define CONFIG_CMD_IRQ		/* irqinfo			*/
- #define CONFIG_CMD_ITEST	/* Integer (and string) test	*/
--#define CONFIG_CMD_JFFS2	/* JFFS2 Support		*/
-+/*#define CONFIG_CMD_JFFS2*/	/* JFFS2 Support		*/
- #define CONFIG_CMD_MEMORY	/* md mm nm mw cp cmp crc base loop mtest */
- #define CONFIG_CMD_MII		/* MII support			*/
- #define CONFIG_CMD_MISC		/* Misc functions like sleep etc*/
-@@ -75,16 +75,19 @@
- #define CONFIG_CMDLINE_EDITING		/* Command-line editing */
- #define CONFIG_AUTO_COMPLETE		/* add autocompletion support */
- 
--#define CONFIG_SYS_CBSIZE	2048	/* Console I/O Buffer Size */
--/* Print Buffer Size */
--#define CONFIG_SYS_PBSIZE (CONFIG_SYS_CBSIZE+sizeof(CONFIG_SYS_PROMPT)+16)
--#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
--/* Boot Argument Buffer Size */
--#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
--/* decrementer freq: 1ms ticks */
--#define CONFIG_SYS_HZ		1000
-+#if defined(CONFIG_CMD_KGDB)
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+
-+
-+
-+
-+
-+
-+
- 
--#define CONFIG_DOS_PARTITION    1               /* support DOS partitions */
- 
- /*
-  * For booting Linux, the board info and command line data
-@@ -104,8 +107,8 @@
- #define CONFIG_BOOTP_SUBNETMASK
- #define CONFIG_BOOTP_OPTIONS
- 
--#define CONFIG_LOADS_ECHO	1	/* echo on for serial download */
--#define CONFIG_SYS_LOADS_BAUD_CHANGE	1	/* allow baudrate change */
-+
-+
- 
- /* Use the HUSH parser */
- #define CONFIG_SYS_HUSH_PARSER
-@@ -124,16 +127,16 @@
- #define CONFIG_SYS_PCIE3_NAME	"Slot 3"
- #endif
- 
--/* pass open firmware flat tree */
--#define CONFIG_OF_LIBFDT		1
--#define CONFIG_OF_BOARD_SETUP		1
--#define CONFIG_OF_STDOUT_VIA_ALIAS	1
- 
--#define CONFIG_FIT			1
- 
--/* common baudrates */
--#define CONFIG_SYS_BAUDRATE_TABLE	\
--	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 115200}
-+
-+
-+
-+
-+
-+
-+
-+
- 
- #define CONFIG_ENV_SIZE		0x2000
- 
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as6700_32x/u-boot/series
+++ b/machine/accton/accton_as6700_32x/u-boot/series
@@ -1,1 +1,2 @@
+# This series applies on GIT commit 6a07845b1d4095a046bdaa40189e6182f7d671d3
 platform-accton-as6700_32x.patch

--- a/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
+++ b/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
@@ -4551,7 +4551,7 @@ index e8613be..f3bedb0 100644
  
  static struct cpu_type cpu_type_unknown = CPU_TYPE_ENTRY(Unknown, Unknown, 0);
 diff --git a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
-index 6265e52..b3a061c 100644
+index 2c71089..81971d6 100644
 --- a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 +++ b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 @@ -375,7 +375,7 @@ static void set_timing_cfg_3(fsl_ddr_cfg_regs_t *ddr,
@@ -4588,7 +4588,7 @@ index 6265e52..b3a061c 100644
  		| (qd_en << 9)
  		| (unq_mrs_en << 8)
  		| ((obc_cfg & 0x1) << 6)
-@@ -1346,9 +1350,9 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
+@@ -1350,9 +1354,9 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
  		wrlvl_mrd = 0x6;
  		/* tWL_ODTEN 128 */
  		wrlvl_odten = 0x7;
@@ -4601,7 +4601,7 @@ index 6265e52..b3a061c 100644
  		/* tWL_DQSEN min = 25 nCK, we set it 32 */
  		wrlvl_dqsen = 0x5;
  		/*
-@@ -1597,8 +1601,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1601,8 +1605,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  				| ((ea & 0xFFF) << 0)	/* ending address MSB */
  				);
  		} else {
@@ -4612,7 +4612,7 @@ index 6265e52..b3a061c 100644
  		}
  
  		debug("FSLDDR: cs[%d]_bnds = 0x%08x\n", i, ddr->cs[i].bnds);
-@@ -1650,5 +1654,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1654,5 +1658,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  
  	set_ddr_sdram_rcw(ddr, popts, common_dimm);
  
@@ -24822,10 +24822,10 @@ index a29f6a6..f26a80d 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6701_32X.h b/include/configs/AS6701_32X.h
 new file mode 100644
-index 0000000..1adaf21
+index 0000000..fcb7ba7
 --- /dev/null
 +++ b/include/configs/AS6701_32X.h
-@@ -0,0 +1,821 @@
+@@ -0,0 +1,797 @@
 +/*
 + * Copyright 2010-2011 Freescale Semiconductor, Inc.
 + *
@@ -25276,24 +25276,13 @@ index 0000000..1adaf21
 +#define CONFIG_NS16550_MIN_FUNCTIONS
 +#endif
 +
-+#define CONFIG_SYS_BAUDRATE_TABLE	\
-+	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200}
-+
 +#define CONFIG_SYS_NS16550_COM1	(CONFIG_SYS_CCSRBAR+0x4500)
 +#define CONFIG_SYS_NS16550_COM2	(CONFIG_SYS_CCSRBAR+0x4600)
 +
 +/* Use the HUSH parser */
 +#define CONFIG_SYS_HUSH_PARSER
 +
-+/*
-+ * Pass open firmware flat tree
-+ */
-+#define CONFIG_OF_LIBFDT
-+#define CONFIG_OF_BOARD_SETUP
-+#define CONFIG_OF_STDOUT_VIA_ALIAS
-+
 +/* new uImage format support */
-+#define CONFIG_FIT
 +#define CONFIG_FIT_VERBOSE	/* enable fit_format_{error,warning}() */
 +
 +/* I2C */
@@ -25375,7 +25364,6 @@ index 0000000..1adaf21
 +#define CONFIG_CMD_NET
 +
 +#define CONFIG_PCI_SCAN_SHOW	/* show pci devices on startup */
-+#define CONFIG_DOS_PARTITION
 +#endif /* CONFIG_PCI */
 +
 +
@@ -25434,9 +25422,6 @@ index 0000000..1adaf21
 +#define CONFIG_ENV_SECT_SIZE	0x20000 /* 128K (one sector) */
 +#define CONFIG_ENV_ADDR	(CONFIG_SYS_MONITOR_BASE - 0x20000) /* from config_env_sect_size */
 +
-+#define CONFIG_LOADS_ECHO		/* echo on for serial download */
-+#define CONFIG_SYS_LOADS_BAUD_CHANGE	/* allow baudrate change */
-+
 +/*
 + * Command line configuration.
 + */
@@ -25480,7 +25465,6 @@ index 0000000..1adaf21
 +		 || defined(CONFIG_FSL_SATA)
 +#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_FAT
-+#define CONFIG_DOS_PARTITION
 +#endif
 +
 +#undef CONFIG_WATCHDOG	/* watchdog disabled */
@@ -25493,16 +25477,6 @@ index 0000000..1adaf21
 +#define CONFIG_AUTO_COMPLETE            /* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
 +#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
-+#if defined(CONFIG_CMD_KGDB)
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+#define CONFIG_SYS_PBSIZE (CONFIG_SYS_CBSIZE + sizeof(CONFIG_SYS_PROMPT) + 16)
-+	/* Print Buffer Size */
-+#define CONFIG_SYS_MAXARGS	16	/* max number of command args */
-+#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE/* Boot Argument Buffer Size */
-+#define CONFIG_SYS_HZ		1000	/* decrementer freq: 1ms tick */
 +
 +/*
 + * For booting Linux, the board info and command line data
@@ -25620,6 +25594,8 @@ index 0000000..1adaf21
 +
 +/* ONIE */
 +#include "common_config.h"
++
++#undef CONFIG_CMD_JFFS2
 +
 +#define CONFIG_SYS_EEPROM_LOAD_ENV_MAC
 +#define CONFIG_CMD_SYS_EEPROM
@@ -30446,93 +30422,6 @@ index 76b3ca6..3a166d9 100644
 +#endif
 +
 +#endif	/* __CONFIG_H */
-diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..9d0d47d 100644
---- a/include/configs/common_config.h
-+++ b/include/configs/common_config.h
-@@ -26,7 +26,7 @@
- #ifndef COMMON_CONFIG_H__
- #define COMMON_CONFIG_H__
- 
--#include "configs/onie_common_config.h"
-+#include "onie_common_config.h"
- 
- /*
-  * Commands common to onie installation platforms.
-@@ -51,7 +51,7 @@
- #define CONFIG_CMD_IMI		/* iminfo			*/
- #define CONFIG_CMD_IRQ		/* irqinfo			*/
- #define CONFIG_CMD_ITEST	/* Integer (and string) test	*/
--#define CONFIG_CMD_JFFS2	/* JFFS2 Support		*/
-+/*#define CONFIG_CMD_JFFS2*/	/* JFFS2 Support		*/
- #define CONFIG_CMD_MEMORY	/* md mm nm mw cp cmp crc base loop mtest */
- #define CONFIG_CMD_MII		/* MII support			*/
- #define CONFIG_CMD_MISC		/* Misc functions like sleep etc*/
-@@ -75,16 +75,19 @@
- #define CONFIG_CMDLINE_EDITING		/* Command-line editing */
- #define CONFIG_AUTO_COMPLETE		/* add autocompletion support */
- 
--#define CONFIG_SYS_CBSIZE	2048	/* Console I/O Buffer Size */
--/* Print Buffer Size */
--#define CONFIG_SYS_PBSIZE (CONFIG_SYS_CBSIZE+sizeof(CONFIG_SYS_PROMPT)+16)
--#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
--/* Boot Argument Buffer Size */
--#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
--/* decrementer freq: 1ms ticks */
--#define CONFIG_SYS_HZ		1000
-+#if defined(CONFIG_CMD_KGDB)
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+
-+
-+
-+
-+
-+
-+
- 
--#define CONFIG_DOS_PARTITION    1               /* support DOS partitions */
- 
- /*
-  * For booting Linux, the board info and command line data
-@@ -104,8 +107,8 @@
- #define CONFIG_BOOTP_SUBNETMASK
- #define CONFIG_BOOTP_OPTIONS
- 
--#define CONFIG_LOADS_ECHO	1	/* echo on for serial download */
--#define CONFIG_SYS_LOADS_BAUD_CHANGE	1	/* allow baudrate change */
-+
-+
- 
- /* Use the HUSH parser */
- #define CONFIG_SYS_HUSH_PARSER
-@@ -124,16 +127,16 @@
- #define CONFIG_SYS_PCIE3_NAME	"Slot 3"
- #endif
- 
--/* pass open firmware flat tree */
--#define CONFIG_OF_LIBFDT		1
--#define CONFIG_OF_BOARD_SETUP		1
--#define CONFIG_OF_STDOUT_VIA_ALIAS	1
- 
--#define CONFIG_FIT			1
- 
--/* common baudrates */
--#define CONFIG_SYS_BAUDRATE_TABLE	\
--	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 115200}
-+
-+
-+
-+
-+
-+
-+
-+
- 
- #define CONFIG_ENV_SIZE		0x2000
- 
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as6701_32x/u-boot/series
+++ b/machine/accton/accton_as6701_32x/u-boot/series
@@ -1,1 +1,2 @@
+# This series applies on GIT commit 96279233ea1ece69e9e48724de4712599cf7ecbf
 platform-accton-as6701_32x.patch

--- a/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
+++ b/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
@@ -4578,7 +4578,7 @@ index e8613be..f3bedb0 100644
  
  static struct cpu_type cpu_type_unknown = CPU_TYPE_ENTRY(Unknown, Unknown, 0);
 diff --git a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
-index 6265e52..644ed40 100644
+index 2c71089..5a5945c 100644
 --- a/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 +++ b/arch/powerpc/cpu/mpc8xxx/ddr/ctrl_regs.c
 @@ -305,7 +305,7 @@ static void set_timing_cfg_0(fsl_ddr_cfg_regs_t *ddr,
@@ -4632,7 +4632,7 @@ index 6265e52..644ed40 100644
  	if (popts->dic_override)
  		dic = popts->dic;
  	/*
-@@ -1346,9 +1351,10 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
+@@ -1350,9 +1355,10 @@ static void set_ddr_wrlvl_cntl(fsl_ddr_cfg_regs_t *ddr, unsigned int wrlvl_en,
  		wrlvl_mrd = 0x6;
  		/* tWL_ODTEN 128 */
  		wrlvl_odten = 0x7;
@@ -4646,7 +4646,7 @@ index 6265e52..644ed40 100644
  		/* tWL_DQSEN min = 25 nCK, we set it 32 */
  		wrlvl_dqsen = 0x5;
  		/*
-@@ -1597,8 +1603,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1601,8 +1607,8 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  				| ((ea & 0xFFF) << 0)	/* ending address MSB */
  				);
  		} else {
@@ -4657,7 +4657,7 @@ index 6265e52..644ed40 100644
  		}
  
  		debug("FSLDDR: cs[%d]_bnds = 0x%08x\n", i, ddr->cs[i].bnds);
-@@ -1650,5 +1656,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
+@@ -1654,5 +1660,10 @@ compute_fsl_memctl_config_regs(const memctl_options_t *popts,
  
  	set_ddr_sdram_rcw(ddr, popts, common_dimm);
  
@@ -24958,10 +24958,10 @@ index a29f6a6..997efd5 100644
  int set_cpu_clk_info(void);
 diff --git a/include/configs/AS6710_32X.h b/include/configs/AS6710_32X.h
 new file mode 100644
-index 0000000..e65dc71
+index 0000000..8a7247f
 --- /dev/null
 +++ b/include/configs/AS6710_32X.h
-@@ -0,0 +1,689 @@
+@@ -0,0 +1,664 @@
 +/*
 + * Copyright 2011-2012 Freescale Semiconductor, Inc.
 + *
@@ -25258,9 +25258,6 @@ index 0000000..e65dc71
 +#define CONFIG_SYS_NS16550_REG_SIZE	1
 +#define CONFIG_SYS_NS16550_CLK		(get_bus_freq(0)/2)
 +
-+#define CONFIG_SYS_BAUDRATE_TABLE	\
-+	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200}
-+
 +#define CONFIG_SYS_NS16550_COM1	(CONFIG_SYS_CCSRBAR+0x11C500)
 +#define CONFIG_SYS_NS16550_COM2	(CONFIG_SYS_CCSRBAR+0x11C600)
 +#define CONFIG_SYS_NS16550_COM3	(CONFIG_SYS_CCSRBAR+0x11D500)
@@ -25269,13 +25266,7 @@ index 0000000..e65dc71
 +/* Use the HUSH parser */
 +#define CONFIG_SYS_HUSH_PARSER
 +
-+/* pass open firmware flat tree */
-+#define CONFIG_OF_LIBFDT
-+#define CONFIG_OF_BOARD_SETUP
-+#define CONFIG_OF_STDOUT_VIA_ALIAS
-+
 +/* new uImage format support */
-+#define CONFIG_FIT
 +#define CONFIG_FIT_VERBOSE	/* enable fit_format_{error,warning}() */
 +
 +/* I2C */
@@ -25393,7 +25384,6 @@ index 0000000..e65dc71
 +#define CONFIG_E1000
 +
 +#define CONFIG_PCI_SCAN_SHOW		/* show pci devices on startup */
-+#define CONFIG_DOS_PARTITION
 +#endif	/* CONFIG_PCI */
 +
 +#ifdef CONFIG_FMAN_ENET
@@ -25419,8 +25409,6 @@ index 0000000..e65dc71
 +/*
 + * Environment
 + */
-+#define CONFIG_LOADS_ECHO		/* echo on for serial download */
-+#define CONFIG_SYS_LOADS_BAUD_CHANGE	/* allow baudrate change */
 +
 +/*
 + * Command line configuration.
@@ -25472,7 +25460,6 @@ index 0000000..e65dc71
 +#define CONFIG_GENERIC_MMC
 +#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_FAT
-+#define CONFIG_DOS_PARTITION
 +#endif
 +
 +/*
@@ -25483,18 +25470,6 @@ index 0000000..e65dc71
 +#define CONFIG_AUTO_COMPLETE			/* add autocompletion support */
 +#define CONFIG_SYS_LOAD_ADDR	0x2000000	/* default load address */
 +#define CONFIG_SYS_PROMPT	"LOADER=> "	/* Monitor Command Prompt */
-+#ifdef CONFIG_CMD_KGDB
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+/* Print Buffer Size */
-+#define CONFIG_SYS_PBSIZE	(CONFIG_SYS_CBSIZE + \
-+				sizeof(CONFIG_SYS_PROMPT)+16)
-+#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
-+/* Boot Argument Buffer Size */
-+#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
-+#define CONFIG_SYS_HZ		1000		/* decrementer freq 1ms ticks */
 +
 +/*
 + * For booting Linux, the board info and command line data
@@ -30450,84 +30425,6 @@ index 76b3ca6..3a166d9 100644
 +#endif
 +
 +#endif	/* __CONFIG_H */
-diff --git a/include/configs/common_config.h b/include/configs/common_config.h
-index e9e2135..46308b8 100644
---- a/include/configs/common_config.h
-+++ b/include/configs/common_config.h
-@@ -26,7 +26,7 @@
- #ifndef COMMON_CONFIG_H__
- #define COMMON_CONFIG_H__
- 
--#include "configs/onie_common_config.h"
-+#include "onie_common_config.h"
- 
- /*
-  * Commands common to onie installation platforms.
-@@ -75,16 +75,19 @@
- #define CONFIG_CMDLINE_EDITING		/* Command-line editing */
- #define CONFIG_AUTO_COMPLETE		/* add autocompletion support */
- 
--#define CONFIG_SYS_CBSIZE	2048	/* Console I/O Buffer Size */
--/* Print Buffer Size */
--#define CONFIG_SYS_PBSIZE (CONFIG_SYS_CBSIZE+sizeof(CONFIG_SYS_PROMPT)+16)
--#define CONFIG_SYS_MAXARGS	16		/* max number of command args */
--/* Boot Argument Buffer Size */
--#define CONFIG_SYS_BARGSIZE	CONFIG_SYS_CBSIZE
--/* decrementer freq: 1ms ticks */
--#define CONFIG_SYS_HZ		1000
-+#if defined(CONFIG_CMD_KGDB)
-+#define CONFIG_SYS_CBSIZE	1024		/* Console I/O Buffer Size */
-+#else
-+#define CONFIG_SYS_CBSIZE	256		/* Console I/O Buffer Size */
-+#endif
-+
-+
-+
-+
-+
-+
-+
- 
--#define CONFIG_DOS_PARTITION    1               /* support DOS partitions */
- 
- /*
-  * For booting Linux, the board info and command line data
-@@ -104,8 +107,8 @@
- #define CONFIG_BOOTP_SUBNETMASK
- #define CONFIG_BOOTP_OPTIONS
- 
--#define CONFIG_LOADS_ECHO	1	/* echo on for serial download */
--#define CONFIG_SYS_LOADS_BAUD_CHANGE	1	/* allow baudrate change */
-+
-+
- 
- /* Use the HUSH parser */
- #define CONFIG_SYS_HUSH_PARSER
-@@ -124,16 +127,16 @@
- #define CONFIG_SYS_PCIE3_NAME	"Slot 3"
- #endif
- 
--/* pass open firmware flat tree */
--#define CONFIG_OF_LIBFDT		1
--#define CONFIG_OF_BOARD_SETUP		1
--#define CONFIG_OF_STDOUT_VIA_ALIAS	1
- 
--#define CONFIG_FIT			1
- 
--/* common baudrates */
--#define CONFIG_SYS_BAUDRATE_TABLE	\
--	{300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 115200}
-+
-+
-+
-+
-+
-+
-+
-+
- 
- #define CONFIG_ENV_SIZE		0x2000
- 
 diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
 index 3f42cd9..26d1689 100644
 --- a/include/configs/corenet_ds.h

--- a/machine/accton/accton_as6710_32x/u-boot/series
+++ b/machine/accton/accton_as6710_32x/u-boot/series
@@ -1,1 +1,2 @@
+# This series applies on GIT commit b3c5ae0f73d18f3462be6f79681a7965904f7fd9
 platform-accton-as6710_32x.patch


### PR DESCRIPTION
After enabling CONFIG_API option in the `common_config.h`, some Accton platforms need to update patch to fix conflict problem.

The platforms are including:

- AS5700_96X
- AS5710_54X
- AS6700_32X
- AS6701_32X
- AS6710_32X