### PR TITLE
onie-mk-itb.sh: revise $10 to ${10}

### DIFF
--- a/build-config/scripts/onie-mk-itb.sh
+++ b/build-config/scripts/onie-mk-itb.sh
@@ -74,7 +74,7 @@ SYSROOT="$9"
     exit 1
 }
 
-OUTFILE="$10"
+OUTFILE="${10}"
 [ -n "$OUTFILE" ] || {
     echo "Error: output .itb file not specified"
     exit 1


### PR DESCRIPTION
The old version bash regards $10 as ${1}0. This makes onie-mk-itb.sh
creates itb file with ${1}0 name:

    accton_as6710_32x0

The patch revise $10 to ${10} to keep the script work with old version
bash.