### PR TITLE
busybox: enable i2c tools if I2CTOOLS_ENABLE=y

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -376,7 +376,7 @@ ifeq ($(UEFI_ENABLE),yes)
   include make/efivar.make
   include make/efibootmgr.make
 endif
-ifeq ($(I2CTOOLS_ENABLE),yes)
+ifeq ($(I2CTOOLS_SYSEEPROM),yes)
   include make/i2ctools.make
 endif
 ifeq ($(DMIDECODE_ENABLE),yes)

--- a/build-config/make/busybox.make
+++ b/build-config/make/busybox.make
@@ -101,6 +101,13 @@ ifeq ($(DOSFSTOOLS_ENABLE),yes)
 	$(Q) sed -i \
 		-e '/\bCONFIG_MKFS_VFAT\b/c\# CONFIG_MKFS_VFAT is not set' $@
 endif
+ifeq ($(I2CTOOLS_ENABLE),yes)
+	$(Q) sed -i \
+		-e '/\bCONFIG_I2CGET\b/cCONFIG_I2CGET=y' \
+		-e '/\bCONFIG_I2CSET\b/cCONFIG_I2CSET=y' \
+		-e '/\bCONFIG_I2CDUMP\b/cCONFIG_I2CDUMP=y' \
+		-e '/\bCONFIG_I2CDETECT\b/cCONFIG_I2CDETECT=y' $@
+endif
 	$(Q) $(SCRIPTDIR)/apply-config-patch $@ $(MACHINE_BUSYBOX_CONFIG_FILE)
 
 busybox-config: $(BUSYBOX_DIR)/.config

--- a/build-config/make/i2ctools.make
+++ b/build-config/make/i2ctools.make
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 #
 #  Copyright (C) 2014 Puneet <puneet@cumulusnetworks.com>
-#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014,2017 david_yang <david_yang@accton.com>
 #  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -28,8 +28,6 @@ I2CTOOLS_STAMP		= $(I2CTOOLS_SOURCE_STAMP) \
 			  $(I2CTOOLS_PATCH_STAMP) \
 			  $(I2CTOOLS_BUILD_STAMP) \
 			  $(I2CTOOLS_INSTALL_STAMP)
-
-I2CTOOLS_PROGRAMS = i2cget i2cset i2cdump i2cdetect
 
 PHONY += i2ctools i2ctools-download i2ctools-source i2ctools-patch \
 	 i2ctools-build i2ctools-install i2ctools-clean \
@@ -101,15 +99,7 @@ i2ctools-install: $(I2CTOOLS_INSTALL_STAMP)
 $(I2CTOOLS_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(I2CTOOLS_BUILD_STAMP) $(ZLIB_INSTALL_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "==== Installing i2ctools in $(DEV_SYSROOT) ===="
-	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(I2CTOOLS_DIR) \
-		CROSS_COMPILE=$(CROSSPREFIX) CFLAGS="$(ONIE_CFLAGS)" \
-		LDFLAGS="$(ONIE_LDFLAGS)" SYSEEPROM_ENABLE=$(I2CTOOLS_SYSEEPROM)
-	$(Q) for file in $(I2CTOOLS_PROGRAMS); do \
-		cp -av $(I2CTOOLS_DIR)/tools/$$file $(SYSROOTDIR)/usr/bin ; \
-	     done
-ifeq ($(I2CTOOLS_SYSEEPROM),yes)
 	$(Q) cp -av $(I2CTOOLS_DIR)/sys_eeprom/onie-syseeprom $(SYSROOTDIR)/usr/bin/onie-syseeprom
-endif
 	$(Q) touch $@
 
 MACHINE_CLEAN += i2ctools-clean


### PR DESCRIPTION
Recently the i2c tools have been ported to busybox.  The patch
will use the ones in busybox instead of in i2c-tools if
`I2CTOOLS_ENABLE` is enabled.

Now, i2c-tools will be built only if `I2CTOOLS_SYSEEPROM` (deprecated)
is enabled.

Using the tools in busybox will reduce a bit of image size compares
to i2c-tools.

The patch has been tested in Accton AS7712_32X.