### PR TITLE
updater: show error messages if failed to access sys_eeprom

### DIFF
--- a/installer/grub-arch/install-arch
+++ b/installer/grub-arch/install-arch
@@ -780,10 +780,8 @@ install_image()
         }
     fi
 
-    # Set platform name and ONIE version to sys_eeprom.
-    if [ -x /usr/bin/onie-syseeprom ] ; then
-        onie-syseeprom -s 0x28="$image_platform",0x29="$image_version" > /dev/null
-    fi
+    # update sys_eeprom
+    update_syseeprom
 
 }
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -132,6 +132,23 @@ check_machine_image()
     fi
 }
 
+update_syseeprom()
+{
+    # Set platform name and ONIE version to sys_eeprom.
+    if [ -x /usr/bin/onie-syseeprom ] ; then
+        local syseeprom_log=$(mktemp)
+        onie-syseeprom \
+            -s 0x28="$image_platform",0x29="$image_version" \
+            > $syseeprom_log 2>&1 || {
+            echo "ERROR: Problems accessing sys_eeprom"
+            cat $syseeprom_log && rm -f $syseeprom_log
+            exit 1
+        }
+        [ "$verbose" = "yes" ] && cat $syseeprom_log
+        rm -f $syseeprom_log
+    fi
+}
+
 [ -r ./install-platform ] && . ./install-platform
 
 fail=

--- a/installer/u-boot-arch/install-arch
+++ b/installer/u-boot-arch/install-arch
@@ -72,10 +72,8 @@ install_image()
     # update u-boot env
     update_uboot_env
 
-    # Set platform name and ONIE version to sys_eeprom.
-    if [ -x /usr/bin/onie-syseeprom ] ; then
-        onie-syseeprom -s 0x28="$image_platform",0x29="$image_version" > /dev/null
-    fi
+    # update sys_eeprom
+    update_syseeprom
 
 }
 


### PR DESCRIPTION
If accessing sys_eeprom is failed during ONIE update, show the error
messages on the console to indicate what happened.

The patch has been tested in Accton grub-arch and u-boot-arch platforms.