### PR TITLE
accton_as4610: Fix up usable SDRAM starting address

### DIFF
--- a/machine/accton/accton_as4610_30/u-boot/platform-as4610_30.patch
+++ b/machine/accton/accton_as4610_30/u-boot/platform-as4610_30.patch
@@ -9746,7 +9746,7 @@ index 0000000..ccccd65
 +#define CONFIG_L2_CACHE_SIZE			0x80000
 +#define CONFIG_PHYS_SDRAM_1				0x60000000
 +#define CONFIG_LOADADDR					0x70000000 /* default destination location for tftp file (tftpboot cmd) */
-+#define CONFIG_PHYS_SDRAM_RSVD_SIZE		0x01000000 /* bytes reserved from CONFIG_PHYS_SDRAM_1 for custom use */
++#define CONFIG_PHYS_SDRAM_RSVD_SIZE		0x0 /* bytes reserved from CONFIG_PHYS_SDRAM_1 for custom use */
 +
 +/* Where kernel is loaded to in memory */
 +#define CONFIG_SYS_LOAD_ADDR				0x70000000

--- a/machine/accton/accton_as4610_54/u-boot/platform-as4610_54.patch
+++ b/machine/accton/accton_as4610_54/u-boot/platform-as4610_54.patch
@@ -9746,7 +9746,7 @@ index 0000000..6e43a9c
 +#define CONFIG_L2_CACHE_SIZE			0x80000
 +#define CONFIG_PHYS_SDRAM_1				0x60000000
 +#define CONFIG_LOADADDR					0x70000000 /* default destination location for tftp file (tftpboot cmd) */
-+#define CONFIG_PHYS_SDRAM_RSVD_SIZE		0x01000000 /* bytes reserved from CONFIG_PHYS_SDRAM_1 for custom use */
++#define CONFIG_PHYS_SDRAM_RSVD_SIZE		0x0 /* bytes reserved from CONFIG_PHYS_SDRAM_1 for custom use */
 +
 +/* Where kernel is loaded to in memory */
 +#define CONFIG_SYS_LOAD_ADDR				0x70000000


### PR DESCRIPTION
The iProc U-Boot maps physical SDRAM to begin at 0x6000_0000.

The initial commits for the as4610_XX platforms defined the first 16MB
(0x0100_0000) as "reserved for custom use" and excluded it from the
available free memory:

  commit 021ea69a39106006f70080f47cc82404294e18c6
  Author: Vidya Sagar Ravipati <vidya@cumulusnetworks.com>
  Date:   Wed Oct 28 12:15:10 2015 -0700
   
      arm: accton AS4610-54: ONIE support for accton as4610-30 board

  commit 17fbb7adc50e514f7f5b8373dfded362fa34a026
  Author: Vidya Sagar Ravipati <vidya@cumulusnetworks.com>
  Date:   Mon Oct 26 14:51:45 2015 -0700
   
      arm: accton AS4610-54: ONIE support for accton as4610-54 board

None of the PowerPC ONIE U-Boot implementations do this.

This is just a waste of 16MB.

This patch sets the reserved SDRAM size to 0x0.

This also has the nice property of aligning the start of RAM to a
512MB boundary, which simplifies the memory layout for loading
kernels.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>