### PR TITLE
Remove the 'local' keyword from global variables

### DIFF
--- a/rootconf/grub-arch/sysroot-lib-onie/init-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/init-arch
@@ -14,8 +14,8 @@
 
 mkdir -p $onie_boot_mnt
 
-local delay=70
-local cnt=0
+delay=70
+cnt=0
 while [ $cnt -lt $delay ] ; do
     device=$(onie_get_boot_dev)
     [ -n "$device" ] && break;


### PR DESCRIPTION
This bug has been lurking in the code for two years.  Now the current
busybox version 1.25.1 catches the syntax error.

Previously the older busybox 1.20.2 ignored the syntax error.

This patch removes the 'local' keyword from the global variable
definitions.

Closes #452
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>