### PR TITLE
u-boot: fix save-default-env-on-bad-crc issue

### DIFF
--- a/patches/u-boot/2012.10/feature-save-default-env-on-bad-crc.patch
+++ b/patches/u-boot/2012.10/feature-save-default-env-on-bad-crc.patch
@@ -2,7 +2,7 @@ Save default env when crc is bad.
 
 Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
 Copyright (C) 2013 Miles Tseng <miles_tseng@accton.com>
-Copyright (C) 2016 david_yang <david_yang@accton.com>
+Copyright (C) 2016,2017 david_yang <david_yang@accton.com>
 
 SPDX-License-Identifier:     GPL-2.0
 
@@ -91,7 +91,7 @@ index 57221ef..4bed603 100644
 +		goto free_and_exit;
 +	}
 +
-+	ret = spi_flash_read(env_flash, CONFIG_ENV_OFFSET, ENV_SIZE, (char *)env_ptr);
++	ret = spi_flash_read(env_flash, CONFIG_ENV_OFFSET, CONFIG_ENV_SIZE, (char *)env_ptr);
 +	if (ret) {
 +		printf("SPI Read Fail!\n");
 +		goto free_and_exit;

--- a/patches/u-boot/2013.01.01/feature-save-default-env-on-bad-crc.patch
+++ b/patches/u-boot/2013.01.01/feature-save-default-env-on-bad-crc.patch
@@ -2,7 +2,7 @@ Save default env when crc is bad.
 
 Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
 Copyright (C) 2013 Miles Tseng <miles_tseng@accton.com>
-Copyright (C) 2016 david_yang <david_yang@accton.com>
+Copyright (C) 2016,2017 david_yang <david_yang@accton.com>
 
 SPDX-License-Identifier:     GPL-2.0
 
@@ -92,7 +92,7 @@ index 906b41f..0de1920 100644
 +		goto free_and_exit;
 +	}
 +
-+	ret = spi_flash_read(env_flash, CONFIG_ENV_OFFSET, ENV_SIZE, (char *)env_ptr);
++	ret = spi_flash_read(env_flash, CONFIG_ENV_OFFSET, CONFIG_ENV_SIZE, (char *)env_ptr);
 +	if (ret) {
 +		printf("SPI Read Fail!\n");
 +		goto free_and_exit;

--- a/patches/u-boot/fsl-sdk-v1.7/feature-save-default-env-on-bad-crc.patch
+++ b/patches/u-boot/fsl-sdk-v1.7/feature-save-default-env-on-bad-crc.patch
@@ -2,7 +2,7 @@ Save default env when crc is bad.
 
 Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
 Copyright (C) 2013 Miles Tseng <miles_tseng@accton.com>
-Copyright (C) 2015,2016 david_yang <david_yang@accton.com>
+Copyright (C) 2015,2016,2017 david_yang <david_yang@accton.com>
 
 SPDX-License-Identifier:     GPL-2.0
 
@@ -107,7 +107,7 @@ index cd7b4cd..b50825d 100644
 +		goto free_and_exit;
 +	}
 +
-+	ret = spi_flash_read(env_flash, CONFIG_ENV_OFFSET, ENV_SIZE, (char *)env_ptr);
++	ret = spi_flash_read(env_flash, CONFIG_ENV_OFFSET, CONFIG_ENV_SIZE, (char *)env_ptr);
 +	if (ret) {
 +		printf("SPI Read Fail!\n");
 +		goto free_and_exit;


### PR DESCRIPTION
While reading u-boot-env from flash, it specifies `ENV_SIZE` as data
length.  `ENV_SIZE` is not equal to size of `env_t` so that it is
possible to read partial data from flash.  That will make crc error.

The patch has been tested in Accton AS4610_54.