### PR TITLE
dni_3048up: Fix up usable SDRAM starting address

### DIFF
--- a/machine/dni/dni_3048up/kernel/platform-dni_3048up.patch
+++ b/machine/dni/dni_3048up/kernel/platform-dni_3048up.patch
@@ -2,7 +2,7 @@
 
 diff --git a/arch/arm/boot/dts/dni_3048up.dts b/arch/arm/boot/dts/dni_3048up.dts
 new file mode 100755
-index 0000000..3215058
+index 0000000..5101c02
 --- /dev/null
 +++ b/arch/arm/boot/dts/dni_3048up.dts
 @@ -0,0 +1,237 @@
@@ -24,7 +24,7 @@ index 0000000..3215058
 +        };
 +        memory {
 +                device_type = "memory";
-+                reg = <0x61000000 0x3f000000>;
++                reg = <0x60000000 0x40000000>;
 +        };
 +        chipcommonA {
 +                compatible = "simple-bus";

--- a/machine/dni/dni_3048up/u-boot/platform-arm-dni_3048up.patch
+++ b/machine/dni/dni_3048up/u-boot/platform-arm-dni_3048up.patch
@@ -8278,7 +8278,7 @@ index a7fd7e3..614a2ce 100644
  
 diff --git a/include/configs/DNI_3048UP.h b/include/configs/DNI_3048UP.h
 new file mode 100755
-index 0000000..dafd295
+index 0000000..6108e96
 --- /dev/null
 +++ b/include/configs/DNI_3048UP.h
 @@ -0,0 +1,354 @@
@@ -8430,7 +8430,7 @@ index 0000000..dafd295
 +#define CONFIG_L2_CACHE_SIZE			0x80000  
 +#define CONFIG_PHYS_SDRAM_1				0x60000000
 +#define CONFIG_LOADADDR					0x70000000 /* default destination location for tftp file (tftpboot cmd) */
-+#define CONFIG_PHYS_SDRAM_RSVD_SIZE		0x1000000 /* bytes reserved from CONFIG_PHYS_SDRAM_1 for custom use */
++#define CONFIG_PHYS_SDRAM_RSVD_SIZE		0x0 /* bytes reserved from CONFIG_PHYS_SDRAM_1 for custom use */
 +
 +/* Where kernel is loaded to in memory */
 +#define CONFIG_SYS_LOAD_ADDR				0x70000000


### PR DESCRIPTION
The iProc U-Boot maps physical SDRAM to begin at 0x6000_0000.

The initial commit for this platform,
65bcc5f5d2027f7fcc929959770a028c46d6352a, defines the first 16MB
(0x0100_0000) as "reserved for custom use" and excludes it from the
available free memory.

  commit 65bcc5f5d2027f7fcc929959770a028c46d6352a
  Author: vincent0083 <Vincent.Liu@agemasystems.com>
  Date:   Thu May 26 11:02:59 2016 +0800

      Add support for DNI 3048UP

None of the PowerPC ONIE U-Boot implementations do this.

This is just a waste of 16MB.

This patch sets the reserved SDRAM size to 0x0.

This also has the nice property of aligning the start of RAM to a
512MB boundary, which simplifies the memory layout for loading kernels.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>