### PR TITLE
Add $onie_disco_serverid and $onie_server_name to TFTP waterfall

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -275,15 +275,15 @@ http_download()
     # Build list of HTTP servers to try
     local http_servers=$(ulist "\
 $onie_server_name
-# HTTP server IP only
+# HTTP server IP only (DHCP opt 72)
 $onie_disco_wwwsrv
-# Try BOOTP next-server IP as HTTP
+# BOOTP next-server IP
 $onie_disco_siaddr
-# Try DHCP server IP as HTTP
+# DHCP server IP (DHCP opt 54)
 $onie_disco_serverid
-# Try TFTP server IP as HTTP
+# TFTP server IP (DHCP opt 150)
 $onie_disco_tftpsiaddr
-# Try DHCP TFTP server name (opt 66) as HTTP
+# DHCP TFTP server name (DHCP opt 66)
 # Requires DNS
 $onie_disco_tftp
 # Add link local neighbors
@@ -311,12 +311,15 @@ $(get_onie_neighs)
 tftp_download()
 {
     local tftp_servers=$(ulist "\
-# Try BOOTP next-server
+$onie_server_name
+# BOOTP next-server IP
 $onie_disco_siaddr
-# Try DHCP TFTP server name (opt 66)
+# DHCP server IP (DHCP opt 54)
+$onie_disco_serverid
+# DHCP TFTP server name (DHCP opt 66)
 # Requires DNS
 $onie_disco_tftp
-# Try DHCP TFTP server IP address (opt 150)
+# TFTP server IP (DHCP opt 150)
 $onie_disco_tftpsiaddr
 ")
 


### PR DESCRIPTION
The ONIE TFTP waterfall (partial image discovery) is missing a few
server identifiers that had been added to the HTTP waterfall a while
back.

Specifically, these are missing:

- well known onie-server name.  This feature was added in commit
  55b0b13ac7f3a5eb3d5fdcbfe9ad28acff175edd for HTTP:

  commit 55b0b13ac7f3a5eb3d5fdcbfe9ad28acff175edd
  Author: Curt Brune <curt@cumulusnetworks.com>
  Date:   Tue Jun 30 17:01:29 2015 -0700

      image discovery waterfall: add well known server name

- DHCP server IP address, also known as dhcp-server-identifier.

This patch adds those server identifiers to the list of potential TFTP
servers.

Also this patch tunes up the comments a bit, highlighting the DHCP
option numbers.

Closes: #506
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>