### PR TITLE
build: compile common utilities once per toolchain

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 #>
 #
-#  Copyright (C) 2013,2014,2015,2016 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2016,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014,2015 Carlos Cardenas <carlos@cumulusnetworks.com>
 #  Copyright (C) 2014 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
@@ -11,44 +11,65 @@
 #
 # Builds the Open Network Install Environment install images
 #
-# The image contains:
+# The install image contains:
 #
-#   u-boot
-#   kernel
-#   initramfs loaded with the ONIE discovery and execution application.
+#   install scripts
+#   Linux kernel
+#   initramfs
+#   boot loader specific binaries, like GRUB or U-Boot
 #
-# THIS MAKEFILE USES SUDO TO EXECUTE VARIOUS OPERATIONS WITH ROOT PRIVILEGES!!!!
+# The configuration for a specific platform is located in
+# ../machine/<vendor>/<platform>
 #
-# The configuration for a specific platform must be located in
-# ../machine/<platform>
+# The build specification is in this directory.  The results of the
+# build process end up in ../build.  The dependencies follow a source,
+# patch, build, install sequence and use stamps to track targets.
 #
-# The build specification is in this directory, and the results of the process end
-# up in ../build.  The dependencies follow a source, patch, build, install
-# sequence and use stamps to track targets.
+# When building multiple machines, common components are only built
+# once per toolchain.
 #
 # Typical usage is to checkout a tree and type:
 #
-#    make MACHINE=<platform> all
+#    make MACHINEROOT=../machine/<vendor> MACHINE=<platform> all demo
 #
-# Note: The directory ../machine/<platform> must exist.
+# Note: The directory ../machine/<vendor>/<platform> must exist.
 #
-# The result of the build creates the following directory tree...
+# The result of the build creates the following directory tree.
+# Platform specific components are in build/<platform>, while common
+# components are in build/user/<toolchain>.
 # 
 #   build
 #   ├── <platform>
 #   │   ├── busybox
-#   |   |-- i2ctools
 #   │   ├── initramfs
 #   │   ├── kernel
 #   │   ├── stamp
-#   │   ├── sysroot
-#   │   ├── u-boot
-#   │   ├── uclibc
-#   │   ├── e2fsprogs
-#   │   ├── zlib
-#   │   ├── lzo
-#   │   ├── mtdutils
-#   │   └── dropbear
+#   │   └── sysroot
+#   ├── user/<toolchain>/
+#   │        ├── btrfs-progs
+#   │        ├── dmidecode
+#   │        ├── dosfstools
+#   │        ├── dropbear
+#   │        ├── e2fsprogs
+#   │        ├── efibootmgr
+#   │        ├── efivar
+#   │        ├── ethtool
+#   │        ├── flashrom
+#   │        ├── gptfdisk
+#   │        ├── grub
+#   │        ├── grub-host
+#   │        ├── kexec-tools
+#   │        ├── lvm2
+#   │        ├── lzo
+#   │        ├── mtd-utils
+#   │        ├── parted
+#   │        ├── pciutils
+#   │        ├── popt
+#   │        ├── stamp
+#   │        ├── util-linux
+#   │        └── zlib
+#   ├── download
+#   ├── x-tools
 #   └── images
 #
 #<
@@ -148,7 +169,6 @@ MAKEOVERRIDES := $(filter-out MACHINE=%,$(MAKEOVERRIDES))
 MBUILDDIR	=  $(BUILDDIR)/$(MACHINE_PREFIX)
 STAMPDIR	=  $(MBUILDDIR)/stamp
 SYSROOTDIR	=  $(MBUILDDIR)/sysroot
-DEV_SYSROOT	=  $(MBUILDDIR)/dev-sysroot
 INITRAMFSDIR	=  $(MBUILDDIR)/initramfs
 
 # These directories are needed per machine
@@ -396,32 +416,42 @@ endif
 # top level targets
 #
 
-PHONY += all source demo clean userspace-clean download download-clean
-
+PHONY += source
 source: $(SOURCE)
 	$(Q) echo "=== Finished making $@ ==="
 
+PHONY += download
 download: $(DOWNLOAD)
 	$(Q) echo "=== Finished making $@ ==="
 
+PHONY += all
 all: $(KERNEL) $(UBOOT) $(SYSROOT) $(IMAGE)
 	$(Q) echo "=== Finished making onie-$(PLATFORM) $(LSB_RELEASE_TAG) ==="
 
+PHONY += demo
 demo: $(KERNEL) $(DEMO_IMAGE)
 	$(Q) echo "=== Finished making demo onie-$(PLATFORM) $(LSB_RELEASE_TAG) ==="
 
-userspace-clean: $(USERSPACE_CLEAN)
-	$(Q) echo "=== Finished making $@ ==="
-
-clean: 	$(CLEAN) $(USERSPACE_CLEAN)
+PHONY += machine-clean
+machine-clean: $(MACHINE_CLEAN)
 	$(Q) rm -rf $(BUILDDIR)/images/*$(MACHINE_PREFIX)*
 	$(Q) rm -rf $(MBUILDDIR)
+	$(Q) echo "=== Finished making $@ ==="
+
+PHONY += clean
+clean: 	machine-clean
 	$(Q) echo "=== Finished making $@ for $(PLATFORM) ==="
 
+PHONY += user-clean
+user-clean: machine-clean $(USER_CLEAN)
+	$(Q) echo "=== Finished making $@ ==="
+
+PHONY += download-clean
 download-clean: $(DOWNLOAD_CLEAN)
 	$(Q) rm -rf $(DOWNLOADDIR)/*
 	$(Q) echo "=== Finished making $@ ==="
 
+PHONY += distclean
 distclean: download-clean $(DIST_CLEAN)
 	$(Q) for d in $(BUILDDIR)/* ; do \
 		[ -e "$$d" ] || break ; \

--- a/build-config/make/acpica-tools.make
+++ b/build-config/make/acpica-tools.make
@@ -1,6 +1,7 @@
 #-------------------------------------------------------------------------------
 #
 #  Copyright (C) 2015 Carlos Cardenas <carlos@cumulusnetworks.com>
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,12 +13,12 @@
 ACPICA_TOOLS_VERSION	= 20150410
 ACPICA_TOOLS_TARBALL	= acpica-unix-$(ACPICA_TOOLS_VERSION).tar.gz
 ACPICA_TOOLS_TARBALL_URLS	+= $(ONIE_MIRROR) https://acpica.org/sites/acpica/files/
-ACPICA_TOOLS_BUILD_DIR	= $(MBUILDDIR)/acpica-tools
+ACPICA_TOOLS_BUILD_DIR	= $(USER_BUILDDIR)/acpica-tools
 ACPICA_TOOLS_DIR		= $(ACPICA_TOOLS_BUILD_DIR)/acpica-unix-$(ACPICA_TOOLS_VERSION)
 
 ACPICA_TOOLS_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/acpica-tools-download
-ACPICA_TOOLS_SOURCE_STAMP	= $(STAMPDIR)/acpica-tools-source
-ACPICA_TOOLS_BUILD_STAMP	= $(STAMPDIR)/acpica-tools-build
+ACPICA_TOOLS_SOURCE_STAMP	= $(USER_STAMPDIR)/acpica-tools-source
+ACPICA_TOOLS_BUILD_STAMP	= $(USER_STAMPDIR)/acpica-tools-build
 ACPICA_TOOLS_INSTALL_STAMP	= $(STAMPDIR)/acpica-tools-install
 ACPICA_TOOLS_STAMP		= $(ACPICA_TOOLS_SOURCE_STAMP) \
 			  $(ACPICA_TOOLS_BUILD_STAMP) \
@@ -41,7 +42,7 @@ $(ACPICA_TOOLS_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(ACPICA_TOOLS_SOURCE_STAMP)
 acpica-tools-source: $(ACPICA_TOOLS_SOURCE_STAMP)
-$(ACPICA_TOOLS_SOURCE_STAMP): $(TREE_STAMP) | $(ACPICA_TOOLS_DOWNLOAD_STAMP)
+$(ACPICA_TOOLS_SOURCE_STAMP): $(USER_TREE_STAMP) | $(ACPICA_TOOLS_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream acpica-tools ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(ACPICA_TOOLS_BUILD_DIR) $(DOWNLOADDIR)/$(ACPICA_TOOLS_TARBALL)
@@ -62,12 +63,6 @@ $(ACPICA_TOOLS_BUILD_STAMP): $(ACPICA_TOOLS_NEW_FILES) \
 		HOST=_LINUX             			\
 		PROGS="$(ACPIBINS)"                             \
 		CC=$(CROSSPREFIX)gcc
-	$(Q) touch $@
-
-acpica-tools-install: $(ACPICA_TOOLS_INSTALL_STAMP)
-$(ACPICA_TOOLS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(ACPICA_TOOLS_BUILD_STAMP)
-	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing acpica-tools in $(DEV_SYSROOT) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'				\
 	    $(MAKE) -C $(ACPICA_TOOLS_DIR)			\
 		DESTDIR=$(DEV_SYSROOT)  			\
@@ -75,12 +70,18 @@ $(ACPICA_TOOLS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(ACPICA_TOOLS_BUILD_STAMP)
 		INSTALLFLAGS="-m 755 -s"        		\
 		PROGS="$(ACPIBINS)"                             \
 		install
+	$(Q) touch $@
+
+acpica-tools-install: $(ACPICA_TOOLS_INSTALL_STAMP)
+$(ACPICA_TOOLS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(ACPICA_TOOLS_BUILD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Installing acpica-tools in $(SYSROOTDIR) ===="
 	$(Q) for file in $(ACPIBINS) ; do \
 		cp -av $(DEV_SYSROOT)/usr/bin/$$file $(SYSROOTDIR)/usr/bin/ ; \
 	done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += acpica-tools-clean
+USER_CLEAN += acpica-tools-clean
 acpica-tools-clean:
 	$(Q) rm -rf $(ACPICA_TOOLS_BUILD_DIR)
 	$(Q) rm -f $(ACPICA_TOOLS_STAMP)

--- a/build-config/make/btrfs-progs.make
+++ b/build-config/make/btrfs-progs.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -13,17 +13,18 @@ BTRFSPROGS_VERSION		= v4.3.1
 BTRFSPROGS_TARBALL		= btrfs-progs-$(BTRFSPROGS_VERSION).tar.xz
 BTRFSPROGS_TARBALL_URLS		+= $(ONIE_MIRROR) \
 				   https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs
-BTRFSPROGS_BUILD_DIR		= $(MBUILDDIR)/btrfs-progs
+BTRFSPROGS_BUILD_DIR		= $(USER_BUILDDIR)/btrfs-progs
 BTRFSPROGS_DIR			= $(BTRFSPROGS_BUILD_DIR)/btrfs-progs-$(BTRFSPROGS_VERSION)
 
 BTRFSPROGS_SRCPATCHDIR		= $(PATCHDIR)/btrfs-progs
 BTRFSPROGS_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/btrfs-progs-download
-BTRFSPROGS_SOURCE_STAMP		= $(STAMPDIR)/btrfs-progs-source
-BTRFSPROGS_PATCH_STAMP		= $(STAMPDIR)/btrfs-progs-patch
-BTRFSPROGS_CONFIGURE_STAMP	= $(STAMPDIR)/btrfs-progs-configure
-BTRFSPROGS_BUILD_STAMP		= $(STAMPDIR)/btrfs-progs-build
+BTRFSPROGS_SOURCE_STAMP		= $(USER_STAMPDIR)/btrfs-progs-source
+BTRFSPROGS_PATCH_STAMP		= $(USER_STAMPDIR)/btrfs-progs-patch
+BTRFSPROGS_CONFIGURE_STAMP	= $(USER_STAMPDIR)/btrfs-progs-configure
+BTRFSPROGS_BUILD_STAMP		= $(USER_STAMPDIR)/btrfs-progs-build
 BTRFSPROGS_INSTALL_STAMP	= $(STAMPDIR)/btrfs-progs-install
 BTRFSPROGS_STAMP		= $(BTRFSPROGS_SOURCE_STAMP) \
+				  $(BTRFSPROGS_PATCH_STAMP) \
 				  $(BTRFSPROGS_CONFIGURE_STAMP) \
 				  $(BTRFSPROGS_BUILD_STAMP) \
 				  $(BTRFSPROGS_INSTALL_STAMP)
@@ -55,7 +56,7 @@ $(BTRFSPROGS_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(BTRFSPROGS_SOURCE_STAMP)
 btrfs-progs-source: $(BTRFSPROGS_SOURCE_STAMP)
-$(BTRFSPROGS_SOURCE_STAMP): $(TREE_STAMP) | $(BTRFSPROGS_DOWNLOAD_STAMP)
+$(BTRFSPROGS_SOURCE_STAMP): $(USER_TREE_STAMP) | $(BTRFSPROGS_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream btrfs-progs ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(BTRFSPROGS_BUILD_DIR) $(DOWNLOADDIR)/$(BTRFSPROGS_TARBALL)
@@ -69,7 +70,7 @@ $(BTRFSPROGS_PATCH_STAMP): $(BTRFSPROGS_SRCPATCHDIR)/* $(BTRFSPROGS_SOURCE_STAMP
 	$(Q) touch $@
 
 btrfs-progs-configure: $(BTRFSPROGS_CONFIGURE_STAMP)
-$(BTRFSPROGS_CONFIGURE_STAMP): $(E2FSPROGS_INSTALL_STAMP) \
+$(BTRFSPROGS_CONFIGURE_STAMP): $(E2FSPROGS_BUILD_STAMP) \
 			      $(BTRFSPROGS_PATCH_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure btrfs-progs-$(BTRFSPROGS_VERSION) ===="
@@ -95,13 +96,13 @@ $(BTRFSPROGS_BUILD_STAMP): $(BTRFSPROGS_NEW_FILES) $(BTRFSPROGS_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building btrfs-progs-$(BTRFSPROGS_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(BTRFSPROGS_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(BTRFSPROGS_DIR) install
 	$(Q) touch $@
 
 btrfs-progs-install: $(BTRFSPROGS_INSTALL_STAMP)
 $(BTRFSPROGS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(BTRFSPROGS_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing btrfs-progs in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(BTRFSPROGS_DIR) install
+	$(Q) echo "==== Installing btrfs-progs in $(SYSROOTDIR) ===="
 	$(Q) for file in $(BTRFSPROGS_LIBS) ; do \
 		cp -av $(DEV_SYSROOT)/usr/lib/$$file $(SYSROOTDIR)/usr/lib/ ; \
 	     done
@@ -110,7 +111,7 @@ $(BTRFSPROGS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(BTRFSPROGS_BUILD_STAMP)
 	     done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += btrfs-progs-clean
+USER_CLEAN += btrfs-progs-clean
 btrfs-progs-clean:
 	$(Q) rm -rf $(BTRFSPROGS_BUILD_DIR)
 	$(Q) rm -f $(BTRFSPROGS_STAMP)

--- a/build-config/make/busybox.make
+++ b/build-config/make/busybox.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014,2017 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
 #  Copyright (C) 2014 Nikolay Shopik <shopik@inblock.ru>
@@ -114,7 +114,7 @@ BUSYBOX_NEW_FILES = $(shell test -d $(BUSYBOX_DIR) && test -f $(BUSYBOX_BUILD_ST
 endif
 
 busybox-build: $(BUSYBOX_BUILD_STAMP)
-$(BUSYBOX_BUILD_STAMP): $(BUSYBOX_DIR)/.config $(BUSYBOX_NEW_FILES) $(UCLIBC_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+$(BUSYBOX_BUILD_STAMP): $(BUSYBOX_DIR)/.config $(BUSYBOX_NEW_FILES) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building busybox-$(BUSYBOX_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'				\
@@ -141,7 +141,7 @@ $(BUSYBOX_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(BUSYBOX_BUILD_STAMP)
 	$(Q) chmod 4755 $(SYSROOTDIR)/bin/busybox
 	$(Q) touch $@
 
-USERSPACE_CLEAN += busybox-clean
+MACHINE_CLEAN += busybox-clean
 busybox-clean:
 	$(Q) rm -rf $(BUSYBOX_BUILD_DIR)
 	$(Q) rm -f $(BUSYBOX_STAMP)

--- a/build-config/make/demo.make
+++ b/build-config/make/demo.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013,2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2015,2016 david_yang <david_yang@accton.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
@@ -123,7 +123,7 @@ demo-image-complete: $(DEMO_IMAGE_COMPLETE_STAMP)
 $(DEMO_IMAGE_COMPLETE_STAMP): $(DEMO_ARCH_BINS)
 	$(Q) touch $@
 
-CLEAN += demo-clean
+MACHINE_CLEAN += demo-clean
 demo-clean:
 	$(Q) rm -rf $(DEMO_SYSROOTDIR)
 	$(Q) rm -f $(MBUILDDIR)/demo-* $(DEMO_IMAGE_PARTS) $(DEMO_OS_BIN) $(DEMO_DIAG_BIN)

--- a/build-config/make/dmidecode.make
+++ b/build-config/make/dmidecode.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,14 +12,14 @@
 DMIDECODE_VERSION		= 2.12
 DMIDECODE_TARBALL		= dmidecode-$(DMIDECODE_VERSION).tar.gz
 DMIDECODE_TARBALL_URLS		+= $(ONIE_MIRROR) http://download.savannah.gnu.org/releases/dmidecode/
-DMIDECODE_BUILD_DIR		= $(MBUILDDIR)/dmidecode
+DMIDECODE_BUILD_DIR		= $(USER_BUILDDIR)/dmidecode
 DMIDECODE_DIR			= $(DMIDECODE_BUILD_DIR)/dmidecode-$(DMIDECODE_VERSION)
 
 DMIDECODE_SRCPATCHDIR		= $(PATCHDIR)/dmidecode
 DMIDECODE_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/dmidecode-download
-DMIDECODE_SOURCE_STAMP		= $(STAMPDIR)/dmidecode-source
-DMIDECODE_PATCH_STAMP		= $(STAMPDIR)/dmidecode-patch
-DMIDECODE_BUILD_STAMP		= $(STAMPDIR)/dmidecode-build
+DMIDECODE_SOURCE_STAMP		= $(USER_STAMPDIR)/dmidecode-source
+DMIDECODE_PATCH_STAMP		= $(USER_STAMPDIR)/dmidecode-patch
+DMIDECODE_BUILD_STAMP		= $(USER_STAMPDIR)/dmidecode-build
 DMIDECODE_INSTALL_STAMP		= $(STAMPDIR)/dmidecode-install
 DMIDECODE_STAMP			= $(DMIDECODE_SOURCE_STAMP) \
 				  $(DMIDECODE_PATCH_STAMP) \
@@ -44,7 +44,7 @@ $(DMIDECODE_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(DMIDECODE_SOURCE_STAMP)
 dmidecode-source: $(DMIDECODE_SOURCE_STAMP)
-$(DMIDECODE_SOURCE_STAMP): $(TREE_STAMP) | $(DMIDECODE_DOWNLOAD_STAMP)
+$(DMIDECODE_SOURCE_STAMP): $(USER_TREE_STAMP) | $(DMIDECODE_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream dmidecode ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(DMIDECODE_BUILD_DIR) $(DOWNLOADDIR)/$(DMIDECODE_TARBALL)
@@ -80,7 +80,7 @@ $(DMIDECODE_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(DMIDECODE_BUILD_STAMP)
 	     done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += dmidecode-clean
+USER_CLEAN += dmidecode-clean
 dmidecode-clean:
 	$(Q) rm -rf $(DMIDECODE_BUILD_DIR)
 	$(Q) rm -f $(DMIDECODE_STAMP)

--- a/build-config/make/dosfstools.make
+++ b/build-config/make/dosfstools.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2015,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,16 +12,17 @@
 DOSFSTOOLS_VERSION		= 3.0.26
 DOSFSTOOLS_TARBALL		= dosfstools-$(DOSFSTOOLS_VERSION).tar.xz
 DOSFSTOOLS_TARBALL_URLS		+= $(ONIE_MIRROR) http://daniel-baumann.ch/files/software/dosfstools
-DOSFSTOOLS_BUILD_DIR		= $(MBUILDDIR)/dosfstools
+DOSFSTOOLS_BUILD_DIR		= $(USER_BUILDDIR)/dosfstools
 DOSFSTOOLS_DIR			= $(DOSFSTOOLS_BUILD_DIR)/dosfstools-$(DOSFSTOOLS_VERSION)
 
 DOSFSTOOLS_SRCPATCHDIR		= $(PATCHDIR)/dosfstools
 DOSFSTOOLS_DOWNLOAD_STAMP		= $(DOWNLOADDIR)/dosfstools-download
-DOSFSTOOLS_SOURCE_STAMP		= $(STAMPDIR)/dosfstools-source
-DOSFSTOOLS_PATCH_STAMP		= $(STAMPDIR)/dosfstools-patch
-DOSFSTOOLS_BUILD_STAMP		= $(STAMPDIR)/dosfstools-build
+DOSFSTOOLS_SOURCE_STAMP		= $(USER_STAMPDIR)/dosfstools-source
+DOSFSTOOLS_PATCH_STAMP		= $(USER_STAMPDIR)/dosfstools-patch
+DOSFSTOOLS_BUILD_STAMP		= $(USER_STAMPDIR)/dosfstools-build
 DOSFSTOOLS_INSTALL_STAMP	= $(STAMPDIR)/dosfstools-install
 DOSFSTOOLS_STAMP		= $(DOSFSTOOLS_SOURCE_STAMP) \
+				  $(DOSFSTOOLS_PATCH_STAMP) \
 				  $(DOSFSTOOLS_BUILD_STAMP) \
 				  $(DOSFSTOOLS_INSTALL_STAMP)
 
@@ -45,7 +46,7 @@ $(DOSFSTOOLS_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(DOSFSTOOLS_SOURCE_STAMP)
 dosfstools-source: $(DOSFSTOOLS_SOURCE_STAMP)
-$(DOSFSTOOLS_SOURCE_STAMP): $(TREE_STAMP) | $(DOSFSTOOLS_DOWNLOAD_STAMP)
+$(DOSFSTOOLS_SOURCE_STAMP): $(USER_TREE_STAMP) | $(DOSFSTOOLS_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream dosfstools ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(DOSFSTOOLS_BUILD_DIR) $(DOWNLOADDIR)/$(DOSFSTOOLS_TARBALL)
@@ -75,20 +76,20 @@ $(DOSFSTOOLS_BUILD_STAMP): $(DOSFSTOOLS_PATCH_STAMP) $(DOSFSTOOLS_NEW_FILES) \
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building dosfstools-$(DOSFSTOOLS_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(DOSFSTOOLS_DIR) $(DOSFSTOOLS_MAKE_VARS)
+	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(DOSFSTOOLS_DIR) $(DOSFSTOOLS_MAKE_VARS) \
+		install-symlinks
 	$(Q) touch $@
 
 dosfstools-install: $(DOSFSTOOLS_INSTALL_STAMP)
 $(DOSFSTOOLS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(DOSFSTOOLS_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Installing dosfstools programs in $(SYSROOTDIR) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(DOSFSTOOLS_DIR) $(DOSFSTOOLS_MAKE_VARS) \
-		install-symlinks
 	$(Q) for file in $(DOSFSTOOLS_PROGRAMS); do \
 		cp -av $(DEV_SYSROOT)/usr/sbin/$$file $(SYSROOTDIR)/usr/sbin ; \
 	     done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += dosfstools-clean
+USER_CLEAN += dosfstools-clean
 dosfstools-clean:
 	$(Q) rm -rf $(DOSFSTOOLS_BUILD_DIR)
 	$(Q) rm -f $(DOSFSTOOLS_STAMP)

--- a/build-config/make/e2fsprogs.make
+++ b/build-config/make/e2fsprogs.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013,2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -13,15 +13,15 @@ E2FSPROGS_VERSION		= 1.42.13
 E2FSPROGS_TARBALL		= e2fsprogs-$(E2FSPROGS_VERSION).tar.xz
 E2FSPROGS_TARBALL_URLS		+= $(ONIE_MIRROR) \
 				   https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v$(E2FSPROGS_VERSION)
-E2FSPROGS_BUILD_DIR		= $(MBUILDDIR)/e2fsprogs
+E2FSPROGS_BUILD_DIR		= $(USER_BUILDDIR)/e2fsprogs
 E2FSPROGS_DIR			= $(E2FSPROGS_BUILD_DIR)/e2fsprogs-$(E2FSPROGS_VERSION)
 
 E2FSPROGS_SRCPATCHDIR		= $(PATCHDIR)/e2fsprogs
 E2FSPROGS_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/e2fsprogs-download
-E2FSPROGS_SOURCE_STAMP		= $(STAMPDIR)/e2fsprogs-source
-E2FSPROGS_PATCH_STAMP		= $(STAMPDIR)/e2fsprogs-patch
-E2FSPROGS_CONFIGURE_STAMP	= $(STAMPDIR)/e2fsprogs-configure
-E2FSPROGS_BUILD_STAMP		= $(STAMPDIR)/e2fsprogs-build
+E2FSPROGS_SOURCE_STAMP		= $(USER_STAMPDIR)/e2fsprogs-source
+E2FSPROGS_PATCH_STAMP		= $(USER_STAMPDIR)/e2fsprogs-patch
+E2FSPROGS_CONFIGURE_STAMP	= $(USER_STAMPDIR)/e2fsprogs-configure
+E2FSPROGS_BUILD_STAMP		= $(USER_STAMPDIR)/e2fsprogs-build
 E2FSPROGS_INSTALL_STAMP		= $(STAMPDIR)/e2fsprogs-install
 E2FSPROGS_STAMP			= $(E2FSPROGS_SOURCE_STAMP) \
 				  $(E2FSPROGS_PATCH_STAMP) \
@@ -52,7 +52,7 @@ $(E2FSPROGS_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(E2FSPROGS_SOURCE_STAMP)
 e2fsprogs-source: $(E2FSPROGS_SOURCE_STAMP)
-$(E2FSPROGS_SOURCE_STAMP): $(TREE_STAMP) | $(E2FSPROGS_DOWNLOAD_STAMP)
+$(E2FSPROGS_SOURCE_STAMP): $(USER_TREE_STAMP) | $(E2FSPROGS_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream e2fsprogs ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(E2FSPROGS_BUILD_DIR) $(DOWNLOADDIR)/$(E2FSPROGS_TARBALL)
@@ -66,8 +66,8 @@ $(E2FSPROGS_PATCH_STAMP): $(E2FSPROGS_SRCPATCHDIR)/* $(E2FSPROGS_SOURCE_STAMP)
 	$(Q) touch $@
 
 e2fsprogs-configure: $(E2FSPROGS_CONFIGURE_STAMP)
-$(E2FSPROGS_CONFIGURE_STAMP): $(ZLIB_INSTALL_STAMP) $(LZO_INSTALL_STAMP) \
-			      $(UTILLINUX_INSTALL_STAMP) $(E2FSPROGS_PATCH_STAMP) | \
+$(E2FSPROGS_CONFIGURE_STAMP): $(ZLIB_BUILD_STAMP) $(LZO_BUILD_STAMP) \
+			      $(UTILLINUX_BUILD_STAMP) $(E2FSPROGS_PATCH_STAMP) | \
 			      $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure e2fsprogs-$(E2FSPROGS_VERSION) ===="
@@ -98,18 +98,9 @@ $(E2FSPROGS_BUILD_STAMP): $(E2FSPROGS_NEW_FILES) $(E2FSPROGS_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building e2fsprogs-$(E2FSPROGS_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(E2FSPROGS_DIR)
-	$(Q) touch $@
-
-e2fsprogs-install: $(E2FSPROGS_INSTALL_STAMP)
-$(E2FSPROGS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(E2FSPROGS_BUILD_STAMP) $(BUSYBOX_INSTALL_STAMP)
-	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing e2fsprogs in $(DEV_SYSROOT) ===="
 	$(Q) for dir in $(E2FSPROGS_LIB_DIRS) ; do \
 		PATH='$(CROSSBIN):$(PATH)' \
 			$(MAKE) -C $(E2FSPROGS_DIR)/lib/$$dir install ; \
-	     done
-	$(Q) for file in $(E2FSPROGS_LIBS) ; do \
-		cp -av $(DEV_SYSROOT)/usr/lib/$$file $(SYSROOTDIR)/usr/lib/ ; \
 	     done
 	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
 		$(MAKE) -C $(E2FSPROGS_DIR)/misc install
@@ -117,6 +108,16 @@ $(E2FSPROGS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(E2FSPROGS_BUILD_STAMP) $(BUS
 		$(MAKE) -C $(E2FSPROGS_DIR)/e2fsck install
 	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
 		$(MAKE) -C $(E2FSPROGS_DIR)/resize install
+	$(Q) touch $@
+
+e2fsprogs-install: $(E2FSPROGS_INSTALL_STAMP)
+$(E2FSPROGS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(E2FSPROGS_BUILD_STAMP) $(ZLIB_INSTALL_STAMP) \
+				$(LZO_INSTALL_STAMP) $(UTILLINUX_INSTALL_STAMP) $(BUSYBOX_INSTALL_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Installing e2fsprogs in $(SYSROOTDIR) ===="
+	$(Q) for file in $(E2FSPROGS_LIBS) ; do \
+		cp -av $(DEV_SYSROOT)/usr/lib/$$file $(SYSROOTDIR)/usr/lib/ ; \
+	     done
 	$(Q) cp -av $(DEV_SYSROOT)/usr/sbin/{mke2fs,tune2fs} $(SYSROOTDIR)/usr/sbin/
 	$(Q) cp -av $(DEV_SYSROOT)/usr/bin/{chattr,lsattr} $(SYSROOTDIR)/usr/bin/
 	$(Q) cp -av $(DEV_SYSROOT)/usr/sbin/{e2fsck,fsck} $(SYSROOTDIR)/usr/sbin/
@@ -129,7 +130,7 @@ $(E2FSPROGS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(E2FSPROGS_BUILD_STAMP) $(BUS
 	$(Q) ln -sf e2fsck $(SYSROOTDIR)/usr/sbin/fsck.ext4
 	$(Q) touch $@
 
-USERSPACE_CLEAN += e2fsprogs-clean
+USER_CLEAN += e2fsprogs-clean
 e2fsprogs-clean:
 	$(Q) rm -rf $(E2FSPROGS_BUILD_DIR)
 	$(Q) rm -f $(E2FSPROGS_STAMP)

--- a/build-config/make/ethtool.make
+++ b/build-config/make/ethtool.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,13 +12,13 @@
 ETHTOOL_VERSION		= 3.14
 ETHTOOL_TARBALL		= ethtool-$(ETHTOOL_VERSION).tar.xz
 ETHTOOL_TARBALL_URLS	+= $(ONIE_MIRROR) https://www.kernel.org/pub/software/network/ethtool
-ETHTOOL_BUILD_DIR	= $(MBUILDDIR)/ethtool
+ETHTOOL_BUILD_DIR	= $(USER_BUILDDIR)/ethtool
 ETHTOOL_DIR		= $(ETHTOOL_BUILD_DIR)/ethtool-$(ETHTOOL_VERSION)
 
 ETHTOOL_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/ethtool-download
-ETHTOOL_SOURCE_STAMP	= $(STAMPDIR)/ethtool-source
-ETHTOOL_CONFIGURE_STAMP	= $(STAMPDIR)/ethtool-configure
-ETHTOOL_BUILD_STAMP	= $(STAMPDIR)/ethtool-build
+ETHTOOL_SOURCE_STAMP	= $(USER_STAMPDIR)/ethtool-source
+ETHTOOL_CONFIGURE_STAMP	= $(USER_STAMPDIR)/ethtool-configure
+ETHTOOL_BUILD_STAMP	= $(USER_STAMPDIR)/ethtool-build
 ETHTOOL_INSTALL_STAMP	= $(STAMPDIR)/ethtool-install
 ETHTOOL_STAMP		= $(ETHTOOL_SOURCE_STAMP) \
 			  $(ETHTOOL_CONFIGURE_STAMP) \
@@ -43,7 +43,7 @@ $(ETHTOOL_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(ETHTOOL_SOURCE_STAMP)
 ethtool-source: $(ETHTOOL_SOURCE_STAMP)
-$(ETHTOOL_SOURCE_STAMP): $(TREE_STAMP) | $(ETHTOOL_DOWNLOAD_STAMP)
+$(ETHTOOL_SOURCE_STAMP): $(USER_TREE_STAMP) | $(ETHTOOL_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream ethtool ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(ETHTOOL_BUILD_DIR) $(DOWNLOADDIR)/$(ETHTOOL_TARBALL)
@@ -66,17 +66,17 @@ $(ETHTOOL_BUILD_STAMP): $(ETHTOOL_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building ethtool-$(ETHTOOL_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(ETHTOOL_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(ETHTOOL_DIR) install
 	$(Q) touch $@
 
 ethtool-install: $(ETHTOOL_INSTALL_STAMP)
 $(ETHTOOL_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(ETHTOOL_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing ethtool in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(ETHTOOL_DIR) install
+	$(Q) echo "==== Installing ethtool in $(SYSROOTDIR) ===="
 	$(Q) cp -av $(DEV_SYSROOT)/usr/sbin/$(ETHTOOL_BIN) $(SYSROOTDIR)/usr/sbin
 	$(Q) touch $@
 
-USERSPACE_CLEAN += ethtool-clean
+USER_CLEAN += ethtool-clean
 ethtool-clean:
 	$(Q) rm -rf $(ETHTOOL_BUILD_DIR)
 	$(Q) rm -f $(ETHTOOL_STAMP)

--- a/build-config/make/firmware-update.make
+++ b/build-config/make/firmware-update.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2016 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2016,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -77,7 +77,7 @@ PHONY += firmware-update
 firmware-update: $(FIRMWARE_UPDATE_COMPLETE_STAMP)
 	$(Q) echo "=== Finished making firmware update package $(FIRMWARE_UPDATE_BASE) ==="
 
-CLEAN += firmware-update-clean
+MACHINE_CLEAN += firmware-update-clean
 firmware-update-clean:
 	$(Q) rm -f $(FIRMWARE_UPDATE_COMPLETE_STAMP) $(FIRMWARE_UPDATE_IMAGE)
 	$(Q) rm -rf $(FIRMWARE_DIR) $(FIRMWARE_UPDATE_IMAGE)

--- a/build-config/make/gptfdisk.make
+++ b/build-config/make/gptfdisk.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,14 +12,14 @@
 GPTFDISK_VERSION		= 0.8.8
 GPTFDISK_TARBALL		= gptfdisk-$(GPTFDISK_VERSION).tar.gz
 GPTFDISK_TARBALL_URLS		+= $(ONIE_MIRROR) http://sourceforge.net/projects/gptfdisk/files/gptfdisk/$(GPTFDISK_VERSION)/
-GPTFDISK_BUILD_DIR		= $(MBUILDDIR)/gptfdisk
+GPTFDISK_BUILD_DIR		= $(USER_BUILDDIR)/gptfdisk
 GPTFDISK_DIR			= $(GPTFDISK_BUILD_DIR)/gptfdisk-$(GPTFDISK_VERSION)
 
 GPTFDISK_SRCPATCHDIR		= $(PATCHDIR)/gptfdisk
 GPTFDISK_DOWNLOAD_STAMP		= $(DOWNLOADDIR)/gptfdisk-download
-GPTFDISK_SOURCE_STAMP		= $(STAMPDIR)/gptfdisk-source
-GPTFDISK_PATCH_STAMP		= $(STAMPDIR)/gptfdisk-patch
-GPTFDISK_BUILD_STAMP		= $(STAMPDIR)/gptfdisk-build
+GPTFDISK_SOURCE_STAMP		= $(USER_STAMPDIR)/gptfdisk-source
+GPTFDISK_PATCH_STAMP		= $(USER_STAMPDIR)/gptfdisk-patch
+GPTFDISK_BUILD_STAMP		= $(USER_STAMPDIR)/gptfdisk-build
 GPTFDISK_INSTALL_STAMP		= $(STAMPDIR)/gptfdisk-install
 GPTFDISK_STAMP			= $(GPTFDISK_SOURCE_STAMP) \
 				  $(GPTFDISK_PATCH_STAMP) \
@@ -44,7 +44,7 @@ $(GPTFDISK_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(GPTFDISK_SOURCE_STAMP)
 gptfdisk-source: $(GPTFDISK_SOURCE_STAMP)
-$(GPTFDISK_SOURCE_STAMP): $(TREE_STAMP) | $(GPTFDISK_DOWNLOAD_STAMP)
+$(GPTFDISK_SOURCE_STAMP): $(USER_TREE_STAMP) | $(GPTFDISK_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream gptfdisk ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(GPTFDISK_BUILD_DIR) $(DOWNLOADDIR)/$(GPTFDISK_TARBALL)
@@ -63,7 +63,7 @@ GPTFDISK_NEW_FILES = $(shell test -d $(GPTFDISK_DIR) && test -f $(GPTFDISK_BUILD
 endif
 
 gptfdisk-build: $(GPTFDISK_BUILD_STAMP)
-$(GPTFDISK_BUILD_STAMP): $(E2FSPROGS_INSTALL_STAMP) $(POPT_INSTALL_STAMP) \
+$(GPTFDISK_BUILD_STAMP): $(E2FSPROGS_BUILD_STAMP) $(POPT_BUILD_STAMP) \
 				$(GPTFDISK_PATCH_STAMP) $(GPTFDISK_NEW_FILES) \
 				| $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
@@ -73,7 +73,7 @@ $(GPTFDISK_BUILD_STAMP): $(E2FSPROGS_INSTALL_STAMP) $(POPT_INSTALL_STAMP) \
 	$(Q) touch $@
 
 gptfdisk-install: $(GPTFDISK_INSTALL_STAMP)
-$(GPTFDISK_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(GPTFDISK_BUILD_STAMP)
+$(GPTFDISK_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(GPTFDISK_BUILD_STAMP) $(POPT_INSTALL_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Installing gptfdisk programs in $(SYSROOTDIR) ===="
 	$(Q) for file in $(GPTFDISK_PROGRAMS); do \
@@ -81,7 +81,7 @@ $(GPTFDISK_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(GPTFDISK_BUILD_STAMP)
 	     done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += gptfdisk-clean
+USER_CLEAN += gptfdisk-clean
 gptfdisk-clean:
 	$(Q) rm -rf $(GPTFDISK_BUILD_DIR)
 	$(Q) rm -f $(GPTFDISK_STAMP)

--- a/build-config/make/grub.make
+++ b/build-config/make/grub.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
@@ -14,25 +14,28 @@
 GRUB_VERSION		= 2.02~beta3
 GRUB_TARBALL		= grub-$(GRUB_VERSION).tar.xz
 GRUB_TARBALL_URLS	+= $(ONIE_MIRROR) http://git.savannah.gnu.org/cgit/grub.git/snapshot/ ftp://alpha.gnu.org/gnu/grub/
-GRUB_BUILD_DIR		= $(MBUILDDIR)/grub
+GRUB_BUILD_DIR		= $(USER_BUILDDIR)/grub
 GRUB_DIR		= $(GRUB_BUILD_DIR)/grub-$(GRUB_VERSION)
 GRUB_I386_DIR		= $(GRUB_BUILD_DIR)/grub-i386-pc
 GRUB_UEFI_DIR		= $(GRUB_BUILD_DIR)/grub-$(ARCH)-efi
 GRUB_I386_COREBOOT_DIR	= $(GRUB_BUILD_DIR)/grub-i386-coreboot
-GRUB_TARGET_LIB_I386_DIR       = $(DEV_SYSROOT)/usr/lib/grub/i386-pc
-GRUB_TARGET_LIB_UEFI_DIR       = $(DEV_SYSROOT)/usr/lib/grub/$(ARCH)-efi
+GRUB_INSTALL_I386_DIR		= $(GRUB_BUILD_DIR)/install/grub-i386-pc
+GRUB_INSTALL_UEFI_DIR		= $(GRUB_BUILD_DIR)/install/grub-$(ARCH)-efi
+GRUB_INSTALL_I386_COREBOOT_DIR	= $(GRUB_BUILD_DIR)/install/grub-i386-coreboot
+GRUB_TARGET_LIB_I386_DIR       = $(GRUB_INSTALL_I386_DIR)/usr/lib/grub/i386-pc
+GRUB_TARGET_LIB_UEFI_DIR       = $(GRUB_INSTALL_UEFI_DIR)/usr/lib/grub/$(ARCH)-efi
 
 GRUB_SRCPATCHDIR	= $(PATCHDIR)/grub/$(GRUB_VERSION)
 GRUB_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/grub-$(GRUB_VERSION)-download
-GRUB_SOURCE_STAMP	= $(STAMPDIR)/grub-source
-GRUB_PATCH_STAMP	= $(STAMPDIR)/grub-patch
-GRUB_CONFIGURE_STAMP	= $(STAMPDIR)/grub-configure
-GRUB_BUILD_STAMP	= $(STAMPDIR)/grub-build
+GRUB_SOURCE_STAMP	= $(USER_STAMPDIR)/grub-source
+GRUB_PATCH_STAMP	= $(USER_STAMPDIR)/grub-patch
+GRUB_CONFIGURE_STAMP	= $(USER_STAMPDIR)/grub-configure
+GRUB_BUILD_STAMP	= $(USER_STAMPDIR)/grub-build
 GRUB_INSTALL_STAMP	= $(STAMPDIR)/grub-install
 ifeq ($(FIRMWARE_TYPE),$(filter $(FIRMWARE_TYPE),auto bios))
-  GRUB_CONFIGURE_I386_STAMP	= $(STAMPDIR)/grub-configure-i386-pc
-  GRUB_BUILD_I386_STAMP		= $(STAMPDIR)/grub-build-i386-pc
-  GRUB_INSTALL_I386_STAMP		= $(STAMPDIR)/grub-install-i386-pc
+  GRUB_CONFIGURE_I386_STAMP	= $(USER_STAMPDIR)/grub-configure-i386-pc
+  GRUB_BUILD_I386_STAMP		= $(USER_STAMPDIR)/grub-build-i386-pc
+  GRUB_INSTALL_I386_STAMP	= $(STAMPDIR)/grub-install-i386-pc
 endif
 ifeq ($(UEFI_ENABLE),yes)
   GRUB_TARGET_UEFI_ENABLE	= yes
@@ -41,13 +44,13 @@ ifeq ($(PXE_EFI64_ENABLE),yes)
   GRUB_TARGET_UEFI_ENABLE	= yes
 endif
 ifeq ($(GRUB_TARGET_UEFI_ENABLE),yes)
-  GRUB_CONFIGURE_UEFI_STAMP	= $(STAMPDIR)/grub-configure-$(ARCH)-efi
-  GRUB_BUILD_UEFI_STAMP		= $(STAMPDIR)/grub-build-$(ARCH)-efi
+  GRUB_CONFIGURE_UEFI_STAMP	= $(USER_STAMPDIR)/grub-configure-$(ARCH)-efi
+  GRUB_BUILD_UEFI_STAMP		= $(USER_STAMPDIR)/grub-build-$(ARCH)-efi
   GRUB_INSTALL_UEFI_STAMP	= $(STAMPDIR)/grub-install-$(ARCH)-efi
 endif
 ifeq ($(FIRMWARE_TYPE),coreboot)
-  GRUB_CONFIGURE_I386_COREBOOT_STAMP	= $(STAMPDIR)/grub-configure-i386-coreboot
-  GRUB_BUILD_I386_COREBOOT_STAMP	= $(STAMPDIR)/grub-build-i386-coreboot
+  GRUB_CONFIGURE_I386_COREBOOT_STAMP	= $(USER_STAMPDIR)/grub-configure-i386-coreboot
+  GRUB_BUILD_I386_COREBOOT_STAMP	= $(USER_STAMPDIR)/grub-build-i386-coreboot
   GRUB_INSTALL_I386_COREBOOT_STAMP	= $(STAMPDIR)/grub-install-i386-coreboot
 endif
 
@@ -95,7 +98,7 @@ $(GRUB_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(GRUB_SOURCE_STAMP)
 grub-source: $(GRUB_SOURCE_STAMP)
-$(GRUB_SOURCE_STAMP): $(TREE_STAMP) | $(GRUB_DOWNLOAD_STAMP)
+$(GRUB_SOURCE_STAMP): $(USER_TREE_STAMP) | $(GRUB_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream grub ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(GRUB_BUILD_DIR) $(DOWNLOADDIR)/$(GRUB_TARBALL)
@@ -109,7 +112,7 @@ $(GRUB_PATCH_STAMP): $(GRUB_SOURCE_STAMP)
 	$(Q) cd $(GRUB_DIR) && ./autogen.sh
 	$(Q) touch $@
 
-$(GRUB_CONFIGURE_I386_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+$(GRUB_CONFIGURE_I386_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_BUILD_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure grub-i386-pc-$(GRUB_VERSION) ===="
 	$(Q) mkdir -p $(GRUB_I386_DIR)
@@ -123,7 +126,7 @@ $(GRUB_CONFIGURE_I386_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_INSTALL_STAMP) | $(DEV_
 		LDFLAGS="$(ONIE_LDFLAGS)"
 	$(Q) touch $@
 
-$(GRUB_CONFIGURE_UEFI_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+$(GRUB_CONFIGURE_UEFI_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_BUILD_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure grub-$(ARCH)-efi-$(GRUB_VERSION) ===="
 	$(Q) mkdir -p $(GRUB_UEFI_DIR)
@@ -137,7 +140,7 @@ $(GRUB_CONFIGURE_UEFI_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_INSTALL_STAMP) | $(DEV_
 		LDFLAGS="$(ONIE_LDFLAGS)"
 	$(Q) touch $@
 
-$(GRUB_CONFIGURE_I386_COREBOOT_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+$(GRUB_CONFIGURE_I386_COREBOOT_STAMP): $(GRUB_PATCH_STAMP) $(LVM2_BUILD_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure grub-i386-coreboot-$(GRUB_VERSION) ===="
 	$(Q) mkdir -p $(GRUB_I386_COREBOOT_DIR)
@@ -159,61 +162,66 @@ $(GRUB_BUILD_I386_STAMP): $(GRUB_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building grub-i386-pc-$(GRUB_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(GRUB_I386_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
+		$(MAKE) -C $(GRUB_I386_DIR) install DESTDIR=$(GRUB_INSTALL_I386_DIR)
 	$(Q) touch $@
 
 $(GRUB_BUILD_UEFI_STAMP): $(GRUB_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building grub-$(ARCH)-efi-$(GRUB_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(GRUB_UEFI_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
+		$(MAKE) -C $(GRUB_UEFI_DIR) install DESTDIR=$(GRUB_INSTALL_UEFI_DIR)
 	$(Q) touch $@
 
 $(GRUB_BUILD_I386_COREBOOT_STAMP): $(GRUB_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building grub-i386-coreboot-$(GRUB_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(GRUB_I386_COREBOOT_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
+		$(MAKE) -C $(GRUB_I386_COREBOOT_DIR) install DESTDIR=$(GRUB_INSTALL_I386_COREBOOT_DIR)
 	$(Q) touch $@
 
 grub-build: $(GRUB_BUILD_STAMP)
 $(GRUB_BUILD_STAMP): $(GRUB_BUILD_I386_STAMP) $(GRUB_BUILD_UEFI_STAMP) $(GRUB_BUILD_I386_COREBOOT_STAMP)
 	$(Q) touch $@
 
+# $(1) -- the type of grub binary
+# $(2) -- the build grub install direcoty
+# $(3) -- the destination systroot directory
+define grub_install
+	$(Q) echo "==== Installing $(1) in $(3) ===="
+	$(Q) cp -a $(2)/usr/lib/grub $(3)/usr/lib
+	$(Q) cp -a $(2)/usr/share/grub $(3)/usr/share
+	$(Q) for f in $(GRUB_SBIN) ; do \
+		cp -a $(2)/usr/sbin/$$f $(3)/usr/sbin ; \
+	done
+	$(Q) for f in $(GRUB_BIN) ; do \
+		cp -a $(2)/usr/bin/$$f $(3)/usr/bin ; \
+	done
+endef
+
 $(GRUB_INSTALL_I386_STAMP): $(SYSROOT_INIT_STAMP) $(GRUB_BUILD_I386_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing grub-i386-pc in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
-		$(MAKE) -C $(GRUB_I386_DIR) install DESTDIR=$(DEV_SYSROOT)
+	$(call grub_install grub-i386-pc $(GRUB_INSTALL_I386_DIR) $(SYSROOTDIR))
 	$(Q) touch $@
 
 $(GRUB_INSTALL_UEFI_STAMP): $(SYSROOT_INIT_STAMP) $(GRUB_INSTALL_I386_STAMP) $(GRUB_BUILD_UEFI_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing grub-$(ARCH)-efi in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
-		$(MAKE) -C $(GRUB_UEFI_DIR) install DESTDIR=$(DEV_SYSROOT)
+	$(call grub_install grub-$(ARCH)-efi $(GRUB_INSTALL_UEFI_DIR) $(SYSROOTDIR))
 	$(Q) touch $@
 
 $(GRUB_INSTALL_I386_COREBOOT_STAMP): $(SYSROOT_INIT_STAMP) $(GRUB_INSTALL_I386_STAMP) $(GRUB_BUILD_I386_COREBOOT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing grub-i386-coreboot in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
-		$(MAKE) -C $(GRUB_I386_COREBOOT_DIR) install DESTDIR=$(DEV_SYSROOT)
+	$(call grub_install grub-i386-coreboot $(GRUB_INSTALL_I386_COREBOOT_DIR) $(SYSROOTDIR))
 	$(Q) touch $@
 
 grub-install: $(GRUB_INSTALL_STAMP)
 $(GRUB_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(GRUB_INSTALL_I386_STAMP) \
 	$(GRUB_INSTALL_UEFI_STAMP) $(GRUB_INSTALL_I386_COREBOOT_STAMP)
-	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing grub in $(SYSROOTDIR) ===="
-	$(Q) cp -a $(DEV_SYSROOT)/usr/lib/grub $(SYSROOTDIR)/usr/lib
-	$(Q) cp -a $(DEV_SYSROOT)/usr/share/grub $(SYSROOTDIR)/usr/share
-	$(Q) for f in $(GRUB_SBIN) ; do \
-		cp -a $(DEV_SYSROOT)/usr/sbin/$$f $(SYSROOTDIR)/usr/sbin ; \
-	done
-	$(Q) for f in $(GRUB_BIN) ; do \
-		cp -a $(DEV_SYSROOT)/usr/bin/$$f $(SYSROOTDIR)/usr/bin ; \
-	done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += grub-clean
+USER_CLEAN += grub-clean
 grub-clean:
 	$(Q) rm -rf $(GRUB_BUILD_DIR)
 	$(Q) rm -f $(GRUB_STAMP)
@@ -228,7 +236,7 @@ grub-download-clean:
 
 # Building the .ISO image requires a host build of GRUB.
 
-GRUB_HOST_BUILD_DIR		= $(MBUILDDIR)/grub-host
+GRUB_HOST_BUILD_DIR		= $(USER_BUILDDIR)/grub-host
 GRUB_HOST_DIR			= $(GRUB_HOST_BUILD_DIR)/grub-$(GRUB_VERSION)
 GRUB_HOST_I386_DIR		= $(GRUB_HOST_BUILD_DIR)/grub-i386-pc
 GRUB_HOST_UEFI_DIR		= $(GRUB_HOST_BUILD_DIR)/grub-x86_64-efi
@@ -238,12 +246,12 @@ GRUB_HOST_BIN_I386_DIR		= $(GRUB_HOST_INSTALL_I386_DIR)/usr/bin
 GRUB_HOST_INSTALL_UEFI_DIR	= $(GRUB_HOST_BUILD_DIR)/x86_64-efi-install
 GRUB_HOST_LIB_UEFI_DIR		= $(GRUB_HOST_INSTALL_UEFI_DIR)/usr/lib/grub/x86_64-efi
 GRUB_HOST_BIN_UEFI_DIR		= $(GRUB_HOST_INSTALL_UEFI_DIR)/usr/bin
-GRUB_HOST_CONFIGURE_STAMP	= $(STAMPDIR)/grub-host-configure
-GRUB_HOST_BUILD_STAMP		= $(STAMPDIR)/grub-host-build
+GRUB_HOST_CONFIGURE_STAMP	= $(USER_STAMPDIR)/grub-host-configure
+GRUB_HOST_BUILD_STAMP		= $(USER_STAMPDIR)/grub-host-build
 GRUB_HOST_INSTALL_STAMP		= $(STAMPDIR)/grub-host-install
-GRUB_HOST_CONFIGURE_I386_STAMP	= $(STAMPDIR)/grub-host-configure-i386-pc
-GRUB_HOST_BUILD_I386_STAMP	= $(STAMPDIR)/grub-host-build-i386-pc
-GRUB_HOST_INSTALL_I386_STAMP	= $(STAMPDIR)/grub-host-install-i386-pc
+GRUB_HOST_CONFIGURE_I386_STAMP	= $(USER_STAMPDIR)/grub-host-configure-i386-pc
+GRUB_HOST_BUILD_I386_STAMP	= $(USER_STAMPDIR)/grub-host-build-i386-pc
+GRUB_HOST_INSTALL_I386_STAMP	= $(USER_STAMPDIR)/grub-host-install-i386-pc
 GRUB_HOST_UEFI_ENABLE		= no
 ifeq ($(UEFI_ENABLE),yes)
   GRUB_HOST_UEFI_ENABLE = yes
@@ -252,9 +260,9 @@ ifeq ($(PXE_EFI64_ENABLE),yes)
   GRUB_HOST_UEFI_ENABLE = yes
 endif
 ifeq ($(GRUB_HOST_UEFI_ENABLE),yes)
-  GRUB_HOST_CONFIGURE_UEFI_STAMP= $(STAMPDIR)/grub-host-configure-x86_64-efi
-  GRUB_HOST_BUILD_UEFI_STAMP	= $(STAMPDIR)/grub-host-build-x86_64-efi
-  GRUB_HOST_INSTALL_UEFI_STAMP	= $(STAMPDIR)/grub-host-install-x86_64-efi
+  GRUB_HOST_CONFIGURE_UEFI_STAMP= $(USER_STAMPDIR)/grub-host-configure-x86_64-efi
+  GRUB_HOST_BUILD_UEFI_STAMP	= $(USER_STAMPDIR)/grub-host-build-x86_64-efi
+  GRUB_HOST_INSTALL_UEFI_STAMP	= $(USER_STAMPDIR)/grub-host-install-x86_64-efi
 endif
 
 PHONY += grub-host-configure grub-host-build grub-host-install grub-host-clean
@@ -322,10 +330,10 @@ $(GRUB_HOST_INSTALL_UEFI_STAMP): $(GRUB_HOST_BUILD_UEFI_STAMP)
 	$(Q) touch $@
 
 grub-host-install: $(GRUB_HOST_INSTALL_STAMP)
-$(GRUB_HOST_INSTALL_STAMP): $(GRUB_HOST_INSTALL_I386_STAMP) $(GRUB_HOST_INSTALL_UEFI_STAMP)
+$(GRUB_HOST_INSTALL_STAMP): $(TREE_STAMP) $(GRUB_HOST_INSTALL_I386_STAMP) $(GRUB_HOST_INSTALL_UEFI_STAMP)
 	$(Q) touch $@
 
-USERSPACE_CLEAN += grub-host-clean
+USER_CLEAN += grub-host-clean
 grub-host-clean:
 	$(Q) rm -rf $(GRUB_HOST_BUILD_DIR)
 	$(Q) rm -f $(GRUB_HOST_STAMP)

--- a/build-config/make/i2ctools.make
+++ b/build-config/make/i2ctools.make
@@ -2,6 +2,7 @@
 #
 #  Copyright (C) 2014 Puneet <puneet@cumulusnetworks.com>
 #  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -88,7 +89,7 @@ endif
 
 i2ctools-build: $(I2CTOOLS_BUILD_STAMP)
 $(I2CTOOLS_BUILD_STAMP): $(I2CTOOLS_NEW_FILES) $(I2CTOOLS_PATCH_STAMP) \
-	$(ZLIB_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+	$(ZLIB_BUILD_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building i2ctools-$(I2CTOOLS_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(I2CTOOLS_DIR) \
@@ -97,7 +98,7 @@ $(I2CTOOLS_BUILD_STAMP): $(I2CTOOLS_NEW_FILES) $(I2CTOOLS_PATCH_STAMP) \
 	$(Q) touch $@
 
 i2ctools-install: $(I2CTOOLS_INSTALL_STAMP)
-$(I2CTOOLS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(I2CTOOLS_BUILD_STAMP)
+$(I2CTOOLS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(I2CTOOLS_BUILD_STAMP) $(ZLIB_INSTALL_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Installing i2ctools in $(DEV_SYSROOT) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(I2CTOOLS_DIR) \
@@ -111,7 +112,7 @@ ifeq ($(I2CTOOLS_SYSEEPROM),yes)
 endif
 	$(Q) touch $@
 
-USERSPACE_CLEAN += i2ctools-clean
+MACHINE_CLEAN += i2ctools-clean
 i2ctools-clean:
 	$(Q) rm -rf $(I2CTOOLS_BUILD_DIR)
 	$(Q) rm -f $(I2CTOOLS_STAMP)

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013,2014,2015,2016 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2016,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014,2015,2016 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
 #  Copyright (C) 2014 Puneet <puneet@cumulusnetworks.com>
@@ -461,7 +461,7 @@ image-complete: $(IMAGE_COMPLETE_STAMP)
 $(IMAGE_COMPLETE_STAMP): $(PLATFORM_IMAGE_COMPLETE) $(MACHINE_IMAGE_COMPLETE_STAMP)
 	$(Q) touch $@
 
-USERSPACE_CLEAN += image-clean
+MACHINE_CLEAN += image-clean
 image-clean:
 	$(Q) rm -f $(IMAGEDIR)/*$(MACHINE_PREFIX)* $(SYSROOT_CPIO_XZ) $(IMAGE_COMPLETE_STAMP) $(KERNEL_VMLINUZ_INSTALL_STAMP)
 	$(Q) rm -rf $(RECOVERY_DIR) $(MACHINE_IMAGE_COMPLETE_STAMP) $(MACHINE_IMAGE_PRODUCTS)

--- a/build-config/make/ipmitool.make
+++ b/build-config/make/ipmitool.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,13 +12,13 @@
 IPMITOOL_VERSION		= 1.8.15
 IPMITOOL_TARBALL		= ipmitool-$(IPMITOOL_VERSION).tar.bz2
 IPMITOOL_TARBALL_URLS	+= $(ONIE_MIRROR) http://sourceforge.net/projects/ipmitool/files/ipmitool/$(IPMITOOL_VERSION)/$(IPMITOOL_TARBALL)/download
-IPMITOOL_BUILD_DIR	= $(MBUILDDIR)/ipmitool
+IPMITOOL_BUILD_DIR	= $(USER_BUILDDIR)/ipmitool
 IPMITOOL_DIR		= $(IPMITOOL_BUILD_DIR)/ipmitool-$(IPMITOOL_VERSION)
 
 IPMITOOL_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/ipmitool-download
-IPMITOOL_SOURCE_STAMP	= $(STAMPDIR)/ipmitool-source
-IPMITOOL_CONFIGURE_STAMP	= $(STAMPDIR)/ipmitool-configure
-IPMITOOL_BUILD_STAMP	= $(STAMPDIR)/ipmitool-build
+IPMITOOL_SOURCE_STAMP	= $(USER_STAMPDIR)/ipmitool-source
+IPMITOOL_CONFIGURE_STAMP	= $(USER_STAMPDIR)/ipmitool-configure
+IPMITOOL_BUILD_STAMP	= $(USER_STAMPDIR)/ipmitool-build
 IPMITOOL_INSTALL_STAMP	= $(STAMPDIR)/ipmitool-install
 IPMITOOL_STAMP		= $(IPMITOOL_SOURCE_STAMP) \
 			  $(IPMITOOL_CONFIGURE_STAMP) \
@@ -43,7 +43,7 @@ $(IPMITOOL_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(IPMITOOL_SOURCE_STAMP)
 ipmitool-source: $(IPMITOOL_SOURCE_STAMP)
-$(IPMITOOL_SOURCE_STAMP): $(TREE_STAMP) | $(IPMITOOL_DOWNLOAD_STAMP)
+$(IPMITOOL_SOURCE_STAMP): $(USER_TREE_STAMP) | $(IPMITOOL_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream ipmitool ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(IPMITOOL_BUILD_DIR) $(DOWNLOADDIR)/$(IPMITOOL_TARBALL)
@@ -67,17 +67,17 @@ $(IPMITOOL_BUILD_STAMP): $(IPMITOOL_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building ipmitool-$(IPMITOOL_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(IPMITOOL_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(IPMITOOL_DIR) install
 	$(Q) touch $@
 
 ipmitool-install: $(IPMITOOL_INSTALL_STAMP)
 $(IPMITOOL_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(IPMITOOL_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing ipmitool in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(IPMITOOL_DIR) install
+	$(Q) echo "==== Installing ipmitool in $(SYSROOTDIR) ===="
 	$(Q) cp -f $(IPMITOOL_DIR)/src/$(IPMITOOL_BIN) $(SYSROOTDIR)/usr/sbin
 	$(Q) touch $@
 
-USERSPACE_CLEAN += ipmitool-clean
+USER_CLEAN += ipmitool-clean
 ipmitool-clean:
 	$(Q) rm -rf $(IPMITOOL_BUILD_DIR)
 	$(Q) rm -f $(IPMITOOL_STAMP)

--- a/build-config/make/kernel.make
+++ b/build-config/make/kernel.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013,2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -135,7 +135,7 @@ $(KERNEL_INSTALL_STAMP): $(KERNEL_INSTALL_DEPS) $(KERNEL_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) touch $@
 
-CLEAN += kernel-clean
+MACHINE_CLEAN += kernel-clean
 kernel-clean:
 	$(Q) rm -rf $(KERNELDIR)
 	$(Q) rm -f $(KERNEL_STAMP)

--- a/build-config/make/lzo.make
+++ b/build-config/make/lzo.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -13,13 +13,13 @@
 LZO_VERSION		= 2.09
 LZO_TARBALL		= lzo-$(LZO_VERSION).tar.gz
 LZO_TARBALL_URLS	+= $(ONIE_MIRROR) http://www.oberhumer.com/opensource/lzo/download
-LZO_BUILD_DIR		= $(MBUILDDIR)/lzo
+LZO_BUILD_DIR		= $(USER_BUILDDIR)/lzo
 LZO_DIR			= $(LZO_BUILD_DIR)/lzo-$(LZO_VERSION)
 
 LZO_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/lzo-$(LZO_VERSION)-download
-LZO_SOURCE_STAMP	= $(STAMPDIR)/lzo-source
-LZO_CONFIGURE_STAMP	= $(STAMPDIR)/lzo-configure
-LZO_BUILD_STAMP		= $(STAMPDIR)/lzo-build
+LZO_SOURCE_STAMP	= $(USER_STAMPDIR)/lzo-source
+LZO_CONFIGURE_STAMP	= $(USER_STAMPDIR)/lzo-configure
+LZO_BUILD_STAMP		= $(USER_STAMPDIR)/lzo-build
 LZO_INSTALL_STAMP	= $(STAMPDIR)/lzo-install
 LZO_STAMP		= $(LZO_SOURCE_STAMP) \
 			  $(LZO_CONFIGURE_STAMP) \
@@ -44,7 +44,7 @@ $(LZO_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(LZO_SOURCE_STAMP)
 lzo-source: $(LZO_SOURCE_STAMP)
-$(LZO_SOURCE_STAMP): $(TREE_STAMP) | $(LZO_DOWNLOAD_STAMP)
+$(LZO_SOURCE_STAMP): $(USER_TREE_STAMP) | $(LZO_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream lzo ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(LZO_BUILD_DIR) $(DOWNLOADDIR)/$(LZO_TARBALL)
@@ -73,20 +73,19 @@ $(LZO_BUILD_STAMP): $(LZO_CONFIGURE_STAMP) $(LZO_NEW_FILES)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building lzo-$(LZO_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(LZO_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(LZO_DIR) install
 	$(Q) touch $@
 
 lzo-install: $(LZO_INSTALL_STAMP)
 $(LZO_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(LZO_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing lzo in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
-		$(MAKE) -C $(LZO_DIR) install
+	$(Q) echo "==== Installing lzo in $(SYSROOTDIR) ===="
 	$(Q) for file in $(LZO_LIBS) ; do \
 		cp -av $(DEV_SYSROOT)/usr/lib/$$file $(SYSROOTDIR)/usr/lib/ ; \
 	done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += lzo-clean
+USER_CLEAN += lzo-clean
 lzo-clean:
 	$(Q) rm -rf $(LZO_BUILD_DIR)
 	$(Q) rm -f $(LZO_STAMP)

--- a/build-config/make/mtdutils.make
+++ b/build-config/make/mtdutils.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013,2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -14,12 +14,12 @@ MTDUTILS_VERSION	= 1.5.2
 MTDUTILS_COMMIT		= e4c8885bddac201ba0ef88560d6444f39e1ff870
 MTDUTILS_TARBALL	= mtd-utils-$(MTDUTILS_VERSION).tar.gz
 MTDUTILS_TARBALL_URLS	+= $(ONIE_MIRROR) http://git.infradead.org/mtd-utils.git/snapshot
-MTDUTILS_BUILD_DIR	= $(MBUILDDIR)/mtd-utils
+MTDUTILS_BUILD_DIR	= $(USER_BUILDDIR)/mtd-utils
 MTDUTILS_DIR		= $(MTDUTILS_BUILD_DIR)/mtd-utils-e4c8885
 
 MTDUTILS_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/mtdutils-$(MTDUTILS_VERSION)-download
-MTDUTILS_SOURCE_STAMP	= $(STAMPDIR)/mtdutils-source
-MTDUTILS_BUILD_STAMP	= $(STAMPDIR)/mtdutils-build
+MTDUTILS_SOURCE_STAMP	= $(USER_STAMPDIR)/mtdutils-source
+MTDUTILS_BUILD_STAMP	= $(USER_STAMPDIR)/mtdutils-build
 MTDUTILS_INSTALL_STAMP	= $(STAMPDIR)/mtdutils-install
 MTDUTILS_STAMP		= $(MTDUTILS_SOURCE_STAMP) \
 			  $(MTDUTILS_BUILD_STAMP) \
@@ -45,7 +45,7 @@ $(MTDUTILS_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(MTDUTILS_SOURCE_STAMP)
 mtdutils-source: $(MTDUTILS_SOURCE_STAMP)
-$(MTDUTILS_SOURCE_STAMP): $(TREE_STAMP) | $(MTDUTILS_DOWNLOAD_STAMP)
+$(MTDUTILS_SOURCE_STAMP): $(USER_TREE_STAMP) | $(MTDUTILS_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream mtdutils ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(MTDUTILS_BUILD_DIR) $(DOWNLOADDIR)/$(MTDUTILS_TARBALL)
@@ -57,8 +57,8 @@ MTDUTILS_NEW_FILES = $(shell test -d $(MTDUTILS_DIR) && test -f $(MTDUTILS_BUILD
 endif
 
 mtdutils-build: $(MTDUTILS_BUILD_STAMP)
-$(MTDUTILS_BUILD_STAMP): $(MTDUTILS_NEW_FILES) $(UTILLINUX_INSTALL_STAMP) \
-			 $(LZO_INSTALL_STAMP) $(ZLIB_INSTALL_STAMP) \
+$(MTDUTILS_BUILD_STAMP): $(MTDUTILS_NEW_FILES) $(UTILLINUX_BUILD_STAMP) \
+			 $(LZO_BUILD_STAMP) $(ZLIB_BUILD_STAMP) \
 			 $(MTDUTILS_SOURCE_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) PATH='$(CROSSBIN):$(PATH)'				\
@@ -67,12 +67,6 @@ $(MTDUTILS_BUILD_STAMP): $(MTDUTILS_NEW_FILES) $(UTILLINUX_INSTALL_STAMP) \
 		CROSS=$(CROSSPREFIX)				\
 		CFLAGS="-g $(ONIE_CFLAGS)"			\
                 WITHOUT_XATTR=1
-	$(Q) touch $@
-
-mtdutils-install: $(MTDUTILS_INSTALL_STAMP)
-$(MTDUTILS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(MTDUTILS_BUILD_STAMP)
-	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing mtdutils in $(DEV_SYSROOT) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'				\
 	    $(MAKE) -C $(MTDUTILS_DIR)				\
 		PREFIX=$(DEV_SYSROOT)/usr			\
@@ -80,6 +74,13 @@ $(MTDUTILS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(MTDUTILS_BUILD_STAMP)
 		CFLAGS="-g $(ONIE_CFLAGS)"			\
                 WITHOUT_XATTR=1                                 \
                 install
+	$(Q) touch $@
+
+mtdutils-install: $(MTDUTILS_INSTALL_STAMP)
+$(MTDUTILS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(MTDUTILS_BUILD_STAMP) $(UTILLINUX_INSTALL_STAMP) \
+				$(LZO_INSTALL_STAMP) $(ZLIB_INSTALL_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Installing mtdutils in $(SYSROOTDIR) ===="
 	$(Q) for file in $(MTDBINS) ; do \
 		cp -av $(DEV_SYSROOT)/usr/sbin/$$file $(SYSROOTDIR)/usr/sbin/ ; \
 	done
@@ -92,7 +93,7 @@ $(MTDUTILS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(MTDUTILS_BUILD_STAMP)
 	done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += mtdutils-clean
+USER_CLEAN += mtdutils-clean
 mtdutils-clean:
 	$(Q) rm -rf $(MTDUTILS_BUILD_DIR)
 	$(Q) rm -f $(MTDUTILS_STAMP)

--- a/build-config/make/mtree.make
+++ b/build-config/make/mtree.make
@@ -1,6 +1,7 @@
 #-------------------------------------------------------------------------------
 #
 #  Copyright (C) 2015 Carlos Cardenas <carlos@cumulusnetworks.com>
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,13 +13,13 @@
 MTREE_VERSION		= 1.0.3
 MTREE_TARBALL		= mtree-$(MTREE_VERSION).tar.gz
 MTREE_TARBALL_URLS	+= $(ONIE_MIRROR)
-MTREE_BUILD_DIR	= $(MBUILDDIR)/mtree
+MTREE_BUILD_DIR	= $(USER_BUILDDIR)/mtree
 MTREE_DIR		= $(MTREE_BUILD_DIR)/mtree-$(MTREE_VERSION)
 
 MTREE_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/mtree-download
-MTREE_SOURCE_STAMP	= $(STAMPDIR)/mtree-source
-MTREE_CONFIGURE_STAMP	= $(STAMPDIR)/mtree-configure
-MTREE_BUILD_STAMP	= $(STAMPDIR)/mtree-build
+MTREE_SOURCE_STAMP	= $(USER_STAMPDIR)/mtree-source
+MTREE_CONFIGURE_STAMP	= $(USER_STAMPDIR)/mtree-configure
+MTREE_BUILD_STAMP	= $(USER_STAMPDIR)/mtree-build
 MTREE_INSTALL_STAMP	= $(STAMPDIR)/mtree-install
 MTREE_STAMP		= $(MTREE_SOURCE_STAMP) \
 			  $(MTREE_CONFIGURE_STAMP) \
@@ -43,7 +44,7 @@ $(MTREE_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(MTREE_SOURCE_STAMP)
 mtree-source: $(MTREE_SOURCE_STAMP)
-$(MTREE_SOURCE_STAMP): $(TREE_STAMP) | $(MTREE_DOWNLOAD_STAMP)
+$(MTREE_SOURCE_STAMP): $(USER_TREE_STAMP) | $(MTREE_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream mtree ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(MTREE_BUILD_DIR) $(DOWNLOADDIR)/$(MTREE_TARBALL)
@@ -67,17 +68,17 @@ $(MTREE_BUILD_STAMP): $(MTREE_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building mtree-$(MTREE_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(MTREE_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(MTREE_DIR) install
 	$(Q) touch $@
 
 mtree-install: $(MTREE_INSTALL_STAMP)
 $(MTREE_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(MTREE_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing mtree in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(MTREE_DIR) install
+	$(Q) echo "==== Installing mtree in $(SYSROOTDIR) ===="
 	$(Q) cp -av $(DEV_SYSROOT)/usr/bin/$(MTREE_BIN) $(SYSROOTDIR)/usr/bin
 	$(Q) touch $@
 
-USERSPACE_CLEAN += mtree-clean
+USER_CLEAN += mtree-clean
 mtree-clean:
 	$(Q) rm -rf $(MTREE_BUILD_DIR)
 	$(Q) rm -f $(MTREE_STAMP)

--- a/build-config/make/parted.make
+++ b/build-config/make/parted.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,14 +12,14 @@
 PARTED_VERSION		= 3.1
 PARTED_TARBALL		= parted-$(PARTED_VERSION).tar.xz
 PARTED_TARBALL_URLS	+= $(ONIE_MIRROR) http://ftp.gnu.org/gnu/parted/
-PARTED_BUILD_DIR	= $(MBUILDDIR)/parted
+PARTED_BUILD_DIR	= $(USER_BUILDDIR)/parted
 PARTED_DIR		= $(PARTED_BUILD_DIR)/parted-$(PARTED_VERSION)
 
 PARTED_SRCPATCHDIR	= $(PATCHDIR)/parted
 PARTED_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/parted-download
-PARTED_SOURCE_STAMP	= $(STAMPDIR)/parted-source
-PARTED_CONFIGURE_STAMP	= $(STAMPDIR)/parted-configure
-PARTED_BUILD_STAMP	= $(STAMPDIR)/parted-build
+PARTED_SOURCE_STAMP	= $(USER_STAMPDIR)/parted-source
+PARTED_CONFIGURE_STAMP	= $(USER_STAMPDIR)/parted-configure
+PARTED_BUILD_STAMP	= $(USER_STAMPDIR)/parted-build
 PARTED_INSTALL_STAMP	= $(STAMPDIR)/parted-install
 
 PARTED_STAMP		= $(PARTED_SOURCE_STAMP) \
@@ -46,14 +46,14 @@ $(PARTED_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(PARTED_SOURCE_STAMP)
 parted-source: $(PARTED_SOURCE_STAMP)
-$(PARTED_SOURCE_STAMP): $(TREE_STAMP) | $(PARTED_DOWNLOAD_STAMP)
+$(PARTED_SOURCE_STAMP): $(USER_TREE_STAMP) | $(PARTED_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream parted ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(PARTED_BUILD_DIR) $(DOWNLOADDIR)/$(PARTED_TARBALL)
 	$(Q) touch $@
 
 parted-configure: $(PARTED_CONFIGURE_STAMP)
-$(PARTED_CONFIGURE_STAMP): $(PARTED_SOURCE_STAMP) $(E2FSPROGS_INSTALL_STAMP) $(LVM2_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+$(PARTED_CONFIGURE_STAMP): $(PARTED_SOURCE_STAMP) $(E2FSPROGS_BUILD_STAMP) $(LVM2_BUILD_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure parted-$(PARTED_VERSION) ===="
 	$(Q) cd $(PARTED_DIR) && PATH='$(CROSSBIN):$(PATH)'	\
@@ -78,20 +78,20 @@ $(PARTED_BUILD_STAMP): $(PARTED_CONFIGURE_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building parted-$(PARTED_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(PARTED_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
+		$(MAKE) -C $(PARTED_DIR) install DESTDIR=$(DEV_SYSROOT)
 	$(Q) touch $@
 
 parted-install: $(PARTED_INSTALL_STAMP)
 $(PARTED_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(PARTED_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing parted in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
-		$(MAKE) -C $(PARTED_DIR) install DESTDIR=$(DEV_SYSROOT)
+	$(Q) echo "==== Installing parted in $(SYSROOTDIR) ===="
 	$(Q) for f in $(PARTED_SBIN) ; do \
 		cp -a $(DEV_SYSROOT)/usr/sbin/$$f $(SYSROOTDIR)/usr/sbin ; \
 	done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += parted-clean
+USER_CLEAN += parted-clean
 parted-clean:
 	$(Q) rm -rf $(PARTED_BUILD_DIR)
 	$(Q) rm -f $(PARTED_STAMP)

--- a/build-config/make/popt.make
+++ b/build-config/make/popt.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -12,15 +12,15 @@
 POPT_VERSION		= 1.16
 POPT_TARBALL		= popt-$(POPT_VERSION).tar.gz
 POPT_TARBALL_URLS	+= $(ONIE_MIRROR) http://rpm5.org/files/popt/
-POPT_BUILD_DIR		= $(MBUILDDIR)/popt
+POPT_BUILD_DIR		= $(USER_BUILDDIR)/popt
 POPT_DIR		= $(POPT_BUILD_DIR)/popt-$(POPT_VERSION)
 
 POPT_SRCPATCHDIR	= $(PATCHDIR)/popt
 POPT_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/popt-download
-POPT_SOURCE_STAMP	= $(STAMPDIR)/popt-source
-POPT_PATCH_STAMP	= $(STAMPDIR)/popt-patch
-POPT_CONFIGURE_STAMP	= $(STAMPDIR)/popt-configure
-POPT_BUILD_STAMP	= $(STAMPDIR)/popt-build
+POPT_SOURCE_STAMP	= $(USER_STAMPDIR)/popt-source
+POPT_PATCH_STAMP	= $(USER_STAMPDIR)/popt-patch
+POPT_CONFIGURE_STAMP	= $(USER_STAMPDIR)/popt-configure
+POPT_BUILD_STAMP	= $(USER_STAMPDIR)/popt-build
 POPT_INSTALL_STAMP	= $(STAMPDIR)/popt-install
 POPT_STAMP		= $(POPT_SOURCE_STAMP) \
 			  $(POPT_PATCH_STAMP) \
@@ -47,7 +47,7 @@ $(POPT_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(POPT_SOURCE_STAMP)
 popt-source: $(POPT_SOURCE_STAMP)
-$(POPT_SOURCE_STAMP): $(TREE_STAMP) | $(POPT_DOWNLOAD_STAMP)
+$(POPT_SOURCE_STAMP): $(USER_TREE_STAMP) | $(POPT_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream popt ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(POPT_BUILD_DIR) $(DOWNLOADDIR)/$(POPT_TARBALL)
@@ -84,20 +84,19 @@ $(POPT_BUILD_STAMP): $(POPT_CONFIGURE_STAMP) $(POPT_NEW_FILES)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building popt-$(POPT_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(POPT_DIR)
+	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(POPT_DIR) install
 	$(Q) touch $@
 
 popt-install: $(POPT_INSTALL_STAMP)
 $(POPT_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(POPT_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing popt in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
-		$(MAKE) -C $(POPT_DIR) install
+	$(Q) echo "==== Installing popt in $(SYSROOTDIR) ===="
 	$(Q) for file in $(POPT_LIBS) ; do \
 		cp -av $(DEV_SYSROOT)/usr/lib/$$file $(SYSROOTDIR)/usr/lib/ ; \
 	done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += popt-clean
+USER_CLEAN += popt-clean
 popt-clean:
 	$(Q) rm -rf $(POPT_BUILD_DIR)
 	$(Q) rm -f $(POPT_STAMP)

--- a/build-config/make/sysroot.make
+++ b/build-config/make/sysroot.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -26,13 +26,27 @@ SYSROOT_INIT_STAMP	= $(STAMPDIR)/sysroot-init
 SYSROOT_CHECK_STAMP	= $(STAMPDIR)/sysroot-check
 SYSROOT_COMPLETE_STAMP	= $(STAMPDIR)/sysroot-complete
 SYSROOT			= $(SYSROOT_COMPLETE_STAMP)
-DEV_SYSROOT_INIT_STAMP	= $(STAMPDIR)/dev-sysroot-init
+
+USER_BUILDDIR		= $(BUILDDIR)/user/$(XTOOLS_VERSION)
+USER_STAMPDIR		= $(USER_BUILDDIR)/stamp
+DEV_SYSROOT		= $(USER_BUILDDIR)/dev-sysroot
+
+USER_TREEDIRS		= $(USER_STAMPDIR)
+
+USER_TREE_STAMP  = $(USER_STAMPDIR)/tree
+
+user-tree-stamp: $(USER_TREE_STAMP)
+$(USER_TREE_STAMP): $(PROJECT_STAMP)
+	$(Q) mkdir -pv $(USER_TREEDIRS)
+	$(Q) touch $@
+
+DEV_SYSROOT_INIT_STAMP	= $(USER_STAMPDIR)/dev-sysroot-init
 
 #-------------------------------------------------------------------------------
 
 # the target for SYSROOT_COMPLETE is defined in make/images.make.
 
-PHONY += sysroot-init dev-sysroot-init
+PHONY += sysroot-init dev-sysroot-init sysroot-clean dev-sysroot-clean
 
 sysroot-init: $(SYSROOT_INIT_STAMP)
 $(SYSROOT_INIT_STAMP): $(TREE_STAMP)
@@ -52,7 +66,7 @@ $(SYSROOT_INIT_STAMP): $(TREE_STAMP)
 # Development sysroot, used for compiling and linking user space
 # applications and libraries.
 dev-sysroot-init: $(DEV_SYSROOT_INIT_STAMP)
-$(DEV_SYSROOT_INIT_STAMP): $(TREE_STAMP) | $(XTOOLS_BUILD_STAMP)
+$(DEV_SYSROOT_INIT_STAMP): $(USER_TREE_STAMP) | $(XTOOLS_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Preparing a new development sysroot ===="
 	$(Q) rm -rf $(DEV_SYSROOT)
@@ -65,12 +79,18 @@ $(DEV_SYSROOT_INIT_STAMP): $(TREE_STAMP) | $(XTOOLS_BUILD_STAMP)
 
 #---
 
-USERSPACE_CLEAN += sysroot-clean
+MACHINE_CLEAN += sysroot-clean
 sysroot-clean:
-	$(Q) rm -rf $(DEV_SYSROOT) $(SYSROOTDIR)
+	$(Q) rm -rf $(SYSROOTDIR)
 	$(Q) rm -f $(SYSROOT_INIT_STAMP) $(SYSROOT_CHECK_STAMP) $(SYSROOT_COMPLETE_STAMP)
-	$(Q) rm -f $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) echo "=== Finished making $@ for $(PLATFORM)"
+
+USER_CLEAN += dev-sysroot-clean
+dev-sysroot-clean:
+	$(Q) rm -rf $(DEV_SYSROOT)
+	$(Q) rm -f $(DEV_SYSROOT_INIT_STAMP)
+	$(Q) rm -rf $(USER_BUILDDIR)
+	$(Q) echo "=== Finished making $@ for $(XTOOLS_VERSION)"
 
 #
 # Local Variables:

--- a/build-config/make/u-boot.make
+++ b/build-config/make/u-boot.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014,2015,2016 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -145,7 +145,7 @@ ifeq ($(UBOOT_PBL_ENABLE),yes)
 endif
 	$(Q) touch $@
 
-CLEAN += u-boot-clean
+MACHINE_CLEAN += u-boot-clean
 u-boot-clean:
 	$(Q) rm -rf $(UBOOT_BUILD_DIR)
 	$(Q) rm -f $(UBOOT_STAMP)

--- a/build-config/make/zlib.make
+++ b/build-config/make/zlib.make
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 #
-#  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 #
@@ -13,13 +13,13 @@ ZLIB_VERSION		= 1.2.8
 ZLIB_TARBALL		= zlib-$(ZLIB_VERSION).tar.gz
 ZLIB_TARBALL_URLS	+= $(ONIE_MIRROR) http://zlib.net \
 			   http://softlayer-dal.dl.sourceforge.net/project/libpng/zlib/1.2.8
-ZLIB_BUILD_DIR		= $(MBUILDDIR)/zlib
+ZLIB_BUILD_DIR		= $(USER_BUILDDIR)/zlib
 ZLIB_DIR		= $(ZLIB_BUILD_DIR)/zlib-$(ZLIB_VERSION)
 
 ZLIB_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/zlib-download
-ZLIB_SOURCE_STAMP	= $(STAMPDIR)/zlib-source
-ZLIB_CONFIGURE_STAMP	= $(STAMPDIR)/zlib-configure
-ZLIB_BUILD_STAMP	= $(STAMPDIR)/zlib-build
+ZLIB_SOURCE_STAMP	= $(USER_STAMPDIR)/zlib-source
+ZLIB_CONFIGURE_STAMP	= $(USER_STAMPDIR)/zlib-configure
+ZLIB_BUILD_STAMP	= $(USER_STAMPDIR)/zlib-build
 ZLIB_INSTALL_STAMP	= $(STAMPDIR)/zlib-install
 ZLIB_STAMP		= $(ZLIB_SOURCE_STAMP) \
 			  $(ZLIB_CONFIGURE_STAMP) \
@@ -44,7 +44,7 @@ $(ZLIB_DOWNLOAD_STAMP): $(PROJECT_STAMP)
 
 SOURCE += $(ZLIB_SOURCE_STAMP)
 zlib-source: $(ZLIB_SOURCE_STAMP)
-$(ZLIB_SOURCE_STAMP): $(TREE_STAMP) | $(ZLIB_DOWNLOAD_STAMP)
+$(ZLIB_SOURCE_STAMP): $(USER_TREE_STAMP) | $(ZLIB_DOWNLOAD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Extracting upstream zlib ===="
 	$(Q) $(SCRIPTDIR)/extract-package $(ZLIB_BUILD_DIR) $(DOWNLOADDIR)/$(ZLIB_TARBALL)
@@ -76,20 +76,19 @@ $(ZLIB_BUILD_STAMP): $(ZLIB_CONFIGURE_STAMP) $(ZLIB_NEW_FILES) | $(DEV_SYSROOT_I
 		CPP=$(CROSSPREFIX)cpp				\
 		LDSHARED="$(CROSSPREFIX)gcc -shared -Wl,-soname,libz.so.1,--version-script,zlib.map $(ONIE_LDFLAGS)" \
 		CFLAGS="-D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN $(ONIE_CFLAGS)"
+	$(Q) PATH='$(CROSSBIN):$(PATH)' $(MAKE) -C $(ZLIB_DIR) install
 	$(Q) touch $@
 
 zlib-install: $(ZLIB_INSTALL_STAMP)
 $(ZLIB_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(ZLIB_BUILD_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(Q) echo "==== Installing zlib in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'			\
-		$(MAKE) -C $(ZLIB_DIR) install
+	$(Q) echo "==== Installing zlib in $(SYSROOTDIR) ===="
 	$(Q) for file in $(ZLIBLIBS) ; do \
 		cp -av $(DEV_SYSROOT)/usr/lib/$$file $(SYSROOTDIR)/usr/lib/ ; \
 	done
 	$(Q) touch $@
 
-USERSPACE_CLEAN += zlib-clean
+USER_CLEAN += zlib-clean
 zlib-clean:
 	$(Q) rm -rf $(ZLIB_BUILD_DIR)
 	$(Q) rm -f $(ZLIB_STAMP)


### PR DESCRIPTION
Today ONIE re-compiles *everything*, except the toolchain, for each
machine.  This is really wasteful of time, CPU and disk space when
building multiple machines that share a toolchain.

Most ONIE components are platform independent.  For example the common
utilities, like e2fstools, dropbear, etc., only need to be built once
for each toolchain.

Some components are machine specific and must be built for each
machine, such as:

- Linux kernel
- U-Boot
- busybox  (contains machine specific i2c EEPROM access)
- i2ctools (contains machine specific i2c EEPROM access)

This patch introduces the notion of common "user" components (short
for user space) that only need to be built once per toolchain.  This
significantly improves the build times when building multiple
machines.

With this change the build directory structure now contains a common
user build directory, called "build/user/<toolchain>".  All the common
components are built here.

The other change is the behavior of "make clean".  Historically "make
clean" cleaned up the build space for a single machine.  Now that
common component build products are shared across machine builds, it
would be bad to remove the common components as part of "make clean".

For cleaning, this patch introduces two new clean related targets:

- machine-clean -- only cleans components that are specific to the
  machine, like the kernel, u-boot, busybox, i2ctools, etc.

- user-clean -- a super set including machine-clean, plus all the
  common user components

The old "clean" target is now a synonym for "machine-clean".

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>