### PR TITLE
Set correct dns server ip in dhcp config

### DIFF
--- a/contrib/oce/test-onie.py
+++ b/contrib/oce/test-onie.py
@@ -407,6 +407,7 @@ def prepare_test_case(test_args):
             dns_server_ip = test_args['host_ipv4_addr']
         test_args['dns_server_ip'] = dns_server_ip
         test_args['dns_server_name'] = 'onie-server'
+        test_args['dhcp_dns_server'] = dns_server_ip
 
     # handle www_server_ip
     if test_num in www_server_cases:


### PR DESCRIPTION
Sync dhcp_dns_server with dhcp_dns_server, this makes dhcp server
issue correct DNS ip to clients.

The client always get 192.168.1.1 as DNS ip and the test cases
32-43 and 92-103 will fail once user choose another ip address
for OCE test host rather than 192.168.1.1.

Please check below discussion on forum:
http://lists.opencompute.org/pipermail/opencompute-onie/2017-June/001440.html