### PR TITLE
Remove surplus syntax and change tar_dir default name

### DIFF
--- a/rootconf/default/bin/onie-support
+++ b/rootconf/default/bin/onie-support
@@ -47,7 +47,7 @@ mount -t tmpfs tmpfs $tmpdir || {
 onie_support_name="onie-support-${onie_machine}.tar.bz2"
 tarfile="$output_dir/$onie_support_name"
 
-tar_dir="onie-support"
+tar_dir="onie-support-${onie_machine}"
 save_dir="$tmpdir/$tar_dir"
 rm -rf $save_dir
 mkdir -p $save_dir || {
@@ -62,7 +62,7 @@ ps w > $save_dir/runtime-process.txt
 dmesg > $save_dir/dmesg.txt
 onie-syseeprom > $save_dir/onie-syseeprom.txt
 onie-sysinfo -a > $save_dir/onie-sysinfo.txt
-cp /etc/machine.conf > $save_dir/machine.txt
+cp /etc/machine.conf $save_dir/machine.txt
 blkid > $save_dir/blkid.txt
 fdisk -l > $save_dir/fdisk.txt
 support_arch


### PR DESCRIPTION
Output:
ONIE:/tmp # sh onie-support /tmp
Success: Support tarball created: /tmp/onie-support-accton_as7712_32x.tar.bz2
ONIE:/tmp # ls
onie-support                            onie-support-accton_as7712_32x.tar.bz2
ONIE:/tmp # tar xvf onie-support-accton_as7712_32x.tar.bz2
onie-support-accton_as7712_32x/log/
...

Signed-off-by: Phil Huang <phil_huang@edge-core.com>