### PR TITLE
installer: Set bootable flag in the GPT protective MBR partition table

### DIFF
--- a/installer/grub-arch/install-arch
+++ b/installer/grub-arch/install-arch
@@ -336,16 +336,28 @@ create_gpt_partition()
         exit 1
     esac
 
-    local sgdisk_log=$(mktemp)
+    local tmp_log=$(mktemp)
     sgdisk --new=$part:$start:+$size \
         --typecode=$part:$gpt_uuid \
         --attributes=$part:=:$attr_bitmask \
-        --change-name=$part:"$label" "$onie_dev" > $sgdisk_log 2>&1 || {
+        --change-name=$part:"$label" "$onie_dev" > $tmp_log 2>&1 || {
         echo "ERROR: Problems creating $label partition $part on: $onie_dev"
-        cat $sgdisk_log && rm -f $sgdisk_log
+        cat $tmp_log && rm -f $tmp_log
         exit 1
     }
-    rm -f $sgdisk_log
+
+    if [ "$p" = "grub_boot" ] ; then
+        # Set "bootable" flag in the protective MBR partition table.
+        # Some buggy UEFI firmwares operating in CSM (legacy BIOS
+        # mode) require this.  See http://www.rodsbooks.com/gdisk/bios.html.
+        parted "$onie_dev" disk_set pmbr_boot on > $tmp_log 2>&1 || {
+            echo "ERROR: Problems setting bootable flag on protected MBR on: $onie_dev"
+            cat $tmp_log && rm -f $tmp_log
+            exit 1
+        }
+    fi
+
+    rm -f $tmp_log
 }
 
 init_gpt_partition_table()


### PR DESCRIPTION
For GPT partition tables, some buggy UEFI firmwares operating in CSM
(legacy BIOS mode) require that the disk have at least one MBR
partition that's marked as bootable/active to boot in BIOS mode.

See http://www.rodsbooks.com/gdisk/bios.html for more discussion.

When creating the GRUB-BIOS GPT partition, indicating that legacy BIOS
GRUB is being installed in a GPT partition, this patch uses parted to
set the bootable/active flag in the disk's protective MBR.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>