### PR TITLE
UBI related fixes

### DIFF
--- a/build-config/make/mtdutils.make
+++ b/build-config/make/mtdutils.make
@@ -24,7 +24,7 @@ MTDUTILS_STAMP		= $(MTDUTILS_SOURCE_STAMP) \
 			  $(MTDUTILS_BUILD_STAMP) \
 			  $(MTDUTILS_INSTALL_STAMP)
 
-MTDBINS = mkfs.jffs2 mkfs.ubifs ubinize ubiformat ubinfo mtdinfo
+MTDBINS = mkfs.jffs2 mkfs.ubifs ubinize ubiformat ubinfo mtdinfo ubiattach ubimkvol ubidetach ubirmvol
 
 PHONY += mtdutils mtdutils-download mtdutils-source mtdutils-build \
 	 mtdutils-install mtdutils-clean mtdutils-download-clean

--- a/build-config/make/mtdutils.make
+++ b/build-config/make/mtdutils.make
@@ -24,7 +24,8 @@ MTDUTILS_STAMP		= $(MTDUTILS_SOURCE_STAMP) \
 			  $(MTDUTILS_BUILD_STAMP) \
 			  $(MTDUTILS_INSTALL_STAMP)
 
-MTDBINS = mkfs.jffs2 mkfs.ubifs ubinize ubiformat ubinfo mtdinfo ubiattach ubimkvol ubidetach ubirmvol
+MTDBINS = mkfs.jffs2 mkfs.ubifs ubinize ubiformat ubinfo mtdinfo 
+UBIBINS = ubiattach ubimkvol ubidetach ubirmvol
 
 PHONY += mtdutils mtdutils-download mtdutils-source mtdutils-build \
 	 mtdutils-install mtdutils-clean mtdutils-download-clean
@@ -80,6 +81,13 @@ $(MTDUTILS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(MTDUTILS_BUILD_STAMP)
                 install
 	$(Q) for file in $(MTDBINS) ; do \
 		cp -av $(DEV_SYSROOT)/usr/sbin/$$file $(SYSROOTDIR)/usr/sbin/ ; \
+	done
+        #if UBI utils from busybox are not installed, use the mtdtools versions
+	$(Q) for file in $(UBIBINS) ; do \
+		if [ ! -f $(SYSROOTDIR)/usr/sbin/$$file ] ; \
+		then \
+			cp -av $(DEV_SYSROOT)/usr/sbin/$$file $(SYSROOTDIR)/usr/sbin/ ; \
+		fi; \
 	done
 	$(Q) touch $@
 

--- a/build-config/scripts/make-devices.pl
+++ b/build-config/scripts/make-devices.pl
@@ -168,16 +168,9 @@ sub devices
     mkdir "${devdir}pts", 0755;
 
     print "NOR flash access: mtd mtdblock\n";
-    foreach my $i (0..7) {
+    foreach my $i (0..12) {
 	makedev("mtdblock${i}", "b", 31, ${i},     ${root}, ${root}, 0660);
 	makedev("mtd${i}",      "c", 90, (2*${i}), ${root}, ${root}, 0660);
-    }
-
-    print "UBI device access: ubi\n";
-    makedev("ubi_ctrl", "c", 10, 63, ${root}, ${root}, 0660);
-    makedev("ubi0"    , "c", 253, 0, ${root}, ${root}, 0660);
-    foreach my $i (0..7) {
-	makedev("ubi0_${i}", "c", 253, ${i}+1, ${root}, ${root}, 0660);
     }
 
     print "SD flash access: mmcblk0 mmcblk0p{1..7}\n";

--- a/rootconf/default/etc/init.d/makedev.sh
+++ b/rootconf/default/etc/init.d/makedev.sh
@@ -117,3 +117,7 @@ vdevs=$(ls -d /sys/block/vd[a-z] 2&> /dev/null) && {
 }
 
 mkdir -p $ONIE_RUN_DIR
+
+#Create initial device nodes that use dynamic major node numbers. e.g ubi
+mdev -s 
+


### PR DESCRIPTION
Hi,

I've been working on bringing up ONIE on another of our boards. It's an older design and uses NAND flash with a UBIFS partitioning scheme. I had some issues with the ONIE build and how it had implemented UBI tools and nodes so made some changes to common ONIE build code.

I think the changes are correct - but it's possible they could impact other vendors (centec and nxp look like they may have boards that are using UBI) though I'd expect them to have issues with the latest build too...

The changes made:
1) The make-devices.pl creates some UBI nodes but the major node numbers are wrong for the UBI driver. I think any installer should be running mdev to get these nodes created correctly so I removed them from the script. 
2) I increased the number of mtd nodes created because on this board if I account for our partitioning we make it to 10. 
3) I added some more of the ubi utilites to the MTDBINS so these are available instead of the busybox versions. The busybox version of ubimkvol doesn't support the "-m" option. It seemed to me that as we are building the utilities and they are more functional than the busybox version we should include them.

I hope it's OK bundling these changes together - they seemed all related. Let me know if any concerns or questions

Thanks
Mark