### PR TITLE
x86_64 demo installer: force to create file system

### DIFF
--- a/demo/installer/x86_64/install.sh
+++ b/demo/installer/x86_64/install.sh
@@ -292,7 +292,7 @@ demo_dev=$(echo $blk_dev | sed -e 's/\(mmcblk[0-9]\)/\1p/')$demo_part
 partprobe
 
 # Create filesystem on demo partition with a label
-mkfs.ext4 -L $demo_volume_label $demo_dev || {
+mkfs.ext4 -F -L $demo_volume_label $demo_dev || {
     echo "Error: Unable to create file system on $demo_dev"
     exit 1
 }


### PR DESCRIPTION
When performing `mkfs.ext4` on some mass storage, it will raise a hint
messege:

    ONIE:/ # mkfs.ext4 /dev/sda3
    mke2fs 1.42.13 (17-May-2015)
    /dev/sda3 contains a ext4 file system
            created on Mon Jan  1 00:01:14 2001
    Proceed anyway? (y,n)

The patch addes `-F` to make it proceed automatically.