### PR TITLE
klogd: add and enable daemon

### DIFF
--- a/rootconf/default/etc/init.d/klogd.sh
+++ b/rootconf/default/etc/init.d/klogd.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+cmd="$1"
+
+daemon="klogd"
+ARGS=
+
+. /lib/onie/functions
+
+case $cmd in
+    start)
+        killall $daemon > /dev/null 2>&1
+        log_begin_msg "Starting: $daemon"
+        $daemon $ARGS
+        log_end_msg
+        ;;
+
+    stop)
+        log_begin_msg "Stopping: $daemon"
+        killall $daemon > /dev/null 2>&1
+        log_end_msg
+        ;;
+
+    *)
+
+esac

--- a/rootconf/default/etc/rc0.d/K85klogd.sh
+++ b/rootconf/default/etc/rc0.d/K85klogd.sh
@@ -1,0 +1,1 @@
+../init.d/klogd.sh

--- a/rootconf/default/etc/rc6.d/K85klogd.sh
+++ b/rootconf/default/etc/rc6.d/K85klogd.sh
@@ -1,0 +1,1 @@
+../init.d/klogd.sh

--- a/rootconf/default/etc/rcS.d/S25klogd.sh
+++ b/rootconf/default/etc/rcS.d/S25klogd.sh
@@ -1,0 +1,1 @@
+../init.d/klogd.sh


### PR DESCRIPTION
Start the klogd daemon at boot time, which logs the kernel dmesg
output to /var/log/messages via syslog.

This ensures the dmesg information is logged into /var/log/messages.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>