### PR TITLE
Boot time network driver initialization hook

### DIFF
--- a/machine/kvm_x86_64/rootconf/sysroot-lib-onie/network-driver-platform
+++ b/machine/kvm_x86_64/rootconf/sysroot-lib-onie/network-driver-platform
@@ -1,0 +1,28 @@
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Demonstration of the platform specific network-driver functionality
+
+# This script fragment is sourced by /etc/init.d/network-driver.sh,
+# which in turn executes the network_driver_platform_pre_init() and
+# network_driver_platform_post_init() functions.
+
+# A machine can use this feature to run any scripts needed by the
+# machine to configure the networking ASIC for the platform.  A
+# typical usage would be to initialize the ASIC for a specific
+# platform port layout.
+
+# Use this function to perform any initialization that are required
+# to happen *before* the primary network ASIC initialization.
+network_driver_platform_pre_init()
+{
+    echo "network_driver: Running demonstration pre_init routines..."
+}
+
+# Use this function to perform any initialization that are required
+# to happen *after* the primary network ASIC initialization.
+network_driver_platform_post_init()
+{
+    echo "network_driver: Running demonstration post_init routines..."
+}

--- a/machine/kvm_x86_64/rootconf/sysroot-lib-onie/network-driver-qemu
+++ b/machine/kvm_x86_64/rootconf/sysroot-lib-onie/network-driver-qemu
@@ -1,0 +1,23 @@
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Demonstration of the ASIC network-driver functionality
+
+# This script fragment is sourced by /etc/init.d/network-driver.sh,
+# which in turn executes the network_driver_init() function.
+
+# A machine, or set of common machines, can use this feature to run
+# any scripts needed to perform the bulk of networking ASIC
+# initialization and configuration.  A typical usage would be to
+# initialize a common ASIC/SDK.
+
+# The platform specific initialization is handled by the
+# network-driver-platform script, which handles platform specific
+# details like port/lane mappings.
+
+# Use this function to initialize the networking ASIC and SDK.
+network_driver_init()
+{
+    echo "network_driver: Running ASIC/SDK init routines..."
+}

--- a/rootconf/default/etc/init.d/network-driver.sh
+++ b/rootconf/default/etc/init.d/network-driver.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Network ASIC / Platform specific network driver initialization
+
+cmd="$1"
+
+. /lib/onie/functions
+
+# Platform specific network driver initialization that happen
+# *before* the primary network driver initialization.  This can be
+# set for each platform.
+network_driver_platform_pre_init()
+{
+    # NO-OP
+    true
+}
+
+# Primary network driver initialization.
+network_driver_init()
+{
+    # NO-OP
+    true
+}
+
+# Platform specific network driver initialization that happen *after*
+# the primary network driver initialization.  This can be set for
+# each platform.
+network_driver_platform_post_init()
+{
+    # NO-OP
+    true
+}
+
+arch_network_driver="/lib/onie/network-driver-${onie_switch_asic}"
+platform_network_driver="/lib/onie/network-driver-platform"
+
+[ -r "$arch_network_driver" ]     && . "$arch_network_driver"
+[ -r "$platform_network_driver" ] && . "$platform_network_driver"
+
+case $cmd in
+    start)
+        network_driver_platform_pre_init
+        network_driver_init
+        network_driver_platform_post_init
+        ;;
+    *)
+
+esac

--- a/rootconf/default/etc/rcS.d/S05network-driver.sh
+++ b/rootconf/default/etc/rcS.d/S05network-driver.sh
@@ -1,0 +1,1 @@
+../init.d/network-driver.sh


### PR DESCRIPTION
This patch series is the first step in implementing the proposal to enable the switching silicon ASIC in ONIE.  This would allow the front panel ports to participate in the ONIE image discovery mechanisms.

The proposal is from the mailing list:
http://lists.opencompute.org/pipermail/opencompute-onie/2017-April/001387.html

