### PR TITLE
dropbear enable ECDSA keys

### DIFF
--- a/rootconf/default/etc/init.d/dropbear.sh
+++ b/rootconf/default/etc/init.d/dropbear.sh
@@ -2,6 +2,7 @@
 
 #  Copyright (C) 2013 Dustin Byford <dustin@cumulusnetworks.com>
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2017 Nikolay Shopik <shopik@nvcube.net>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -18,15 +19,18 @@ ARGS="-m -B"
 
 RSA_KEY=/etc/dropbear/dropbear_rsa_host_key
 DSS_KEY=/etc/dropbear/dropbear_dss_host_key
+ECDSA_KEY=/etc/dropbear/dropbear_ecdsa_host_key
 
 [ -r /lib/onie/dropbear-arch ] && . /lib/onie/dropbear-arch
 
 get_keys() {
     # If keys are already present just return
-    [ -r "$RSA_KEY" ] && [ -r "$DSS_KEY" ] && return 0
+    [ -r "$ECDSA_KEY" ] && [ -r "$RSA_KEY" ] && [ -r "$DSS_KEY" ] && return 0
 
     get_keys_arch || {
         # If problems just make new keys in ramdisk
+        # genereate ecdsa key
+        dropbearkey -t ecdsa -s 256 -f $ECDSA_KEY > /dev/null 2>&1
         # genereate rsa key
         dropbearkey -t rsa -s 1024 -f $RSA_KEY > /dev/null 2>&1
         # genereate dss key

--- a/rootconf/grub-arch/sysroot-lib-onie/dropbear-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/dropbear-arch
@@ -1,6 +1,7 @@
 # dropbear config for x86_64 platforms
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2017 Nikolay Shopik <shopik@nvcube.net>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -13,6 +14,15 @@ get_keys_arch() {
 
     # The ONIE-CONFIG partition is unavailable during recovery.
     [ "$boot_env" = "recovery" ] && return 1
+
+    if [ -r "$onie_config_dir/$ECDSA_KEY" ] ; then
+        cp "$onie_config_dir/$ECDSA_KEY" $ECDSA_KEY
+    else
+        # genereate ecdsa key
+        dropbearkey -t ecdsa -s 256 -f $ECDSA_KEY > /dev/null 2>&1
+        mkdir -p "$(dirname $onie_config_dir/$ECDSA_KEY)"
+        cp $ECDSA_KEY "$onie_config_dir/$ECDSA_KEY"
+    fi
 
     if [ -r "$onie_config_dir/$RSA_KEY" ] ; then
         cp "$onie_config_dir/$RSA_KEY" $RSA_KEY

--- a/rootconf/u-boot-arch/sysroot-lib-onie/dropbear-arch
+++ b/rootconf/u-boot-arch/sysroot-lib-onie/dropbear-arch
@@ -1,9 +1,11 @@
 # dropbear config for U-Boot platforms
 
 #  Copyright (C) 2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2017 Nikolay Shopik <shopik@nvcube.net>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
+ecdsa_var=onie_dropbear_ecdsa_host_key
 rsa_var=onie_dropbear_rsa_host_key
 dss_var=onie_dropbear_dss_host_key
 
@@ -11,6 +13,15 @@ dss_var=onie_dropbear_dss_host_key
 # the variables are empty generate the keys and store the results for
 # future boots.
 get_keys_arch() {
+    ecdsa_val=$(fw_printenv -n "$ecdsa_var" 2> /dev/null)
+    if [ -n "$ecdsa_val" ] ; then
+        # decode base64 string
+        echo "$ecdsa_val" | tr '@#' ' \n' | uudecode -o $ECDSA_KEY
+    else
+        # genereate ecdsa key
+        dropbearkey -t ecdsa -s 256 -f $ECDSA_KEY > /dev/null 2>&1
+    fi
+
     rsa_val=$(fw_printenv -n "$rsa_var" 2> /dev/null)
     if [ -n "$rsa_val" ] ; then
         # decode base64 string
@@ -29,9 +40,13 @@ get_keys_arch() {
         dropbearkey -t dss -s 1024 -f $DSS_KEY > /dev/null 2>&1
     fi
 
-    if [ -z "$rsa_val" ] || [ -z "$dss_val" ] ; then
+    if [ -z "$ecdsa_val" ] || [ -z "$rsa_val" ] || [ -z "$dss_val" ] ; then
         tmp_env=$(mktemp)
         # encode key values
+        if [ -z "$ecdsa_val" ] ; then
+            ecdsa_val=$(uuencode -m $ECDSA_KEY r | tr ' \n' '@#')
+            echo "$ecdsa_var $ecdsa_val" >> $tmp_env
+        fi
         if [ -z "$rsa_val" ] ; then
             rsa_val=$(uuencode -m $RSA_KEY r | tr ' \n' '@#')
             echo "$rsa_var $rsa_val" >> $tmp_env


### PR DESCRIPTION
This is enable ECDSA keys which is shorter and faster than RSA

`-R` option in init generate keys as they needed, if they don't exist (as soon someone connects to SSH) makes faster startup times and better `urandom` for them

I didn't test this yet, creating pull for comments if any