### PR TITLE
[imt] correcting missed diag_bootcmd_file variable.

### DIFF
--- a/machine/imt/im_n29xx_t40n/rootconf/sysroot-lib-onie/onie-blkdev-common
+++ b/machine/imt/im_n29xx_t40n/rootconf/sysroot-lib-onie/onie-blkdev-common
@@ -1,5 +1,6 @@
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014 Alex Belits <alexb@interfacemasters.com>
+#  Copyright (C) 2016 Vitaliy Ivanov <vitaliyi@interfacemasters.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -33,6 +34,7 @@ fi
 
 grub_root_dir="${common_boot_mnt}/grub"
 grub_env_file="${grub_root_dir}/grubenv"
+diag_bootcmd_file="${onie_root_dir}/grub/diag-bootcmd.cfg"
 
 onie_update_dir="${onie_root_dir}/update"
 onie_update_pending_dir="${onie_update_dir}/pending"


### PR DESCRIPTION
Fixing #444

On Interface Masters HW we use part of ONIE code that is shared between
all platforms and part that is custom for IMT only.
In shared code new variable was added - 'diag_bootcmd_file'.
If it's missed 'cp' command would fail and ONIE installer/updater would
stop w/o finishing required steps.
No UEFI support for IMT HW.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>