### PR TITLE
Create "resolv.conf" by default

### DIFF
--- a/rootconf/default/etc/resolv.conf
+++ b/rootconf/default/etc/resolv.conf
@@ -1,0 +1,3 @@
+# DNS Resolver Configuration File 
+# Example:
+#nameserver 8.8.4.4


### PR DESCRIPTION
"resolv.conf" is helpful for manually via network if operator want to get installer image

Signed-off-by: Phil Huang <phil_huang@edge-core.com>