### PR TITLE
U boot version info

### DIFF
--- a/build-config/make/u-boot.make
+++ b/build-config/make/u-boot.make
@@ -99,6 +99,7 @@ $(UBOOT_PATCH_STAMP): $(UBOOT_CMNPATCHDIR)/* $(UBOOT_SRCPATCHDIR)/* $(MACHINEDIR
 	$(Q) $(SCRIPTDIR)/cp-machine-patches $(UBOOT_PATCHDIR) $(MACHINEDIR)/u-boot/series	\
 		$(MACHINEDIR)/u-boot $(MACHINEROOT)/u-boot
 	$(Q) $(SCRIPTDIR)/apply-patch-series $(UBOOT_PATCHDIR)/series $(UBOOT_DIR)
+	$(Q) echo "#include <version.h>" > $(UBOOT_DIR)/include/configs/onie_version.h
 	$(Q) echo "#define ONIE_VERSION \
 		\"onie_version=$(LSB_RELEASE_TAG)\\0\"	\
 		\"onie_vendor_id=$(VENDOR_ID)\\0\"	\
@@ -108,7 +109,10 @@ $(UBOOT_PATCH_STAMP): $(UBOOT_CMNPATCHDIR)/* $(UBOOT_SRCPATCHDIR)/* $(MACHINEDIR
 		\"onie_machine_rev=$(MACHINE_REV)\\0\"	\
 		\"dhcp_vendor-class-identifier=$(PLATFORM)\\0\"	\
 		\"dhcp_user-class=$(PLATFORM)_uboot\\0\"	\
-		" > $(UBOOT_DIR)/include/configs/onie_version.h
+		\"onie_build_date=$$(LC_ALL=C date -Imin)\\0\"	\
+		\"onie_uboot_version=\" U_BOOT_VERSION_STRING \"\\0\" \
+		\"ver=\" U_BOOT_VERSION_STRING \"\\0\" \
+		" >> $(UBOOT_DIR)/include/configs/onie_version.h
 	$(Q) echo '#define CONFIG_IDENT_STRING " - $(UBOOT_IDENT_STRING)"' \
 		>> $(UBOOT_DIR)/include/configs/onie_version.h
 	$(Q) echo '#define PLATFORM_STRING "$(PLATFORM)"' \

--- a/installer/u-boot-arch/install-arch
+++ b/installer/u-boot-arch/install-arch
@@ -36,8 +36,9 @@ update_uboot_env()
     #
     # - update onie_version with the version of the update image.
     #
-    # - update the 'ver' environment variable.  Use the U-Boot/ONIE
-    #   version compiled into the image.  The string is null-terminated.
+    # - update onie_uboot_version environment variable.  Use the
+    #   U-Boot/ONIE version compiled into the image.  The string is
+    #   null-terminated.
     #
     # - update the onie_bootcmd variable as this command may have changed
     #   from one version to the next.  Use the value found in the update
@@ -55,6 +56,7 @@ update_uboot_env()
 onie_boot_reason
 onie_version $image_version
 ver $ver
+onie_uboot_version $ver
 $bootvar $bootcmd
 EOF
     ) | fw_setenv -f -s -

--- a/installer/u-boot-arch/install-arch
+++ b/installer/u-boot-arch/install-arch
@@ -40,6 +40,8 @@ update_uboot_env()
     #   U-Boot/ONIE version compiled into the image.  The string is
     #   null-terminated.
     #
+    # - update onie_build_date with the image build date.
+    #
     # - update the onie_bootcmd variable as this command may have changed
     #   from one version to the next.  Use the value found in the update
     #   image.
@@ -68,6 +70,7 @@ onie_boot_reason
 onie_version $image_version
 ver $ver
 onie_uboot_version $ver
+onie_build_date $image_build_date
 $bootvar $bootcmd
 EOF
     ) | fw_setenv -f -s -

--- a/installer/u-boot-arch/install-arch
+++ b/installer/u-boot-arch/install-arch
@@ -43,7 +43,18 @@ update_uboot_env()
     # - update the onie_bootcmd variable as this command may have changed
     #   from one version to the next.  Use the value found in the update
     #   image.
-    ver=$(dd if=u-boot.bin bs=1 skip=4 count=256 2>/dev/null | awk -F\x00 '{ print $1; exit }')
+    case "$onie_arch" in
+        powerpc)
+            ver=$(dd if=u-boot.bin bs=1 skip=4 count=256 2>/dev/null | awk -F\x00 '{ print $1; exit }')
+            ;;
+        arm)
+            ver=$(awk -F\x00 '{print $1}' u-boot.bin | grep U-Boot | head -n 1)
+            ;;
+        *)
+            echo "ERROR: Unsupported ONIE U-Boot architecture: $onie_arch"
+            echo "ERROR: Setting U-Boot env 'onie_uboot_version' to 'unknown'"
+            ver="unknown"
+    esac
     bootcmd=$(awk -F\x00 '{print $1}' u-boot.bin | awk -F= '{ if ($1 == "onie_bootcmd") { print $2 } }')
     if [ -z "$bootcmd" ] ; then
     # do not update this var


### PR DESCRIPTION
A few changes for U-Boot platforms during the ONIE update process.  This is for arm-32 and powerpc.

The changes involve the U-Boot variables that are created/updated when ONIE is installed/updated.