### PR TITLE
Supporting common CPU modules

### DIFF
--- a/build-config/make/firmware-update.make
+++ b/build-config/make/firmware-update.make
@@ -12,7 +12,7 @@
 #
 
 FIRMWARE_DIR		= $(MBUILDDIR)/firmware
-FIRMWARE_CONF		= $(FIRMWARE_DIR)/machine.conf
+FIRMWARE_CONF		= $(FIRMWARE_DIR)/machine-build.conf
 FIRMWARE_UPDATE_BASE	= onie-firmware-$(PLATFORM).bin
 FIRMWARE_UPDATE_IMAGE	= $(IMAGEDIR)/$(FIRMWARE_UPDATE_BASE)
 
@@ -61,8 +61,7 @@ $(FIRMWARE_UPDATE_COMPLETE_STAMP): $(IMAGE_UPDATER_SHARCH) $(MACHINE_FW_INSTALLE
 	$(Q) rm -f $(FIRMWARE_CONF)
 	$(Q) echo "onie_version=$(FW_VERSION)" >> $(FIRMWARE_CONF)
 	$(Q) echo "onie_vendor_id=$(VENDOR_ID)" >> $(FIRMWARE_CONF)
-	$(Q) echo "onie_platform=$(RUNTIME_ONIE_PLATFORM)" >> $(FIRMWARE_CONF)
-	$(Q) echo "onie_machine=$(RUNTIME_ONIE_MACHINE)" >> $(FIRMWARE_CONF)
+	$(Q) echo "onie_build_machine=$(ONIE_BUILD_MACHINE)" >> $(FIRMWARE_CONF)
 	$(Q) echo "onie_machine_rev=$(MACHINE_REV)" >> $(FIRMWARE_CONF)
 	$(Q) echo "onie_arch=$(ARCH)" >> $(FIRMWARE_CONF)
 	$(Q) echo "onie_config_version=$(ONIE_CONFIG_VERSION)" >> $(FIRMWARE_CONF)

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -38,7 +38,7 @@ IMAGE			= $(IMAGE_COMPLETE_STAMP)
 
 LSB_RELEASE_FILE = $(MBUILDDIR)/lsb-release
 OS_RELEASE_FILE	 = $(MBUILDDIR)/os-release
-MACHINE_CONF	 = $(MBUILDDIR)/machine.conf
+MACHINE_CONF	 = $(MBUILDDIR)/machine-build.conf
 
 INSTALLER_DIR	= $(abspath ../installer)
 
@@ -234,15 +234,13 @@ $(SYSROOT_CHECK_STAMP): $(PACKAGES_INSTALL_STAMPS)
        endif
 	$(Q) touch $@
 
-# Setting RUNTIME_ONIE_PLATFORM and RUNTIME_ONIE_MACHINE on the
-# command line allows you "fake" a real machine at runtime.  This is
-# particularly useful when MACHINE is the kvm_x86_64 virtual machine.
-# Using these variables you can make the running virtual machine look
-# like a specific real machine.  This is useful when developing an
-# installer for a particular platform.  You can develope the installer
-# using the virtual machine.
-RUNTIME_ONIE_MACHINE	?= $(MACHINE)
-RUNTIME_ONIE_PLATFORM	?= $(ARCH)-$(RUNTIME_ONIE_MACHINE)-r$(MACHINE_REV)
+# Setting ONIE_BUILD_MACHINE on the command line allows you "fake" a
+# real machine at runtime.  This is particularly useful when MACHINE
+# is the kvm_x86_64 virtual machine.  Using these variables you can
+# make the running virtual machine look like a specific real machine.
+# This is useful when developing an installer for a particular
+# platform.  You can develop the installer using the virtual machine.
+ONIE_BUILD_MACHINE	?= $(MACHINE)
 
 sysroot-complete: $(SYSROOT_COMPLETE_STAMP)
 $(SYSROOT_COMPLETE_STAMP): $(SYSROOT_CHECK_STAMP)
@@ -282,8 +280,7 @@ $(SYSROOT_COMPLETE_STAMP): $(SYSROOT_CHECK_STAMP)
 	$(Q) rm -f $(MACHINE_CONF)
 	$(Q) echo "onie_version=$(LSB_RELEASE_TAG)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_vendor_id=$(VENDOR_ID)" >> $(MACHINE_CONF)
-	$(Q) echo "onie_platform=$(RUNTIME_ONIE_PLATFORM)" >> $(MACHINE_CONF)
-	$(Q) echo "onie_machine=$(RUNTIME_ONIE_MACHINE)" >> $(MACHINE_CONF)
+	$(Q) echo "onie_build_machine=$(ONIE_BUILD_MACHINE)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_machine_rev=$(MACHINE_REV)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_arch=$(ARCH)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_config_version=$(ONIE_CONFIG_VERSION)" >> $(MACHINE_CONF)
@@ -298,7 +295,7 @@ $(SYSROOT_COMPLETE_STAMP): $(SYSROOT_CHECK_STAMP)
        endif
 	$(Q) cp $(LSB_RELEASE_FILE) $(SYSROOTDIR)/etc/lsb-release
 	$(Q) cp $(OS_RELEASE_FILE) $(SYSROOTDIR)/etc/os-release
-	$(Q) cp $(MACHINE_CONF) $(SYSROOTDIR)/etc/machine.conf
+	$(Q) cp $(MACHINE_CONF) $(SYSROOTDIR)/etc/machine-build.conf
 	$(Q) touch $@
 
 # This step creates the cpio archive and compresses it

--- a/build-config/scripts/onie-mk-installer.sh
+++ b/build-config/scripts/onie-mk-installer.sh
@@ -206,7 +206,7 @@ EOF
         $tmp_installdir/grub.d/50_onie_grub
 fi
 
-sed -e 's/onie_/image_/' $machine_conf > $tmp_installdir/machine.conf || exit 1
+sed -e 's/onie_/image_/' $machine_conf > $tmp_installdir/machine-build.conf || exit 1
 echo -n "."
 
 if [ "$update_type" = "firmware" ] ; then

--- a/installer/grub-arch/install-arch
+++ b/installer/grub-arch/install-arch
@@ -15,11 +15,11 @@
 . ./installer.conf
 
 # Load machine info from image to be installed.
-[ -r ./machine.conf ] || {
-    echo "ERROR: ONIE update image machine.conf file is missing."
+[ -r ./machine-build.conf ] || {
+    echo "ERROR: ONIE update image machine-build.conf file is missing."
     exit 1
 }
-. ./machine.conf
+. ./machine-build.conf
 
 # get running machine from conf file
 [ -r /etc/machine.conf ] && . /etc/machine.conf

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -7,11 +7,11 @@
 
 cd $(dirname $0)
 
-[ -r ./machine.conf ] || {
-    echo "ERROR: machine.conf file is missing."
+[ -r ./machine-build.conf ] || {
+    echo "ERROR: machine-build.conf file is missing."
     exit 1
 }
-. ./machine.conf
+. ./machine-build.conf
 
 # Default implementation is no additional args
 parse_arg_arch()
@@ -43,6 +43,10 @@ true ${onie_machine_rev=0}
 # for backward compatibility if running onie_conf_version is empty
 # assume it is 0.
 true ${onie_config_version=0}
+
+# for backward compatibility, if running onie_build_machine is empty
+# assign the value from onie_machine.
+onie_build_machine=${onie_build_machine:-$onie_machine}
 
 args="hivfqx${args_arch}"
 
@@ -99,7 +103,7 @@ while getopts "$args" a ; do
             ;;
         i)
             # Dump the image information
-            cat ./machine.conf
+            cat ./machine-build.conf
             exit 0
             ;;
         *)
@@ -121,7 +125,7 @@ xz -d -c onie-update.tar.xz | tar -xf -
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then
@@ -156,15 +160,15 @@ check_machine_image
 
 if [ "$fail" = "yes" ] && [ "$force" = "no" ] ; then
     echo "ERROR:$update_label: Machine mismatch"
-    echo "Running machine     : ${onie_arch}-${onie_machine}-${onie_machine_rev}"
-    echo "Update Image machine: ${image_arch}-${image_machine}-${image_machine_rev}"
+    echo "Running platform     : ${onie_arch}-${onie_build_machine}-r${onie_machine_rev}"
+    echo "Update Image platform: ${image_arch}-${image_build_machine}-r${image_machine_rev}"
     echo "Source URL: $onie_exec_url"
     exit 1
 fi
 
 [ "$quiet" = "no" ] && echo "$update_label: Version       : $image_version"
 [ "$quiet" = "no" ] && echo "$update_label: Architecture  : $image_arch"
-[ "$quiet" = "no" ] && echo "$update_label: Machine       : $image_machine"
+[ "$quiet" = "no" ] && echo "$update_label: Machine       : $image_build_machine"
 [ "$quiet" = "no" ] && echo "$update_label: Machine Rev   : $image_machine_rev"
 [ "$quiet" = "no" ] && echo "$update_label: Config Version: $image_config_version"
 

--- a/machine/kvm_x86_64/rootconf/sysroot-lib-onie/gen-config-platform
+++ b/machine/kvm_x86_64/rootconf/sysroot-lib-onie/gen-config-platform
@@ -1,0 +1,48 @@
+# KVM x86_64 Virtual Machine
+#
+# Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+# Test of the runtime config generation mechanism
+
+# /etc/init.d/gen-config.sh sources this file and executes
+# gen_live_config() to generate runtime ONIE variables.
+
+# Two variables of interest to set here:
+#
+# onie_machine     -- runtime ONIE platform string
+# onie_switch_asic -- runtime switch ASIC vendor
+
+# Use kernel command line parameters to test the dynamic generation.
+# The default is to not generate anything dynamically.
+
+gen_live_config()
+{
+    # Parse kernel command line options
+    for x in $(cat /proc/cmdline); do
+        parm=${x%%=*}
+        val=${x#*=}
+        case $parm in
+            live_machine)
+                local live_machine="$val"
+                ;;
+            live_asic)
+                local live_asic="$val"
+                ;;
+        esac
+    done
+
+    if [ -n "$live_machine" ] ; then
+        cat<<EOF
+# Runtime ONIE Machine
+onie_machine="$live_machine"
+EOF
+    fi
+
+    if [ -n "$live_asic" ] ; then
+        cat<<EOF
+# Runtime ONIE ASIC
+onie_switch_asic="$live_asic"
+EOF
+    fi
+
+}

--- a/rootconf/default/bin/onie-support
+++ b/rootconf/default/bin/onie-support
@@ -62,7 +62,7 @@ ps w > $save_dir/runtime-process.txt
 dmesg > $save_dir/dmesg.txt
 onie-syseeprom > $save_dir/onie-syseeprom.txt
 onie-sysinfo -a > $save_dir/onie-sysinfo.txt
-cp /etc/machine.conf $save_dir/machine.txt
+cp /etc/machine*.conf $save_dir
 blkid > $save_dir/blkid.txt
 fdisk -l > $save_dir/fdisk.txt
 support_arch

--- a/rootconf/default/bin/onie-sysinfo
+++ b/rootconf/default/bin/onie-sysinfo
@@ -95,7 +95,7 @@ get_ethaddr()
 [ -r $lib_dir/sysinfo-arch ]     && . $lib_dir/sysinfo-arch
 [ -r $lib_dir/sysinfo-platform ] && . $lib_dir/sysinfo-platform
 
-args="hsSevimrpcfdatP"
+args="hsbSevimrpcfdatP"
 
 usage()
 {
@@ -124,6 +124,9 @@ COMMAND LINE OPTIONS
 
 	-i
 		ONIE vendor ID.  Print the ONIE vendor's IANA enterprise number.
+
+	-b
+		ONIE build machine string
 
 	-m
 		ONIE machine string
@@ -158,6 +161,7 @@ sn=no
 mac=no
 version=no
 vendor_id=no
+build_machine=no
 machine=no
 machine_rev=no
 platform=no
@@ -191,6 +195,9 @@ while getopts "$args" a ; do
             ;;
         i)
             vendor_id=yes
+            ;;
+        b)
+            build_machine=yes
             ;;
         m)
             machine=yes
@@ -255,7 +262,9 @@ if [ "$mac" = "yes" ] || [ "$all" = "yes" ] ; then
     print_val $val
 fi
 
-for v in version vendor_id machine machine_rev platform arch config_version partition_type build_date switch_asic ; do
+for v in version vendor_id build_machine machine \
+         machine_rev platform arch config_version \
+         partition_type build_date switch_asic ; do
     eval dump='$'$v
     if [ "$dump" = "yes" ] || [ "$all" = "yes" ] ; then
         eval val='$onie'_$v

--- a/rootconf/default/etc/init.d/gen-config.sh
+++ b/rootconf/default/etc/init.d/gen-config.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# If necessary, generate run-time ONIE configuration variables in
+# /etc/machine-live.conf.
+
+cmd="$1"
+
+gen_live_config()
+{
+    # NO-OP
+    true
+}
+
+[ -r /lib/onie/gen-config-platform ] && . /lib/onie/gen-config-platform
+
+case $cmd in
+    start)
+        gen_live_config > /etc/machine-live.conf
+        ;;
+    *)
+
+esac

--- a/rootconf/default/etc/machine.conf
+++ b/rootconf/default/etc/machine.conf
@@ -1,0 +1,16 @@
+# /etc/machine.conf for onie
+
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Source build-time machine configuration
+. /etc/machine-build.conf
+
+# Source run-time machine configuration if available
+[ -r /etc/machine-live.conf ] && . /etc/machine-live.conf
+
+# Use onie_machine if set, otherwise use build_machine
+onie_machine=${onie_machine:-$onie_build_machine}
+
+onie_platform="${onie_arch}-${onie_machine}-r${onie_machine_rev}"

--- a/rootconf/default/etc/rcS.d/S05gen-config.sh
+++ b/rootconf/default/etc/rcS.d/S05gen-config.sh
@@ -1,0 +1,1 @@
+../init.d/gen-config.sh


### PR DESCRIPTION
This patch series adds support and infrastructure for platforms that use a common CPU module.

Also included is an example of using the infrastructure byway of the kvm_x86_64 virtual machine.
