### PR TITLE
qemu_armv7a: update demo OS install parameters

### DIFF
--- a/machine/qemu_armv7a/demo/platform.conf
+++ b/machine/qemu_armv7a/demo/platform.conf
@@ -5,5 +5,5 @@
 #  SPDX-License-Identifier:     GPL-2.0
 
 mtd_dev=/dev/mtd-open
-img_start=0x00700000
-img_sz=0x00600000
+img_start=0x00900000
+img_sz=0x00700000


### PR DESCRIPTION
Correct a little bit rot.

The offset and size of the ONIE image have changed slightly over
time.  This patch corrects that.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>