### PR TITLE
Accton platforms: update u-boot patch

### DIFF
--- a/machine/accton/accton_as4610_30/u-boot/platform-as4610_30.patch
+++ b/machine/accton/accton_as4610_30/u-boot/platform-as4610_30.patch
@@ -2432,36 +2432,10 @@ index 78e85b7..fefca71 100755
  extern void save_shmoo_to_flash(void);
  
 diff --git a/arch/arm/lib/board.c b/arch/arm/lib/board.c
-index 33e7098..747d9bf 100755
+index 466de29..7e042ea 100755
 --- a/arch/arm/lib/board.c
 +++ b/arch/arm/lib/board.c
-@@ -848,6 +848,15 @@ void board_init_r(gd_t *id, ulong dest_addr)
- 	/* initialize environment */
- 	env_relocate();
- 
-+#if defined(CONFIG_ID_EEPROM) || defined(CONFIG_SYS_I2C_MAC_OFFSET) || \
-+    defined(CONFIG_SYS_EEPROM_LOAD_ENV_MAC)
-+    mac_read_from_eeprom();
-+#endif
-+
-+#ifdef CONFIG_POPULATE_SERIAL_NUMBER
-+    populate_serial_number();
-+#endif
-+
- #if defined(CONFIG_CMD_PCI) || defined(CONFIG_PCI)
- 	arm_pci_init();
- #endif
-@@ -951,6 +960,9 @@ void board_init_r(gd_t *id, ulong dest_addr)
- #endif
- #endif
- 
-+#ifdef CONFIG_ENV_WRITE_DEFAULT_IF_CRC_BAD
-+    env_write_default_if_crc_bad();
-+#endif
- 
- #if defined(CONFIG_PRAM) || defined(CONFIG_LOGBUFFER)
- 	/*
-@@ -975,8 +987,8 @@ void board_init_r(gd_t *id, ulong dest_addr)
+@@ -987,8 +987,8 @@ void board_init_r(gd_t *id, ulong dest_addr)
  	}
  #endif
  

--- a/machine/accton/accton_as4610_30/u-boot/series
+++ b/machine/accton/accton_as4610_30/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit aecc5cfea682aed59f4442ae92678c6709d6279e
+# This series applies on GIT commit d44ea7942bb35ff51ee0bd77be4af779042155e6
 platform-as4610_30.patch

--- a/machine/accton/accton_as4610_54/u-boot/platform-as4610_54.patch
+++ b/machine/accton/accton_as4610_54/u-boot/platform-as4610_54.patch
@@ -2432,36 +2432,10 @@ index 78e85b7..fefca71 100755
  extern void save_shmoo_to_flash(void);
  
 diff --git a/arch/arm/lib/board.c b/arch/arm/lib/board.c
-index 33e7098..747d9bf 100755
+index 466de29..7e042ea 100755
 --- a/arch/arm/lib/board.c
 +++ b/arch/arm/lib/board.c
-@@ -848,6 +848,15 @@ void board_init_r(gd_t *id, ulong dest_addr)
- 	/* initialize environment */
- 	env_relocate();
- 
-+#if defined(CONFIG_ID_EEPROM) || defined(CONFIG_SYS_I2C_MAC_OFFSET) || \
-+    defined(CONFIG_SYS_EEPROM_LOAD_ENV_MAC)
-+    mac_read_from_eeprom();
-+#endif
-+
-+#ifdef CONFIG_POPULATE_SERIAL_NUMBER
-+    populate_serial_number();
-+#endif
-+
- #if defined(CONFIG_CMD_PCI) || defined(CONFIG_PCI)
- 	arm_pci_init();
- #endif
-@@ -951,6 +960,9 @@ void board_init_r(gd_t *id, ulong dest_addr)
- #endif
- #endif
- 
-+#ifdef CONFIG_ENV_WRITE_DEFAULT_IF_CRC_BAD
-+    env_write_default_if_crc_bad();
-+#endif
- 
- #if defined(CONFIG_PRAM) || defined(CONFIG_LOGBUFFER)
- 	/*
-@@ -975,8 +987,8 @@ void board_init_r(gd_t *id, ulong dest_addr)
+@@ -987,8 +987,8 @@ void board_init_r(gd_t *id, ulong dest_addr)
  	}
  #endif
  

--- a/machine/accton/accton_as4610_54/u-boot/series
+++ b/machine/accton/accton_as4610_54/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit 9857723c47f92f2de5a52cdb306b083640f2bd2b
+# This series applies on GIT commit 8df7bc34d9edd264458ebbc31b352e62691d4f79
 platform-as4610_54.patch


### PR DESCRIPTION
In commit 65bcc5f, some chunks was moved to common patches.  So that the platform's patches would never include them.

- AS4610_54
- AS4610_30