### PR TITLE
During ONIE update, do not modify EEPROM TLV 0x28

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -138,7 +138,7 @@ update_syseeprom()
     if [ -x /usr/bin/onie-syseeprom ] ; then
         local syseeprom_log=$(mktemp)
         onie-syseeprom \
-            -s 0x28="$image_platform",0x29="$image_version" \
+            -s 0x29="$image_version" \
             > $syseeprom_log 2>&1 || {
             echo "ERROR: Problems accessing sys_eeprom"
             cat $syseeprom_log && rm -f $syseeprom_log


### PR DESCRIPTION
A historical artifact in the ONIE installer is to update the platform
name (TLV 0x28) in the system EEPROM as part of the upgrade.

That operation is not needed as the platform name should be static
across upgrades.

This patch removes the code from the ONIE installer that was updating
EEPROM TLV 0x28 during ONIE upgrades.

Closes: #572
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>