### PR TITLE
grub.make: fix grub install issue in a48f8ad

### DIFF
--- a/build-config/make/grub.make
+++ b/build-config/make/grub.make
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 #
 #  Copyright (C) 2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2015 david_yang <david_yang@accton.com>
+#  Copyright (C) 2015,2017 david_yang <david_yang@accton.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -203,17 +203,17 @@ endef
 
 $(GRUB_INSTALL_I386_STAMP): $(SYSROOT_INIT_STAMP) $(GRUB_BUILD_I386_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(call grub_install grub-i386-pc $(GRUB_INSTALL_I386_DIR) $(SYSROOTDIR))
+	$(call grub_install, grub-i386-pc, $(GRUB_INSTALL_I386_DIR), $(SYSROOTDIR))
 	$(Q) touch $@
 
 $(GRUB_INSTALL_UEFI_STAMP): $(SYSROOT_INIT_STAMP) $(GRUB_INSTALL_I386_STAMP) $(GRUB_BUILD_UEFI_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(call grub_install grub-$(ARCH)-efi $(GRUB_INSTALL_UEFI_DIR) $(SYSROOTDIR))
+	$(call grub_install, grub-$(ARCH)-efi, $(GRUB_INSTALL_UEFI_DIR), $(SYSROOTDIR))
 	$(Q) touch $@
 
 $(GRUB_INSTALL_I386_COREBOOT_STAMP): $(SYSROOT_INIT_STAMP) $(GRUB_INSTALL_I386_STAMP) $(GRUB_BUILD_I386_COREBOOT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
-	$(call grub_install grub-i386-coreboot $(GRUB_INSTALL_I386_COREBOOT_DIR) $(SYSROOTDIR))
+	$(call grub_install, grub-i386-coreboot, $(GRUB_INSTALL_I386_COREBOOT_DIR), $(SYSROOTDIR))
 	$(Q) touch $@
 
 grub-install: $(GRUB_INSTALL_STAMP)


### PR DESCRIPTION
There is a syntax issue in the expressions of installing grub that
makes the recipes have no effect.  So that the sysroot has no grub
commands for installing ONIE or NOS.

    ONIE: Executing installer: tftp://192.168.1.99/onie-updater-x86_64-accton_as7716_32x-r0
    Verifying image checksum ... OK.
    Preparing image archive ... OK.
    ONIE: Version       : 2017.05.31-test
    ONIE: Architecture  : x86_64
    ONIE: Machine       : accton_as7716_32x
    ONIE: Machine Rev   : 0
    ONIE: Config Version: 1
    Installing ONIE on: /dev/sda
    Found a dos partition table in /dev/sda2
    ERROR: grub-install failed on: /dev/sda2
    /tmp/tmp.YbCxvh/installer/install.sh: line 1: grub-install: not found
    ONIE: ERROR: Firmware update URL: tftp://192.168.1.99/onie-updater-x86_64-accton_as7716_32x-r0
    ONIE: ERROR: Firmware update version: 2017.02.00.06
    Failure: Unable to install image: tftp://192.168.1.99/onie-updater-x86_64-accton_as7716_32x-r0
    ONIE:/ #

The patch has been tested in Accton AS7716_32X.