### PR TITLE
networking: bring up link on the loopback interface

### DIFF
--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -186,10 +186,12 @@ config_ethmgmt()
     return $return_value
 }
 
-# When starting the network at boot time configure the MAC addresses
-# for all the Ethernet management interfaces.
 if [ "$1" = "start" ] ; then
-    # Configure Ethernet management MAC addresses
+    # Bring up the loopback interface
+    cmd_run ip link set dev lo up
+
+    # When starting the network at boot time configure the MAC
+    # addresses for all the Ethernet management interfaces.
     intf_list=$(net_intf)
     intf_counter=0
 


### PR DESCRIPTION
The boot time networking script never brought the link up for the
loopback interface (lo).  This is a historical oversight that never
caused any problems with the ONIE services.

While not fatal, it is confusing that the loopback address, 127.0.0.1,
and the host name "localhost" do not function properly.

This patch brings up the "lo" interface as part of the system
networking initialization.

Closes: #498
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>