### PR TITLE
sys_eeprom: fix issue of updating CRC TLV

### DIFF
--- a/machine/accton/accton_as4600_54t/u-boot/platform-accton-as4600_54t.patch
+++ b/machine/accton/accton_as4600_54t/u-boot/platform-accton-as4600_54t.patch
@@ -2912,10 +2912,10 @@ index e4b0d44..4e75ca6 100644
  sbc8548_PCI_33               powerpc     mpc85xx     sbc8548             -              -           sbc8548:PCI,33
  sbc8548_PCI_33_PCIE          powerpc     mpc85xx     sbc8548             -              -           sbc8548:PCI,33,PCIE
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..2f4ca01 100644
+index ab02104..4e71587 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1063,18 +1063,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1052,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -2952,7 +2952,7 @@ index 3d5dace..2f4ca01 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1155,36 @@ int populate_serial_number(void)
+@@ -1127,3 +1144,36 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as4600_54t/u-boot/series
+++ b/machine/accton/accton_as4600_54t/u-boot/series
@@ -1,2 +1,3 @@
+# This series applies on GIT commit 455f6353f4331175c40b8a8b4d6a4d89188ebdaa
 driver-swizzle-flash-sectors-error.patch
 platform-accton-as4600_54t.patch

--- a/machine/accton/accton_as4610_30/u-boot/platform-as4610_30.patch
+++ b/machine/accton/accton_as4610_30/u-boot/platform-as4610_30.patch
@@ -7724,7 +7724,7 @@ index 2268829..21b87c3 100644
  				id->size, id->mtd_id);
  
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..2f298a7 100644
+index ab02104..1b25036 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
 @@ -9,6 +9,7 @@
@@ -7781,21 +7781,7 @@ index 3d5dace..2f298a7 100644
  
  #ifdef DEBUG
  	show_eeprom(eeprom);
-@@ -331,11 +338,10 @@ static void update_crc(u8 *eeprom)
- 	tlvinfo_tlv_t    * eeprom_crc;
- 	unsigned int       calc_crc;
- 
--	// Is the eeprom header valid?
-+// Is the eeprom header valid?
- 	if (!is_valid_tlvinfo_header(eeprom_hdr)) {
--		return;
-+        return;
- 	}
--
- 	// Is the last TLV a CRC?
- 	eeprom_crc = (tlvinfo_tlv_t *) &eeprom[sizeof(tlvinfo_header_t) +
- 					       be16_to_cpu(eeprom_hdr->totallen) - (sizeof(tlvinfo_tlv_t) + 4)];
-@@ -858,6 +864,44 @@ static int set_bytes(char *buf, const char *string, int * converted_accum)
+@@ -847,6 +854,44 @@ static int set_bytes(char *buf, const char *string, int * converted_accum)
  	return 0;
  }
  
@@ -7840,7 +7826,7 @@ index 3d5dace..2f298a7 100644
  #ifdef CONFIG_SYS_EEPROM_USE_COMMON_FLASH_IO
  
  /**
-@@ -935,7 +979,7 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -924,7 +969,7 @@ int write_sys_eeprom(void *eeprom, int len)
  	return 0;
  }
  
@@ -7849,7 +7835,7 @@ index 3d5dace..2f298a7 100644
  
  #ifdef CONFIG_SYS_EEPROM_USE_COMMON_I2C_IO
  
-@@ -968,7 +1012,10 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -957,7 +1002,10 @@ int write_sys_eeprom(void *eeprom, int len)
   */
  int read_sys_eeprom(void *eeprom, int offset, int len)
  {
@@ -7861,7 +7847,7 @@ index 3d5dace..2f298a7 100644
  #ifdef CONFIG_SYS_EEPROM_BUS_NUM
  	unsigned int bus;
  #endif
-@@ -977,7 +1024,13 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
+@@ -966,7 +1014,13 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
  	bus = i2c_get_bus_num();
  	i2c_set_bus_num(CONFIG_SYS_EEPROM_BUS_NUM);
  #endif
@@ -7876,7 +7862,7 @@ index 3d5dace..2f298a7 100644
  			  EEPROM_OFFSET + offset,
  			  eeprom, len);
  
-@@ -993,7 +1046,10 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
+@@ -982,7 +1036,10 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
   */
  int write_sys_eeprom(void *eeprom, int len)
  {
@@ -7888,7 +7874,7 @@ index 3d5dace..2f298a7 100644
  	int i;
  	void *p;
  #ifdef CONFIG_SYS_EEPROM_BUS_NUM
-@@ -1004,7 +1060,10 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -993,7 +1050,10 @@ int write_sys_eeprom(void *eeprom, int len)
  	bus = i2c_get_bus_num();
  	i2c_set_bus_num(CONFIG_SYS_EEPROM_BUS_NUM);
  #endif
@@ -7900,7 +7886,7 @@ index 3d5dace..2f298a7 100644
  	ret = eeprom_write(CONFIG_SYS_I2C_EEPROM_ADDR,
  			   EEPROM_OFFSET,
  			   eeprom, len);
-@@ -1016,7 +1075,7 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -1005,7 +1065,7 @@ int write_sys_eeprom(void *eeprom, int len)
  	return ret;
  }
  
@@ -7909,7 +7895,7 @@ index 3d5dace..2f298a7 100644
  
  #ifdef CONFIG_SYS_EEPROM_LOAD_ENV_MAC
  
-@@ -1042,13 +1101,16 @@ int mac_read_from_eeprom(void)
+@@ -1031,13 +1091,16 @@ int mac_read_from_eeprom(void)
  	u8 macbase[6];
  	tlvinfo_header_t * eeprom_hdr = (tlvinfo_header_t *) eeprom;
  

--- a/machine/accton/accton_as4610_30/u-boot/series
+++ b/machine/accton/accton_as4610_30/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit d44ea7942bb35ff51ee0bd77be4af779042155e6
+# This series applies on GIT commit 5e5b41b79f3d81eb6782c3639a158e88d77e6829
 platform-as4610_30.patch

--- a/machine/accton/accton_as4610_54/u-boot/platform-as4610_54.patch
+++ b/machine/accton/accton_as4610_54/u-boot/platform-as4610_54.patch
@@ -7724,7 +7724,7 @@ index 2268829..21b87c3 100644
  				id->size, id->mtd_id);
  
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..2f298a7 100644
+index ab02104..1b25036 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
 @@ -9,6 +9,7 @@
@@ -7781,21 +7781,7 @@ index 3d5dace..2f298a7 100644
  
  #ifdef DEBUG
  	show_eeprom(eeprom);
-@@ -331,11 +338,10 @@ static void update_crc(u8 *eeprom)
- 	tlvinfo_tlv_t    * eeprom_crc;
- 	unsigned int       calc_crc;
- 
--	// Is the eeprom header valid?
-+// Is the eeprom header valid?
- 	if (!is_valid_tlvinfo_header(eeprom_hdr)) {
--		return;
-+        return;
- 	}
--
- 	// Is the last TLV a CRC?
- 	eeprom_crc = (tlvinfo_tlv_t *) &eeprom[sizeof(tlvinfo_header_t) +
- 					       be16_to_cpu(eeprom_hdr->totallen) - (sizeof(tlvinfo_tlv_t) + 4)];
-@@ -858,6 +864,44 @@ static int set_bytes(char *buf, const char *string, int * converted_accum)
+@@ -847,6 +854,44 @@ static int set_bytes(char *buf, const char *string, int * converted_accum)
  	return 0;
  }
  
@@ -7840,7 +7826,7 @@ index 3d5dace..2f298a7 100644
  #ifdef CONFIG_SYS_EEPROM_USE_COMMON_FLASH_IO
  
  /**
-@@ -935,7 +979,7 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -924,7 +969,7 @@ int write_sys_eeprom(void *eeprom, int len)
  	return 0;
  }
  
@@ -7849,7 +7835,7 @@ index 3d5dace..2f298a7 100644
  
  #ifdef CONFIG_SYS_EEPROM_USE_COMMON_I2C_IO
  
-@@ -968,7 +1012,10 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -957,7 +1002,10 @@ int write_sys_eeprom(void *eeprom, int len)
   */
  int read_sys_eeprom(void *eeprom, int offset, int len)
  {
@@ -7861,7 +7847,7 @@ index 3d5dace..2f298a7 100644
  #ifdef CONFIG_SYS_EEPROM_BUS_NUM
  	unsigned int bus;
  #endif
-@@ -977,7 +1024,13 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
+@@ -966,7 +1014,13 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
  	bus = i2c_get_bus_num();
  	i2c_set_bus_num(CONFIG_SYS_EEPROM_BUS_NUM);
  #endif
@@ -7876,7 +7862,7 @@ index 3d5dace..2f298a7 100644
  			  EEPROM_OFFSET + offset,
  			  eeprom, len);
  
-@@ -993,7 +1046,10 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
+@@ -982,7 +1036,10 @@ int read_sys_eeprom(void *eeprom, int offset, int len)
   */
  int write_sys_eeprom(void *eeprom, int len)
  {
@@ -7888,7 +7874,7 @@ index 3d5dace..2f298a7 100644
  	int i;
  	void *p;
  #ifdef CONFIG_SYS_EEPROM_BUS_NUM
-@@ -1004,7 +1060,10 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -993,7 +1050,10 @@ int write_sys_eeprom(void *eeprom, int len)
  	bus = i2c_get_bus_num();
  	i2c_set_bus_num(CONFIG_SYS_EEPROM_BUS_NUM);
  #endif
@@ -7900,7 +7886,7 @@ index 3d5dace..2f298a7 100644
  	ret = eeprom_write(CONFIG_SYS_I2C_EEPROM_ADDR,
  			   EEPROM_OFFSET,
  			   eeprom, len);
-@@ -1016,7 +1075,7 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -1005,7 +1065,7 @@ int write_sys_eeprom(void *eeprom, int len)
  	return ret;
  }
  
@@ -7909,7 +7895,7 @@ index 3d5dace..2f298a7 100644
  
  #ifdef CONFIG_SYS_EEPROM_LOAD_ENV_MAC
  
-@@ -1042,13 +1101,16 @@ int mac_read_from_eeprom(void)
+@@ -1031,13 +1091,16 @@ int mac_read_from_eeprom(void)
  	u8 macbase[6];
  	tlvinfo_header_t * eeprom_hdr = (tlvinfo_header_t *) eeprom;
  

--- a/machine/accton/accton_as4610_54/u-boot/series
+++ b/machine/accton/accton_as4610_54/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit 8df7bc34d9edd264458ebbc31b352e62691d4f79
+# This series applies on GIT commit 1f80833480b0b64f777a607564bcce85323a9947
 platform-as4610_54.patch

--- a/machine/accton/accton_as5600_52x/u-boot/platform-accton-as5600_52x.patch
+++ b/machine/accton/accton_as5600_52x/u-boot/platform-accton-as5600_52x.patch
@@ -2359,10 +2359,10 @@ index e4b0d44..09fbf0b 100644
  sbc8548_PCI_33               powerpc     mpc85xx     sbc8548             -              -           sbc8548:PCI,33
  sbc8548_PCI_33_PCIE          powerpc     mpc85xx     sbc8548             -              -           sbc8548:PCI,33,PCIE
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..2f4ca01 100644
+index ab02104..4e71587 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1063,18 +1063,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1052,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -2399,7 +2399,7 @@ index 3d5dace..2f4ca01 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1155,36 @@ int populate_serial_number(void)
+@@ -1127,3 +1144,36 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as5600_52x/u-boot/series
+++ b/machine/accton/accton_as5600_52x/u-boot/series
@@ -1,2 +1,3 @@
+# This series applies on GIT commit 3d31ce484a98960a43f3a919efde636a12bd9e59
 driver-swizzle-flash-sectors-error.patch
 platform-accton-as5600_52x.patch

--- a/machine/accton/accton_as5610_52x/u-boot/platform-accton-as5610_52x.patch
+++ b/machine/accton/accton_as5610_52x/u-boot/platform-accton-as5610_52x.patch
@@ -2608,10 +2608,10 @@ index e4b0d44..fd57186 100644
  sbc8548_PCI_33               powerpc     mpc85xx     sbc8548             -              -           sbc8548:PCI,33
  sbc8548_PCI_33_PCIE          powerpc     mpc85xx     sbc8548             -              -           sbc8548:PCI,33,PCIE
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..6bb3afc 100644
+index ab02104..eeb40ec 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1063,18 +1063,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1052,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -2648,7 +2648,7 @@ index 3d5dace..6bb3afc 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1155,36 @@ int populate_serial_number(void)
+@@ -1127,3 +1144,36 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as5610_52x/u-boot/series
+++ b/machine/accton/accton_as5610_52x/u-boot/series
@@ -1,2 +1,3 @@
+# This series applies on GIT commit 27a5ec2af3683cee2b16d859ecde7b4e1646c90c
 driver-swizzle-flash-sectors-error.patch
 platform-accton-as5610_52x.patch

--- a/machine/accton/accton_as5700_96x/u-boot/platform-accton-as5700_96x.patch
+++ b/machine/accton/accton_as5700_96x/u-boot/platform-accton-as5700_96x.patch
@@ -21131,10 +21131,10 @@ index b175358..bd3c508 100644
  #include <spi_flash.h>
  
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..6bb3afc 100644
+index ab02104..eeb40ec 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1063,18 +1063,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1052,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -21171,7 +21171,7 @@ index 3d5dace..6bb3afc 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1155,36 @@ int populate_serial_number(void)
+@@ -1127,3 +1144,36 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as5700_96x/u-boot/series
+++ b/machine/accton/accton_as5700_96x/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit e6aee6ad3c7942b8d6d93d18895a2990fd22dcf6
+# This series applies on GIT commit b3f4d9f580697d31c0a315a00ed1d9f9f593b513
 platform-accton-as5700_96x.patch

--- a/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
+++ b/machine/accton/accton_as5710_54x/u-boot/platform-accton-as5710_54x.patch
@@ -21131,10 +21131,10 @@ index b175358..bd3c508 100644
  #include <spi_flash.h>
  
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..6bb3afc 100644
+index ab02104..eeb40ec 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1063,18 +1063,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1052,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -21171,7 +21171,7 @@ index 3d5dace..6bb3afc 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1155,36 @@ int populate_serial_number(void)
+@@ -1127,3 +1144,36 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as5710_54x/u-boot/series
+++ b/machine/accton/accton_as5710_54x/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit 9d0e4ad6f2bc6e25245c09b97fa775116fd151de
+# This series applies on GIT commit cde27562bc34d079f9f0014d0318b22a9925097c
 platform-accton-as5710_54x.patch

--- a/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
+++ b/machine/accton/accton_as6700_32x/u-boot/platform-accton-as6700_32x.patch
@@ -21069,7 +21069,7 @@ index b175358..099a3cb 100644
  
  #ifdef CONFIG_CMD_SF_TEST
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..9fdda9e 100644
+index ab02104..9c36aba 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
 @@ -8,6 +8,8 @@
@@ -21081,7 +21081,7 @@ index 3d5dace..9fdda9e 100644
  #include <linux/ctype.h>
  
  #include "sys_eeprom.h"
-@@ -937,6 +939,84 @@ int write_sys_eeprom(void *eeprom, int len)
+@@ -926,6 +928,84 @@ int write_sys_eeprom(void *eeprom, int len)
  
  #endif /* CONFIG_SYS_FLASH_HWINFO_ADDR && CONFIG_SYS_FLASH_HWINFO_SECT_SIZE */
  
@@ -21166,7 +21166,7 @@ index 3d5dace..9fdda9e 100644
  #ifdef CONFIG_SYS_EEPROM_USE_COMMON_I2C_IO
  
  /**
-@@ -1063,18 +1143,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1132,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -21203,7 +21203,7 @@ index 3d5dace..9fdda9e 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1235,36 @@ int populate_serial_number(void)
+@@ -1127,3 +1224,36 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as6700_32x/u-boot/series
+++ b/machine/accton/accton_as6700_32x/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit 6a07845b1d4095a046bdaa40189e6182f7d671d3
+# This series applies on GIT commit 549e5b66d47721fe5c260f6863a415e02460185e
 platform-accton-as6700_32x.patch

--- a/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
+++ b/machine/accton/accton_as6701_32x/u-boot/platform-accton-as6701_32x.patch
@@ -21217,10 +21217,10 @@ index b175358..bd3c508 100644
  #include <spi_flash.h>
  
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..6bb3afc 100644
+index ab02104..eeb40ec 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1063,18 +1063,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1052,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -21257,7 +21257,7 @@ index 3d5dace..6bb3afc 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1155,36 @@ int populate_serial_number(void)
+@@ -1127,3 +1144,36 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as6701_32x/u-boot/series
+++ b/machine/accton/accton_as6701_32x/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit 96279233ea1ece69e9e48724de4712599cf7ecbf
+# This series applies on GIT commit 54d5286d3409bd885382d5d4baca0f93b008162e
 platform-accton-as6701_32x.patch

--- a/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
+++ b/machine/accton/accton_as6710_32x/u-boot/platform-accton-as6710_32x.patch
@@ -21133,10 +21133,10 @@ index b175358..bd3c508 100644
  #include <spi_flash.h>
  
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..27375a6 100644
+index ab02104..546da79 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1063,18 +1063,35 @@ int mac_read_from_eeprom(void)
+@@ -1052,18 +1052,35 @@ int mac_read_from_eeprom(void)
  
  	for (i = 0; i < min(maccount, CONFIG_SYS_EEPROM_MAX_NUM_ETH_PORTS); i++) {
  		if (is_valid_ether_addr(macbase)) {
@@ -21173,7 +21173,7 @@ index 3d5dace..27375a6 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1138,3 +1155,65 @@ int populate_serial_number(void)
+@@ -1127,3 +1144,65 @@ int populate_serial_number(void)
  }
  
  #endif /* CONFIG_POPULATE_SERIAL_NUMBER */

--- a/machine/accton/accton_as6710_32x/u-boot/series
+++ b/machine/accton/accton_as6710_32x/u-boot/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit b3c5ae0f73d18f3462be6f79681a7965904f7fd9
+# This series applies on GIT commit c8dff525a597222b96ad2ba7943dd07b91fc0144
 platform-accton-as6710_32x.patch

--- a/machine/accton/accton_as7710_32x/u-boot/platform-accton-as7710_32x.patch
+++ b/machine/accton/accton_as7710_32x/u-boot/platform-accton-as7710_32x.patch
@@ -43,7 +43,7 @@ index 603834b..12dd1c3 100644
  #endif
 diff --git a/board/accton/as7710_32x/Makefile b/board/accton/as7710_32x/Makefile
 new file mode 100644
-index 0000000..29481cd
+index 0000000..3aa9241
 --- /dev/null
 +++ b/board/accton/as7710_32x/Makefile
 @@ -0,0 +1,18 @@
@@ -337,7 +337,7 @@ index 0000000..24484cd
 +website www.freescale.com and Freescale QorIQ SDK Infocenter document.
 diff --git a/board/accton/as7710_32x/as7710_32x.c b/board/accton/as7710_32x/as7710_32x.c
 new file mode 100644
-index 0000000..f3ae81e
+index 0000000..be77af0
 --- /dev/null
 +++ b/board/accton/as7710_32x/as7710_32x.c
 @@ -0,0 +1,238 @@
@@ -1453,7 +1453,7 @@ index 0000000..2ebea36
 +
 +int num_tlb_entries = ARRAY_SIZE(tlb_table);
 diff --git a/boards.cfg b/boards.cfg
-index 117d2a2..dc185ad 100644
+index 117d2a2..75ac0e7 100644
 --- a/boards.cfg
 +++ b/boards.cfg
 @@ -977,6 +977,7 @@ Active  powerpc     mpc85xx        -           freescale       t208xrdb
@@ -1465,10 +1465,10 @@ index 117d2a2..dc185ad 100644
  Active  powerpc     mpc85xx        -           freescale       t4qds               T4160QDS_NAND                         T4240QDS:PPC_T4160,RAMBOOT_PBL,SPL_FSL_PBL,NAND                                                                                   -
  Active  powerpc     mpc85xx        -           freescale       t4qds               T4160QDS_SDCARD                       T4240QDS:PPC_T4160,RAMBOOT_PBL,SPL_FSL_PBL,SDCARD                                                                                 -
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
-index 3d5dace..f914a45 100644
+index ab02104..405024f 100644
 --- a/common/cmd_sys_eeprom.c
 +++ b/common/cmd_sys_eeprom.c
-@@ -1070,11 +1070,28 @@ int mac_read_from_eeprom(void)
+@@ -1059,11 +1059,28 @@ int mac_read_from_eeprom(void)
  				macbase[0], macbase[1], macbase[2],
  				macbase[3], macbase[4], macbase[5]);
  			sprintf(enetvar, i ? "eth%daddr" : "ethaddr", i);
@@ -1497,7 +1497,7 @@ index 3d5dace..f914a45 100644
  
  			macbase[5]++;
  			if (macbase[5] == 0) {
-@@ -1119,9 +1136,6 @@ int populate_serial_number(void)
+@@ -1108,9 +1125,6 @@ int populate_serial_number(void)
  	int eeprom_index;
  	tlvinfo_tlv_t * eeprom_tlv;
  
@@ -1507,7 +1507,7 @@ index 3d5dace..f914a45 100644
  	if (read_eeprom(eeprom)) {
  		printf("Read failed.\n");
  		return -1;
-@@ -1131,7 +1145,14 @@ int populate_serial_number(void)
+@@ -1120,7 +1134,14 @@ int populate_serial_number(void)
  		eeprom_tlv = (tlvinfo_tlv_t *) &eeprom[eeprom_index];
  		memcpy(serialstr, eeprom_tlv->value, eeprom_tlv->length);
  		serialstr[eeprom_tlv->length] = 0;
@@ -1583,7 +1583,7 @@ index 2db75d0..b77ab65 100644
 +#endif
 diff --git a/include/configs/AS7710_32X.h b/include/configs/AS7710_32X.h
 new file mode 100644
-index 0000000..3bd1a46
+index 0000000..65deeef
 --- /dev/null
 +++ b/include/configs/AS7710_32X.h
 @@ -0,0 +1,842 @@

--- a/machine/accton/accton_as7710_32x/u-boot/series
+++ b/machine/accton/accton_as7710_32x/u-boot/series
@@ -1,1 +1,2 @@
+# This series applies on GIT commit 8709831f7cc3de996289b59bffc7adeb6320fd53
 platform-accton-as7710_32x.patch

--- a/patches/busybox/feature-onie-syseeprom-command.patch
+++ b/patches/busybox/feature-onie-syseeprom-command.patch
@@ -1,5 +1,11 @@
 Add to support onie-syseeprom command.
 
+Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+Copyright (C) 2014,2016 david_yang <david_yang@accton.com>
+Copyright (C) 2015 Ellen Wang <ellen@cumulusnetworks.com>
+
+SPDX-License-Identifier:     GPL-2.0
+
 diff --git a/include/24cXX.h b/include/24cXX.h
 new file mode 100644
 index 0000000..c304273
@@ -786,7 +792,7 @@ index 0000000..b448761
 +	}
 +}
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index 4a1928d..394b703 100644
+index 4a1928d..6036daf 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -625,4 +625,84 @@ config WATCHDOG
@@ -887,10 +893,10 @@ index a2a860b..13d8cc3 100644
 +lib-$(CONFIG_SYS_EEPROM_DEVICE_MTD) += sys_eeprom_mtd.o
 diff --git a/miscutils/onie_tlvinfo.c b/miscutils/onie_tlvinfo.c
 new file mode 100644
-index 0000000..95a46e1
+index 0000000..5cf6463
 --- /dev/null
 +++ b/miscutils/onie_tlvinfo.c
-@@ -0,0 +1,753 @@
+@@ -0,0 +1,743 @@
 +#include "libbb.h"
 +#include "onie_tlvinfo.h"
 +#include "sys_eeprom.h"
@@ -1268,27 +1274,21 @@ index 0000000..95a46e1
 +    tlvinfo_header_t * eeprom_hdr = (tlvinfo_header_t *) eeprom;
 +    tlvinfo_tlv_t    * eeprom_crc;
 +    unsigned int       calc_crc;
++    int                eeprom_index;
 +
-+    // Is the eeprom header valid?
-+    if (!is_valid_tlvinfo_header(eeprom_hdr)) {
-+	return;
-+    }
-+    // Is the last TLV a CRC?
-+    eeprom_crc = (tlvinfo_tlv_t *) &eeprom[sizeof(tlvinfo_header_t) +
-+					   be16_to_cpu(eeprom_hdr->totallen) -
-+					   (sizeof(tlvinfo_tlv_t) + 4)];
-+    if (eeprom_crc->type != TLV_CODE_CRC_32) {
++    // Discover the CRC TLV
++    if (!tlvinfo_find_tlv(eeprom, TLV_CODE_CRC_32, &eeprom_index)) {
 +	if ((be16_to_cpu(eeprom_hdr->totallen) + sizeof(tlvinfo_tlv_t) + 4) >
 +	    TLV_TOTAL_LEN_MAX) {
 +	    return;
 +	}
-+	eeprom_crc = (tlvinfo_tlv_t *) &eeprom[sizeof(tlvinfo_header_t) +
-+					       be16_to_cpu(
-+						   eeprom_hdr->totallen)];
++	eeprom_index = sizeof(tlvinfo_header_t) +
++	    be16_to_cpu(eeprom_hdr->totallen);
 +	eeprom_hdr->totallen = cpu_to_be16(be16_to_cpu(eeprom_hdr->totallen) +
 +					   sizeof(tlvinfo_tlv_t) + 4);
-+	eeprom_crc->type = TLV_CODE_CRC_32;
 +    }
++    eeprom_crc = (tlvinfo_tlv_t *) &eeprom[eeprom_index];
++    eeprom_crc->type = TLV_CODE_CRC_32;
 +    eeprom_crc->length = 4;
 +
 +    // Calculate the checksum
@@ -1443,10 +1443,6 @@ index 0000000..95a46e1
 +    tlvinfo_tlv_t    * eeprom_tlv;
 +    int eeprom_end;
 +
-+    // Make sure the EEPROM contents are valid
-+    if (!is_valid_tlvinfo_header(eeprom_hdr) || !is_checksum_valid(eeprom)) {
-+	return(FALSE);
-+    }
 +    // Search through the TLVs, looking for the first one which matches the
 +    // supplied type code.
 +    *eeprom_index = sizeof(tlvinfo_header_t);

--- a/patches/busybox/feature-onie-syseeprom-sysfs.patch
+++ b/patches/busybox/feature-onie-syseeprom-sysfs.patch
@@ -13,7 +13,7 @@ index b602736..2713b86 100644
  #define SYS_EEPROM_OFFSET            CONFIG_SYS_EEPROM_OFFSET
  
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index 78b1eba..644b942 100644
+index 78b1eba..91a9cef 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -650,6 +650,9 @@ config SYS_EEPROM_DEVICE_MTD

--- a/patches/busybox/series
+++ b/patches/busybox/series
@@ -1,4 +1,4 @@
-# This series applies on GIT commit a57a0a8393e105cc7340375cd6b905f247f4f749
+# This series applies on GIT commit 88041b58e880346be4ec6d1472a51f029f95b487
 gitignore.patch
 u-boot-env-tools.patch
 dhcp-additional-options.patch

--- a/patches/u-boot/2013.01.01/series
+++ b/patches/u-boot/2013.01.01/series
@@ -1,4 +1,4 @@
-# This series applies on GIT commit ff30c3fa38a18c80c3311a9d1ffc50f1a3903e8a
+# This series applies on GIT commit 46294db109a0af449cea7ec954fa24cce4ecfe55
 git-ignore.patch
 feature-config-repeatable.patch
 feature-dhcp-options.patch

--- a/patches/u-boot/common/feature-sys-eeprom-tlv-common.patch
+++ b/patches/u-boot/common/feature-sys-eeprom-tlv-common.patch
@@ -2,15 +2,16 @@ Add to support 'sys_eeprom' command (common part)
 
 Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
 Copyright (C) 2014 Srideep <srideep_devireddy@dell.com>
+Copyright (C) 2014,2016 david_yang <david_yang@accton.com>
 
 SPDX-License-Identifier:     GPL-2.0
 
 diff --git a/common/cmd_sys_eeprom.c b/common/cmd_sys_eeprom.c
 new file mode 100644
-index 0000000..3d5dace
+index 0000000..ab02104
 --- /dev/null
 +++ b/common/cmd_sys_eeprom.c
-@@ -0,0 +1,1140 @@
+@@ -0,0 +1,1129 @@
 +/*
 + * See file CREDITS for list of people who contributed to this
 + * project.
@@ -343,25 +344,19 @@ index 0000000..3d5dace
 +	tlvinfo_header_t * eeprom_hdr = (tlvinfo_header_t *) eeprom;
 +	tlvinfo_tlv_t    * eeprom_crc;
 +	unsigned int       calc_crc;
++	int                eeprom_index;
 +
-+	// Is the eeprom header valid?
-+	if (!is_valid_tlvinfo_header(eeprom_hdr)) {
-+		return;
-+	}
-+
-+	// Is the last TLV a CRC?
-+	eeprom_crc = (tlvinfo_tlv_t *) &eeprom[sizeof(tlvinfo_header_t) +
-+					       be16_to_cpu(eeprom_hdr->totallen) - (sizeof(tlvinfo_tlv_t) + 4)];
-+	if (eeprom_crc->type != TLV_CODE_CRC_32) {
++	// Discover the CRC TLV
++	if (!tlvinfo_find_tlv(eeprom, TLV_CODE_CRC_32, &eeprom_index)) {
 +		if ((be16_to_cpu(eeprom_hdr->totallen) + sizeof(tlvinfo_tlv_t) + 4) > TLV_TOTAL_LEN_MAX) {
 +			return;
 +		}
-+		eeprom_crc = (tlvinfo_tlv_t *) &eeprom[sizeof(tlvinfo_header_t) +
-+						       be16_to_cpu(eeprom_hdr->totallen)];
++		eeprom_index = sizeof(tlvinfo_header_t) + be16_to_cpu(eeprom_hdr->totallen);
 +		eeprom_hdr->totallen = cpu_to_be16(be16_to_cpu(eeprom_hdr->totallen) +
 +						   sizeof(tlvinfo_tlv_t) + 4);
-+		eeprom_crc->type = TLV_CODE_CRC_32;
 +	}
++	eeprom_crc = (tlvinfo_tlv_t *) &eeprom[eeprom_index];
++	eeprom_crc->type = TLV_CODE_CRC_32;
 +	eeprom_crc->length = 4;
 +
 +	// Calculate the checksum
@@ -543,11 +538,6 @@ index 0000000..3d5dace
 +	tlvinfo_header_t * eeprom_hdr = (tlvinfo_header_t *) eeprom;
 +	tlvinfo_tlv_t    * eeprom_tlv;
 +	int eeprom_end;
-+
-+	// Make sure the EEPROM contents are valid
-+	if (!is_valid_tlvinfo_header(eeprom_hdr) || !is_checksum_valid(eeprom)) {
-+		return(FALSE);
-+	}
 +
 +	// Search through the TLVs, looking for the first one which matches the
 +	// supplied type code.


### PR DESCRIPTION
During Accton MFG test, we found an implicit bug in sys_eeprom.
Writing the Base MAC Address (TLV 0x24) composed of '0xFE' and then writing the Devise Version (TLV 0x26) will trigger the issue.

When updating CRC, it may get the wrong CRC TLV and corrupt the EEPROM data.  This is a common issue in both u-boot and busybox.

The patch fixed the issue and was tested in Accton Platforms.

    LOADER=> sys_eeprom erase
    EEPROM data in memory reset.
    LOADER=> sys_eeprom
    TlvInfo Header:
       Id String:    TlvInfo
       Version:      1
       Total Length: 6
    TLV Name             Code Len Value
    -------------------- ---- --- -----
    CRC-32               0xFE   4 0xD4431C18
    Checksum is valid.
    LOADER=> sys_eeprom set 0x24 CC:37:AB:FE:00:00
    LOADER=> sys_eeprom set 0x26 2
    LOADER=> sys_eeprom
    TlvInfo Header:
       Id String:    TlvInfo
       Version:      1
       Total Length: 11
    TLV Name             Code Len Value
    -------------------- ---- --- -----
    Base MAC Address     0x24   6 CC:37:AB:FE:04:DB
    Unknown              0xED 103  0x43 0xFD 0xBA 0xCA 0xF4 0x92 0x69 0x00
    0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
    0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
    0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
    0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
    0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
    0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
    0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
    Checksum is valid.
    LOADER=>
