### PR TITLE
Update variables in install-platform revised in 3cbcb9e

### DIFF
--- a/machine/accton/accton_as4510_52t/installer/install-platform
+++ b/machine/accton/accton_as4510_52t/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "$onie_machine" != "accton_as4510_54t" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "$onie_build_machine" != "accton_as4510_54t" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as4600_54t/installer/install-platform
+++ b/machine/accton/accton_as4600_54t/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as4610_30/installer/install-platform
+++ b/machine/accton/accton_as4610_30/installer/install-platform
@@ -1,7 +1,7 @@
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_as4610_30" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_as4610_30" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as4610_54/installer/install-platform
+++ b/machine/accton/accton_as4610_54/installer/install-platform
@@ -1,7 +1,7 @@
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_as4610_54" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_as4610_54" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as5512_54x/installer/install-platform
+++ b/machine/accton/accton_as5512_54x/installer/install-platform
@@ -1,7 +1,7 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as5600_52x/installer/install-platform
+++ b/machine/accton/accton_as5600_52x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as5610_52x/installer/install-platform
+++ b/machine/accton/accton_as5610_52x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as5700_96x/installer/install-platform
+++ b/machine/accton/accton_as5700_96x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as5710_54x/installer/install-platform
+++ b/machine/accton/accton_as5710_54x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as5712_54x/installer/install-platform
+++ b/machine/accton/accton_as5712_54x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as6700_32x/installer/install-platform
+++ b/machine/accton/accton_as6700_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as6701_32x/installer/install-platform
+++ b/machine/accton/accton_as6701_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as6710_32x/installer/install-platform
+++ b/machine/accton/accton_as6710_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as6712_32x/installer/install-platform
+++ b/machine/accton/accton_as6712_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as7512_32x/installer/install-platform
+++ b/machine/accton/accton_as7512_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "accton_$onie_machine" != "$image_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "accton_$onie_build_machine" != "$image_build_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_as7712_32x/installer/install-platform
+++ b/machine/accton/accton_as7712_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "$onie_machine" != "accton_as7702_32x" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "$onie_build_machine" != "accton_as7702_32x" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/accton/accton_wedge100_32x/installer/install-platform
+++ b/machine/accton/accton_wedge100_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "$onie_machine" != "accton_wedge_32x" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "$onie_build_machine" != "accton_wedge_32x" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/celestica/cel_bigstone_g/installer/install-platform
+++ b/machine/celestica/cel_bigstone_g/installer/install-platform
@@ -11,8 +11,8 @@ check_machine_image()
     fi
     echo "ONIE: Platform Machine: $image_platform_machine"
 
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "$onie_machine" != "$image_platform_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "$onie_build_machine" != "$image_platform_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/facebook/facebook_backpack_b632vg/installer/install-platform
+++ b/machine/facebook/facebook_backpack_b632vg/installer/install-platform
@@ -9,8 +9,8 @@ check_machine_image()
     image_platform_machine=$(echo $image_machine | sed "s/facebook_backpack/facebook_backpack_${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
-    if [ "$onie_machine" != "$image_machine" ] &&
-       [ "$onie_machine" != "$image_platform_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] &&
+       [ "$onie_build_machine" != "$image_platform_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/netberg/netberg_rangeley_p1330/installer/install-platform
+++ b/machine/netberg/netberg_rangeley_p1330/installer/install-platform
@@ -9,7 +9,7 @@ check_machine_image()
     image_platform_machine=$(echo $image_machine | sed "s/rangeley_p1330/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
-    if [ "$onie_machine" != "$image_machine" ] && [ "$onie_machine" != "$image_platform_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/quanta/quanta_bwde/installer/install-platform
+++ b/machine/quanta/quanta_bwde/installer/install-platform
@@ -7,7 +7,7 @@ check_machine_image()
     image_platform_machine=$(echo $image_machine | sed "s/bwde/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
-    if [ "$onie_machine" != "$image_machine" ] && [ "$onie_machine" != "$image_platform_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/quanta/quanta_common_p2020/installer/install-platform
+++ b/machine/quanta/quanta_common_p2020/installer/install-platform
@@ -7,7 +7,7 @@ check_machine_image()
     image_platform_machine=$(echo $image_machine | sed "s/common_p2020/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
-    if [ "$onie_machine" != "$image_machine" ] && [ "$onie_machine" != "$image_platform_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/quanta/quanta_common_rangeley/installer/install-platform
+++ b/machine/quanta/quanta_common_rangeley/installer/install-platform
@@ -12,7 +12,7 @@ check_machine_image()
     image_platform_machine=$(echo $image_machine | sed "s/common_rangeley/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
-    if [ "$onie_machine" != "$image_machine" ] && [ "$onie_machine" != "$image_platform_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then

--- a/machine/quanta/quanta_common_rglbmc/installer/install-platform
+++ b/machine/quanta/quanta_common_rglbmc/installer/install-platform
@@ -7,7 +7,7 @@ check_machine_image()
     image_platform_machine=$(echo $image_machine | sed "s/common_rglbmc/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
-    if [ "$onie_machine" != "$image_machine" ] && [ "$onie_machine" != "$image_platform_machine" ] ; then
+    if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then
         fail=yes
     fi
     if [ "$onie_machine_rev" != "$image_machine_rev" ] ; then


### PR DESCRIPTION
In commit 3cbcb9e, it renamed `onie_machine` and `image_machine` to `onie_build_machine` and `image_build_machine`.  And `image_machine` never exists since the commit.  We need to update these variables to the new ones.

The modification has been tested only in Accton AS7712_32X because it is the same in other machines.