### PR TITLE
BigStone-G: Allow ONIE install when there are no EEPROM contents

### DIFF
--- a/machine/celestica/cel_bigstone_g/installer/install-platform
+++ b/machine/celestica/cel_bigstone_g/installer/install-platform
@@ -6,7 +6,9 @@
 check_machine_image()
 {
     bigstone_g_card_detect
-    image_platform_machine=$(echo $image_machine | sed "s/cel_bigstone_g/cel_bigstone_g_${platform}/g")
+    if [ -n "${platform}" ] ; then
+        image_platform_machine=$(echo $image_machine | sed "s/cel_bigstone_g/cel_bigstone_g_${platform}/g")
+    fi
     echo "ONIE: Platform Machine: $image_platform_machine"
 
     if [ "$onie_machine" != "$image_machine" ] &&

--- a/machine/celestica/cel_bigstone_g/rootconf/sysroot-init/machine-detect.sh
+++ b/machine/celestica/cel_bigstone_g/rootconf/sysroot-init/machine-detect.sh
@@ -3,6 +3,8 @@
 . /lib/onie/platform-discover
 
 bigstone_g_card_detect
-cp -f /etc/machine.conf /etc/machine_cel_bigstone_g.conf
-/bin/sed "s/cel_bigstone_g/cel_bigstone_g_${platform}/g" /etc/machine_cel_bigstone_g.conf > /etc/machine.conf
+if [ -n "${platform}" ] ; then
+    cp -f /etc/machine.conf /etc/machine_cel_bigstone_g.conf
+    /bin/sed "s/cel_bigstone_g/cel_bigstone_g_${platform}/g" /etc/machine_cel_bigstone_g.conf > /etc/machine.conf
+fi
 log_info_msg "Platform $(onie-sysinfo -m) detected ..."

--- a/machine/celestica/cel_bigstone_g/rootconf/sysroot-lib-onie/platform-discover
+++ b/machine/celestica/cel_bigstone_g/rootconf/sysroot-lib-onie/platform-discover
@@ -10,9 +10,12 @@
 #
 bigstone_g_card_detect()
 {
-	local PART_NUM=$(/usr/bin/onie-syseeprom -g 0x22)
+	local PART_NUM
+	PART_NUM=$(/usr/bin/onie-syseeprom -g 0x22) || PART_NUM=""
 	local LABEL_REV
-	LABEL_REV="_"$(/usr/bin/onie-syseeprom -g 0x27) || LABEL_REV=""
+	if [ -n "${PART_NUM}" ] ; then
+		LABEL_REV="_"$(/usr/bin/onie-syseeprom -g 0x27) || LABEL_REV=""
+	fi
 	platform=$(/bin/echo ${PART_NUM}${LABEL_REV} |
 		   /bin/sed s/-/_/g |
 		   /usr/bin/awk '{print tolower($0)}')


### PR DESCRIPTION
When the EEPROM is not initialized the platform was being misidentified on the BigStone-G platform. This prevented ONIE from being able to be installed because of a platform mismatch. Which, in turn, prevented the EEPROM from being programmed because ONIE was being used to program the EEPROM.

This patch corrects the problem by checking to see if the Part Number (0x22) field of the EEPROM is valid, instead of blindly using it. This prevents an invalid platform string from being created.
