### PR TITLE
Log local file image discovery paths

### DIFF
--- a/rootconf/default/bin/discover
+++ b/rootconf/default/bin/discover
@@ -87,6 +87,7 @@ sd_localfs()
     for p in $part_list ; do
         mount $p $mp > /dev/null 2>&1 && {
             for f in $onie_default_filenames ; do
+                log_info_msg "Attempting file:/$p/$f ..."
                 if [ -r $mp/$f ] ; then
                     local_parts="${p},$local_parts"
                     break

--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -153,7 +153,7 @@ wget_run()
     # escape any % characters for printing with printf
     print_exec_url=$(echo -n $URL | sed -e 's/%/%%/g')
     log_debug_msg "Running wget with: $user_agent $wget_args $print_exec_url\n"
-    log_info_msg "Fetching $print_exec_url ..."
+    log_info_msg "Attempting $print_exec_url ..."
     wget -U "$user_agent" $wget_args       \
         --header "$header_serial_num"   \
         --header "$header_eth_addr"     \
@@ -203,7 +203,7 @@ tftp_run()
 
     URL="tftp://$SERVER/$BOOTFILE"
     log_debug_msg "Running tftp get with: server: $SERVER, bootfile: $BOOTFILE"
-    log_info_msg "Fetching $URL ..."
+    log_info_msg "Attempting $URL ..."
     if [ "$onie_verbose" = "y" ] || [ "$from_cli" = "yes" ] ; then
         tftp_wrap -g -l $onie_installer -r $BOOTFILE $SERVER && run_installer "$URL" && return 0
     else


### PR DESCRIPTION
The http and tftp image discovery mechanisms log helpful information
about the attempted URL paths.  The local file (typically USB)
discovery mechanism, however, does not.  This is a historical
oversight.

This patch adds some logging to the local file discovery mechanism.
The discovery mechanism now logs the disk partition and file name for
each discovery attempt.

As an example, the kvm_x86 machine log for local file discovery now
logs this:

  Info: Attempting file://dev/vda3/onie-installer-x86_64-kvm_x86_64-r0 ...
  Info: Attempting file://dev/vda3/onie-installer-x86_64-kvm_x86_64 ...
  Info: Attempting file://dev/vda3/onie-installer-kvm_x86_64 ...
  Info: Attempting file://dev/vda3/onie-installer-x86_64-qemu ...
  Info: Attempting file://dev/vda3/onie-installer-x86_64 ...
  Info: Attempting file://dev/vda3/onie-installer ...

Closes: #467
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>