### PR TITLE
quanta_common_rangeley: Alias mbdetect from mb_detect for backward co…

### DIFF
--- a/machine/quanta/quanta_common_rangeley/busybox/patches/onie-sys-eeprom-platform.patch
+++ b/machine/quanta/quanta_common_rangeley/busybox/patches/onie-sys-eeprom-platform.patch
@@ -1,14 +1,16 @@
 Add support for onie-syseeprom and mb_detect
+Alias mbdetect from mb_detect for backward compatible
 
 diff --git a/include/applets.src.h b/include/applets.src.h
-index 71b8cbd..891fb67 100644
+index 71b8cbd..736a31b 100644
 --- a/include/applets.src.h
 +++ b/include/applets.src.h
-@@ -345,6 +345,7 @@ IF_WHOAMI(APPLET_NOFORK(whoami, whoami, BB_DIR_USR_BIN, BB_SUID_DROP, whoami))
+@@ -345,6 +345,8 @@ IF_WHOAMI(APPLET_NOFORK(whoami, whoami, BB_DIR_USR_BIN, BB_SUID_DROP, whoami))
  IF_YES(APPLET_NOFORK(yes, yes, BB_DIR_USR_BIN, BB_SUID_DROP, yes))
  IF_ZCIP(APPLET(zcip, BB_DIR_SBIN, BB_SUID_DROP))
  IF_SYS_EEPROM(APPLET_ODDNAME(onie-syseeprom, onie_syseeprom, BB_DIR_USR_BIN, BB_SUID_DROP, onie_syseeprom))
 +APPLET_ODDNAME(mb_detect, mbdetect, BB_DIR_USR_BIN, BB_SUID_DROP, mbdetect)
++APPLET_ODDNAME(mbdetect, mbdetect, BB_DIR_USR_BIN, BB_SUID_DROP, mbdetect)
  
  #if !defined(PROTOTYPES) && !defined(NAME_MAIN) && !defined(MAKE_USAGE) \
  	&& !defined(MAKE_LINKS) && !defined(MAKE_SUID)

--- a/machine/quanta/quanta_common_rangeley/installer/install-platform
+++ b/machine/quanta/quanta_common_rangeley/installer/install-platform
@@ -3,7 +3,12 @@
 # Overrides install.sh
 check_machine_image()
 {
-    platform=$(/usr/bin/mb_detect -p)
+    [ -x "/usr/bin/mb_detect" ] && {
+        platform=$(/usr/bin/mb_detect -p)
+    }
+    [ -x "/usr/bin/mbdetect" ] && {
+        platform=$(/usr/bin/mbdetect -p)
+    }
     image_platform_machine=$(echo $image_machine | sed "s/common_rangeley/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 


### PR DESCRIPTION
…mpatible

mbdetect is the name of formal release 2014.05 version, which is written as shell script
mb_detect is busybox executable for ONIE, alias to mbdetect for backward compatible
And also add it into install-platform to use the existed one