### PR TITLE
lvm2: default to version 2_02_105

### DIFF
--- a/build-config/arch/armv8a.make
+++ b/build-config/arch/armv8a.make
@@ -93,6 +93,8 @@ I2CTOOLS_ENABLE ?= yes
 
 # Include lvm2 tools (needed for parted)
 LVM2_ENABLE = yes
+# Currently armv8a requires a special version of lvm2
+LVM2_VERSION ?= 2_02_155
 
 # Include ethtool by default
 ETHTOOL_ENABLE ?= yes

--- a/build-config/make/lvm2.make
+++ b/build-config/make/lvm2.make
@@ -10,7 +10,7 @@
 # This is a makefile fragment that defines the build of lvm2
 #
 
-LVM2_VERSION		= 2_02_155
+LVM2_VERSION		?= 2_02_105
 LVM2_TARBALL		= lvm2-$(LVM2_VERSION).tar.xz
 LVM2_TARBALL_URLS	+= $(ONIE_MIRROR) https://git.fedorahosted.org/cgit/lvm2.git/snapshot/
 LVM2_BUILD_DIR		= $(MBUILDDIR)/lvm2

--- a/patches/lvm2/2_02_105/lvm2-conf-install-directory-fixup.patch
+++ b/patches/lvm2/2_02_105/lvm2-conf-install-directory-fixup.patch
@@ -1,0 +1,34 @@
+lvm2 conf install directory fixup
+
+Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+
+SPDX-License-Identifier:     GPL-2.0
+
+The lvm2 install target for the conf/ subdirectory is not quite right
+for cross compiling.  It tries to install files in /etc instead of the
+target sysroot directory.
+
+diff --git a/conf/Makefile.in b/conf/Makefile.in
+index 3f66621..4193111 100644
+--- a/conf/Makefile.in
++++ b/conf/Makefile.in
+@@ -24,14 +24,14 @@ PROFILES=$(DEFAULT_PROFILE) $(srcdir)/thin-performance.profile
+ include $(top_builddir)/make.tmpl
+ 
+ install_conf: $(CONFSRC)
+-	@if [ ! -e $(confdir)/$(CONFDEST) ]; then \
+-		echo "$(INSTALL_WDATA) -D $< $(confdir)/$(CONFDEST)"; \
+-		$(INSTALL_WDATA) -D $< $(confdir)/$(CONFDEST); \
++	@if [ ! -e $(sysconfdir)/$(CONFDEST) ]; then \
++		echo "$(INSTALL_WDATA) -D $< $(sysconfdir)/$(CONFDEST)"; \
++		$(INSTALL_WDATA) -D $< $(sysconfdir)/$(CONFDEST); \
+ 	fi
+ 
+ install_profiles: $(PROFILES)
+-	$(INSTALL_DIR) $(DESTDIR)$(DEFAULT_PROFILE_DIR)
+-	$(INSTALL_DATA) $(PROFILES) $(DESTDIR)$(DEFAULT_PROFILE_DIR)/
++	$(INSTALL_DIR) $(sysconfdir)/profile
++	$(INSTALL_DATA) $(PROFILES) $(sysconfdir)/profile/
+ 
+ install_lvm2: install_conf install_profiles
+ 

--- a/patches/lvm2/2_02_105/series
+++ b/patches/lvm2/2_02_105/series
@@ -1,0 +1,2 @@
+# This series applies on GIT commit ad50b40707ea89ec1f8b9d3071df331dc3b289fd
+lvm2-conf-install-directory-fixup.patch


### PR DESCRIPTION
The version of lvm2 was pushed ahead to 2_02_155 as part of the
aarch64 work.  It appears it was tested using glibc, but was never
tested using uClibc.

It is unclear why moving ahead to version 2_02_155 was necessary.
Looking at the upstream, version 2_02_155 was never officially
released.

This patch reverts the default version of lvm2 to 2_02_105, which
works fine.

Closes: #480
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>