### PR TITLE
Added 'pkg-config' to the install list for preparing debian build host

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -423,7 +423,7 @@ DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools util-linux \
 				  gperf device-tree-compiler python-all-dev xorriso \
 				  autoconf automake bison flex texinfo libtool libtool-bin \
 				  realpath gawk libncurses5 libncurses5-dev bc \
-				  dosfstools mtools
+				  dosfstools mtools pkg-config
 
 PHONY += debian-prepare-build-host
 debian-prepare-build-host:


### PR DESCRIPTION
Included the apt package 'pkg-config' to the list of packages installed when preparing the debian host for ONIE builds. Apparently this package is required for building some machines, and was not previously installed as a dependency.