### PR TITLE
Add ".bin" extension to default waterfall file names

### DIFF
--- a/rootconf/default/bin/discover
+++ b/rootconf/default/bin/discover
@@ -86,7 +86,7 @@ sd_localfs()
     local_parts=
     for p in $part_list ; do
         mount $p $mp > /dev/null 2>&1 && {
-            for f in $onie_default_filenames ; do
+            for f in $(get_default_filenames) ; do
                 log_info_msg "Attempting file:/$p/$f ..."
                 if [ -r $mp/$f ] ; then
                     local_parts="${p},$local_parts"

--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -294,7 +294,7 @@ $(get_onie_neighs)
         # Check if server appears to be alive
         nc -w 10 $server 80 -e /bin/true > /dev/null 2>&1 && {
             # Try list of default file names
-            for f in $onie_default_filenames ; do
+            for f in $(get_default_filenames) ; do
                 url_run "http://$server/$f" && return 0
             done
         }
@@ -360,7 +360,7 @@ waterfall()
     fi
 
     # Next is root of tftp server -- try all default filenames
-    wf_paths="$wf_paths $onie_default_filenames"
+    wf_paths="$wf_paths $(get_default_filenames)"
 
     # TFTP waterfall
     local tftp_servers=$(ulist "$onie_server_name $onie_disco_siaddr $onie_disco_tftp $onie_disco_tftpsiaddr")
@@ -384,7 +384,7 @@ local_fs_run()
         p=${onie_local_parts%%,*}
         onie_local_parts=${onie_local_parts#*,}
         mount $p $mp > /dev/null 2>&1 && {
-            for f in $onie_default_filenames ; do
+            for f in $(get_default_filenames) ; do
                 if [ -r $mp/$f ] ; then
                     # copy to /tmp, which is a tmpfs -- installer needs to
                     # run with everything unmounted.

--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -36,6 +36,25 @@ ${filename_prefix}-${onie_arch}
 ${filename_prefix}
 "
 
+# Possible image suffixes.  A space separated list of suffixes to
+# append to the default file names during image discovery.
+onie_image_suffixes=".bin"
+
+# get_default_filenames() - function returning a space separated list
+# of default image file names, with the most specific file name first.
+get_default_filenames() {
+    local f
+    local s
+    local paths
+    for f in $onie_default_filenames ; do
+        paths="$paths $f"
+        for s in $onie_image_suffixes ; do
+            paths="$paths ${f}$s"
+        done
+    done
+    echo -n "$paths"
+}
+
 # Default ONIE server name
 onie_server_name="onie-server"
 


### PR DESCRIPTION
In the field a number of user errors have been reported where the
setting of the default ONIE waterfall image is incorrect.  In most
cases the user has mistakenly appended ".bin" to the simple base name
"onie-installer".

The error is so trivially simple that most will miss it, which
prevents ONIE from finding installers.  This is especially common when
performing USB-based installations.

When the file extension is not detected, the USB stick then has to be
mounted manually and manually installed. This process can make Open
Networking look harder than it is.

This patch adds infrastructure for appending any number of suffixes to
the waterfall image names.  This infrastructure is then used to append
".bin" to the default names.

Closes: #567
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>