### PR TITLE
i2ctools: set I2CTOOLS_SYSEEPROM=no as the default

### DIFF
--- a/build-config/arch/x86_64.make
+++ b/build-config/arch/x86_64.make
@@ -125,11 +125,6 @@ GRUB_IMAGE_NAME = grubx64.efi
 # override this.
 I2CTOOLS_ENABLE ?= yes
 
-# The onie-syseeprom in i2ctools is deprecated from now on.
-# It is recommended to migrate the support from i2ctools to busybox.
-# To compatible with current design, the feature is still enabled by default.
-I2CTOOLS_SYSEEPROM ?= yes
-
 # Include dmidecode tools
 DMIDECODE_ENABLE = yes
 

--- a/machine/alphanetworks/alphanetworks_snh60a0_320f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snh60a0_320f/machine.make
@@ -25,6 +25,7 @@ VENDOR_ID = 31874
 
 # Enable the i2ctools and the onie-syseeprom command for this platform
 I2CTOOLS_ENABLE = yes
+I2CTOOLS_SYSEEPROM = yes
 
 # Console parameters
 CONSOLE_DEV = 1

--- a/machine/alphanetworks/alphanetworks_snq60a0_320f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snq60a0_320f/machine.make
@@ -25,6 +25,7 @@ VENDOR_ID = 31874
 
 # Enable the i2ctools and the onie-syseeprom command for this platform
 I2CTOOLS_ENABLE = yes
+I2CTOOLS_SYSEEPROM = yes
 
 # Console parameters
 CONSOLE_DEV = 1

--- a/machine/alphanetworks/alphanetworks_snx60a0_486f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snx60a0_486f/machine.make
@@ -25,6 +25,7 @@ VENDOR_ID = 31874
 
 # Enable the i2ctools and the onie-syseeprom command for this platform
 I2CTOOLS_ENABLE = yes
+I2CTOOLS_SYSEEPROM = yes
 
 # Console parameters
 CONSOLE_DEV = 1

--- a/machine/celestica/cel_redstone_xp/machine.make
+++ b/machine/celestica/cel_redstone_xp/machine.make
@@ -20,6 +20,7 @@ endif
 VENDOR_ID = 12244
 # Add the onie-syseeprom command for this platform
 I2CTOOLS_ENABLE = yes
+I2CTOOLS_SYSEEPROM = yes
 
 PARTED_ENABLE = yes
 

--- a/machine/celestica/cel_smallstone_xp/machine.make
+++ b/machine/celestica/cel_smallstone_xp/machine.make
@@ -25,6 +25,7 @@ VENDOR_VERSION = .0.0.3
 VENDOR_ID = 12244
 # Add the onie-syseeprom command for this platform
 I2CTOOLS_ENABLE = yes
+I2CTOOLS_SYSEEPROM = yes
 
 PARTED_ENABLE = yes
 

--- a/machine/dell/dell_s6000_s1220/machine.make
+++ b/machine/dell/dell_s6000_s1220/machine.make
@@ -29,6 +29,10 @@ LINUX_MINOR_VERSION	= 69
 # Older GCC required for older 3.2 kernel
 GCC_VERSION = 4.9.2
 
+# Enable the i2ctools and the onie-syseeprom command for this platform
+I2CTOOLS_ENABLE = yes
+I2CTOOLS_SYSEEPROM = yes
+
 #-------------------------------------------------------------------------------
 #
 # Local Variables:

--- a/machine/mellanox/mlnx_x86/machine.make
+++ b/machine/mellanox/mlnx_x86/machine.make
@@ -19,7 +19,9 @@ endif
 # Mellanox IANA number
 VENDOR_ID = 33049
 
+# Enable the i2ctools and the onie-syseeprom command for this platform
 I2CTOOLS_ENABLE = yes
+I2CTOOLS_SYSEEPROM = yes
 
 export EXTRA_CMDLINE_LINUX := acpi_enforce_resources=no nmi_watchdog=0 $(EXTRA_CMDLINE_LINUX)
 


### PR DESCRIPTION
Using the system EEPROM support in i2ctools has been deprecated since
2014.  The accepted method is to use the support added to busybox with
this commit:

  commit fc76004dca594a5f4f12a7905474f77c67e5effb
  Author: david_yang <david_yang@accton.com>
  Date:   Thu Sep 18 09:33:01 2014 +0800
   
      Add to support onie-syseeprom command in busybox

The legacy default for x86_64 machines is I2CTOOLS_SYSEEPROM=yes,
which is painful as all new machines have to explicitly set it to "no"
as they are using the busybox implementation.

This is dumb. The time come to change the default of this option to
no.

This patch also goes through all the legacy machines using the
i2ctools syseeprom implementation, which were relying on the old
default value of "yes", and explicitly sets the option to "yes" in the
corresponding machine.make file.

Closes: #565
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>