### PR TITLE
Alphanetworks STX60A0-486F : fix the console device number

### DIFF
--- a/machine/alphanetworks/alphanetworks_stx60a0_486f/machine.make
+++ b/machine/alphanetworks/alphanetworks_stx60a0_486f/machine.make
@@ -28,7 +28,7 @@ I2CTOOLS_ENABLE = yes
 I2CTOOLS_SYSEEPROM = no
 
 # Console parameters
-CONSOLE_DEV = 0
+CONSOLE_DEV = 1
 
 # Set Linux kernel version
 LINUX_VERSION		= 3.14


### PR DESCRIPTION
The machine has 48x10GbE SFP+ ports and 6x100GbE QSFP28 ports on Broadcom Qumran switch ASIC. CPU module is Intel Rangeley C2558.
Change the console device from ttyS0 to ttyS1.