### PR TITLE
Accton AS5512_54X: revise SWITCH_ASIC_VENDOR to 'nephos'

### DIFF
--- a/machine/accton/accton_as5512_54x/machine.make
+++ b/machine/accton/accton_as5512_54x/machine.make
@@ -7,7 +7,7 @@
 
 
 ONIE_ARCH ?= x86_64
-SWITCH_ASIC_VENDOR = bcm
+SWITCH_ASIC_VENDOR = nephos
 
 VENDOR_REV ?= 0
 


### PR DESCRIPTION
The switch ASIC model is MediaTek/Nephos MT3257.