### PR TITLE
quanta_ly4r: Fix fix-i2c-ismt-write-error.patch build issue

### DIFF
--- a/machine/quanta/quanta_ly4r/kernel/fix-i2c-ismt-write-error.patch
+++ b/machine/quanta/quanta_ly4r/kernel/fix-i2c-ismt-write-error.patch
@@ -13,7 +13,7 @@ index 6e932d1..dc348fa 100644
 +
 +	do {
 +		val = readl(priv->smba + ISMT_MSTR_MSTS);
-+	} while (val & (ISMT_MSTS_IP))
++	} while (val & (ISMT_MSTS_IP));
 +
 +	writel(val | ISMT_MSTS_MIS | ISMT_MSTS_MEIS,
 +	       priv->smba + ISMT_MSTR_MSTS);


### PR DESCRIPTION
Correct the do-while loop semicolon missing issue.