### PR TITLE
kernel-4.1.28: back port severe memory leak fix

### DIFF
--- a/patches/kernel/4.1.28/4.1.28-Fix-bad-backport-of-8f182270dfec-mm-swap.c-fl.patch
+++ b/patches/kernel/4.1.28/4.1.28-Fix-bad-backport-of-8f182270dfec-mm-swap.c-fl.patch
@@ -1,0 +1,72 @@
+From 74225a4cbea38034034add5da67a2f7ee23251c0 Mon Sep 17 00:00:00 2001
+From: Steven Rostedt <rostedt@goodmis.org>
+Date: Thu, 14 Jul 2016 17:55:21 -0400
+Subject: [PATCH 1/1] 4.1.28 Fix bad backport of 8f182270dfec "mm/swap.c: flush
+ lru pvecs on compound page arrival"
+
+When I pulled in 4.1.28 into my stable 4.1-rt tree and ran the tests,
+it crashed with a severe OOM killing everything. I then tested 4.1.28
+without -rt and it had the same issue. I did a bisect between 4.1.27
+and 4.1.28 and found that the bug started at:
+
+commit 8f182270dfec "mm/swap.c: flush lru pvecs on compound page
+arrival"
+
+Looking at that patch and what's in mainline, I see that there's a
+mismatch in one of the hunks:
+
+Mainline:
+
+@@ -391,9 +391,8 @@ static void __lru_cache_add(struct page *page)
+        struct pagevec *pvec = &get_cpu_var(lru_add_pvec);
+
+        get_page(page);
+-       if (!pagevec_space(pvec))
++       if (!pagevec_add(pvec, page) || PageCompound(page))
+                __pagevec_lru_add(pvec);
+-       pagevec_add(pvec, page);
+        put_cpu_var(lru_add_pvec);
+ }
+
+Stable 4.1.28:
+
+@@ -631,9 +631,8 @@ static void __lru_cache_add(struct page *page)
+        struct pagevec *pvec = &get_cpu_var(lru_add_pvec);
+
+        page_cache_get(page);
+-       if (!pagevec_space(pvec))
++       if (!pagevec_space(pvec) || PageCompound(page))
+                __pagevec_lru_add(pvec);
+-       pagevec_add(pvec, page);
+        put_cpu_var(lru_add_pvec);
+ }
+
+Where mainline replace pagevec_space() with pagevec_add, and stable did
+not.
+
+Fixing this makes the OOM go away.
+
+Note, 3.18 has the same bug.
+
+Signed-off-by: Steven Rostedt <rostedt@goodmis.org>
+Signed-off-by: Sasha Levin <alexander.levin@verizon.com>
+---
+ mm/swap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mm/swap.c b/mm/swap.c
+index b523f0a..ab3b9c2 100644
+--- a/mm/swap.c
++++ b/mm/swap.c
+@@ -631,7 +631,7 @@ static void __lru_cache_add(struct page *page)
+ 	struct pagevec *pvec = &get_cpu_var(lru_add_pvec);
+ 
+ 	page_cache_get(page);
+-	if (!pagevec_space(pvec) || PageCompound(page))
++	if (!pagevec_add(pvec, page) || PageCompound(page))
+ 		__pagevec_lru_add(pvec);
+ 	put_cpu_var(lru_add_pvec);
+ }
+-- 
+1.9.1
+

--- a/patches/kernel/4.1.28/series
+++ b/patches/kernel/4.1.28/series
@@ -1,2 +1,3 @@
 # This series applies on GIT commit 6f9bd6143527badc829bfb0d06fa4c8ef89f234d
 arch-powerpc-update-tm-feature-bits.patch
+4.1.28-Fix-bad-backport-of-8f182270dfec-mm-swap.c-fl.patch


### PR DESCRIPTION
Back port fix of bad memory leak introduced in 4.1.28.  This fix comes
from 4.1.29.

For ONIE this would manifest itself as running out of memory when
trying to install ONIE via an .ISO image on a blank system.

The start up code searches for the ONIE disk label using the 'blkid'
inside a while loop for 70 iterations.  Each invocation of 'blkid'
would leak ~30MB inside the kernel, eventually running out of memory
with a kernel panic.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>