### PR TITLE
add $onie_disco_serverid and $onie_server_name to tftp_download()

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -311,8 +311,11 @@ $(get_onie_neighs)
 tftp_download()
 {
     local tftp_servers=$(ulist "\
+$onie_server_name
 # Try BOOTP next-server
 $onie_disco_siaddr
+# Try DHCP server IP as TFTP
+$onie_disco_serverid
 # Try DHCP TFTP server name (opt 66)
 # Requires DNS
 $onie_disco_tftp


### PR DESCRIPTION
Need to add `$onie_disco_serverid` and `$onie_server_name` to tftp_download() in exec_installer to proper handle Tests 13 and 73 in the ONIE Compliance Environment (OCE) Testing.

This task is to track:
* code revision
* OCE test revision
* doc (wiki)