### PR TITLE
limit platform install files to installer only

### DIFF
--- a/build-config/scripts/onie-mk-installer.sh
+++ b/build-config/scripts/onie-mk-installer.sh
@@ -135,9 +135,9 @@ echo -n "."
 cp -r $installer_dir/$arch_dir/* $tmp_installdir
 echo -n "."
 
-[ -r $machine_dir/installer/install-platform ] && {
+if [ "$update_type" = "onie" -a -r $machine_dir/installer/install-platform ] ; then
     cp $machine_dir/installer/install-platform $tmp_installdir
-}
+fi
 
 # Massage install-arch
 if [ "$arch_dir" = "u-boot-arch" ] ; then


### PR DESCRIPTION
The build-config/scripts/onie-mk-installer.sh script is used for
making both the ONIE installer and any ONIE firmware installers.

The type of installer to build is specified in $update_type.

For firmware installers we do not want to include the
$machine_dir/installer/install-platform file, which is only intended
to be used by the ONIE installer.  The firmware installers do not need
this and it can cause problems.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>