### PR TITLE
Reduce verbosity during boot

### DIFF
--- a/rootconf/default/etc/init.d/makedev.sh
+++ b/rootconf/default/etc/init.d/makedev.sh
@@ -17,8 +17,8 @@ mount -t proc -o nodev,noexec,nosuid proc /proc
 
 . /lib/onie/functions
 
-# Set console logging to show KERN_NOTICE and above
-echo "6 4 1 6" > /proc/sys/kernel/printk
+# Set console logging to show KERN_WARNING and above
+echo "5 4 1 5" > /proc/sys/kernel/printk
 
 ##
 ## Mount kernel virtual file systems, ala debian init script of the

--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -59,7 +59,8 @@ config_ethmgmt_dhcp4()
     done
 
     log_info_msg "Trying DHCPv4 on interface: $intf"
-    tmp=$(udhcpc $udhcp_args $udhcp_request_opts $udhcp_user_class -i $intf -s /lib/onie/udhcp4_net)
+    udhcpc $udhcp_args $udhcp_request_opts $udhcp_user_class \
+           -i $intf -s /lib/onie/udhcp4_net > /dev/null 2>&1
     if [ "$?" = "0" ] ; then
         local ipaddr=$(ifconfig $intf |grep 'inet '|sed -e 's/:/ /g'|awk '{ print $3 " / " $7 }')
         log_console_msg "Using DHCPv4 addr: ${intf}: $ipaddr"


### PR DESCRIPTION
This series reduces the boot time chattiness.  Everything import is still logged to /var/log/messages.