### PR TITLE
installer mode: show a hint message during making install boot mode sticky

### DIFF
--- a/rootconf/default/etc/init.d/boot-mode.sh
+++ b/rootconf/default/etc/init.d/boot-mode.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2015,2016,2017 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -49,6 +49,13 @@ do_start() {
             exit 0
             ;;
         install)
+            cat <<EOF >> /etc/issue
+NOTE: ONIE install mode booting has been sticky. i.e.,
+      it stays install mode until a NOS installer runs
+      successfully.
+
+EOF
+            log_console_msg "Installer mode detected.  Making install boot mode sticky."
             install_remain_sticky_arch || {
                 echo "Error: problems making install boot mode sticky" > /dev/console
             }


### PR DESCRIPTION
…ticky

The commit 42c7448 accomplished the feature of making install boot
mode sticky for x86_64 ONIE in May, 2015.  Since then people often
complain to me:

    "I'm surprised at ONIE killed my NOS without any reason!"
    "The NOS has disappeared unexpectedly!  This is a critical issue!"

Adding a hint message to indicate what ONIE is doing would help people
to understand the design.

The patch has been tested in AS7716_32X and AS4610_30.