### PR TITLE
x86 uninstall: install grub before deleting NOS

### DIFF
--- a/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
+++ b/rootconf/x86_64/sysroot-lib-onie/uninstall-arch
@@ -169,14 +169,6 @@ uninstall_system()
         exit 1
     }
 
-    # Wipe out and delete all partitions, except for important ones,
-    # like GRUB, ONIE and possibly a DIAG.
-    ls -d /sys/block/$blk_dev/${blk_dev}* | sed -e "s/^.*$blk_dev//" | while read part ; do
-        if eval $should_delete_partition $blk_dev $part ; then
-            erase_part $blk_dev $part
-        fi
-    done
-
     if [ "$(onie_get_running_firmware)" = "uefi" ] ; then
         uefi_clean_up
         uefi_boot_onie_install
@@ -185,6 +177,14 @@ uninstall_system()
         # probably installed there.
         bios_boot_onie_install
     fi
+
+    # Wipe out and delete all partitions, except for important ones,
+    # like GRUB, ONIE and possibly a DIAG.
+    ls -d /sys/block/$blk_dev/${blk_dev}* | sed -e "s/^.*$blk_dev//" | while read part ; do
+        if eval $should_delete_partition $blk_dev $part ; then
+            erase_part $blk_dev $part
+        fi
+    done
 
     return 0
 }


### PR DESCRIPTION
ONIE can take a long time to erase NOS storage during uninstall, and reinstalls
itself to grub only after NOS erasure completes. If power is interrupted to the
system while ONIE is erasing NOS storage, it is likely to come up in grub
rescue, because the NOS grub partition has been wiped. If the symbols for
NOS-grub in the MBR do not match those in ONIE (likely), it may become
necessary to recover via ISO, which may not be available, thereby necessitating
RMA.

This patch addresses the issue by changing the order of the uninstall process
to first installing ONIE to grub then erase NOS partitions.  With this order of
operations, even if the system loses power, it should still come up to an
working environment (ONIE) where further action can be taken.