### PR TITLE
Update variables in install-platform revised in 3cbcb9e 

### DIFF
--- a/machine/accton/accton_as7710_32x/installer/install-platform
+++ b/machine/accton/accton_as7710_32x/installer/install-platform
@@ -1,8 +1,8 @@
 
 check_machine_image()
 {
-    if [ "${onie_machine}-$onie_machine_rev" != "accton_as7700_32x-1" ] &&
-       [ "${onie_machine}-$onie_machine_rev" != "accton_as7710_32x-0" ] ; then
+    if [ "${onie_build_machine}-$onie_machine_rev" != "accton_as7700_32x-1" ] &&
+       [ "${onie_build_machine}-$onie_machine_rev" != "accton_as7710_32x-0" ] ; then
         fail=yes
     fi
     if [ "$onie_arch" != "$image_arch" ] ; then

--- a/machine/celestica/cel_bigstone_g/installer/install-platform
+++ b/machine/celestica/cel_bigstone_g/installer/install-platform
@@ -7,7 +7,7 @@ check_machine_image()
 {
     bigstone_g_card_detect
     if [ -n "${platform}" ] ; then
-        image_platform_machine=$(echo $image_machine | sed "s/cel_bigstone_g/cel_bigstone_g_${platform}/g")
+        image_platform_machine=$(echo $image_build_machine | sed "s/cel_bigstone_g/cel_bigstone_g_${platform}/g")
     fi
     echo "ONIE: Platform Machine: $image_platform_machine"
 

--- a/machine/facebook/facebook_backpack_b632vg/installer/install-platform
+++ b/machine/facebook/facebook_backpack_b632vg/installer/install-platform
@@ -6,7 +6,7 @@
 check_machine_image()
 {
     backpack_card_detect
-    image_platform_machine=$(echo $image_machine | sed "s/facebook_backpack/facebook_backpack_${platform}/g")
+    image_platform_machine=$(echo $image_build_machine | sed "s/facebook_backpack/facebook_backpack_${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
     if [ "$onie_build_machine" != "$image_build_machine" ] &&

--- a/machine/netberg/netberg_rangeley_p1330/installer/install-platform
+++ b/machine/netberg/netberg_rangeley_p1330/installer/install-platform
@@ -6,7 +6,7 @@ check_machine_image()
     [ -x "/usr/bin/mb_detect" ] && {
         platform=$(/usr/bin/mb_detect -p)
     }
-    image_platform_machine=$(echo $image_machine | sed "s/rangeley_p1330/${platform}/g")
+    image_platform_machine=$(echo $image_build_machine | sed "s/rangeley_p1330/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
     if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then

--- a/machine/quanta/quanta_bwde/installer/install-platform
+++ b/machine/quanta/quanta_bwde/installer/install-platform
@@ -4,7 +4,7 @@
 check_machine_image()
 {
     platform=$(/usr/bin/mb_detect -p)
-    image_platform_machine=$(echo $image_machine | sed "s/bwde/${platform}/g")
+    image_platform_machine=$(echo $image_build_machine | sed "s/bwde/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
     if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then

--- a/machine/quanta/quanta_common_p2020/installer/install-platform
+++ b/machine/quanta/quanta_common_p2020/installer/install-platform
@@ -4,7 +4,7 @@
 check_machine_image()
 {
     platform=$(/bin/sed 's/quanta,//g' /proc/device-tree/compatible)
-    image_platform_machine=$(echo $image_machine | sed "s/common_p2020/${platform}/g")
+    image_platform_machine=$(echo $image_build_machine | sed "s/common_p2020/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
     if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then

--- a/machine/quanta/quanta_common_rangeley/installer/install-platform
+++ b/machine/quanta/quanta_common_rangeley/installer/install-platform
@@ -9,7 +9,7 @@ check_machine_image()
     [ -x "/usr/bin/mbdetect" ] && {
         platform=$(/usr/bin/mbdetect -p)
     }
-    image_platform_machine=$(echo $image_machine | sed "s/common_rangeley/${platform}/g")
+    image_platform_machine=$(echo $image_build_machine | sed "s/common_rangeley/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
     if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then

--- a/machine/quanta/quanta_common_rglbmc/installer/install-platform
+++ b/machine/quanta/quanta_common_rglbmc/installer/install-platform
@@ -4,7 +4,7 @@
 check_machine_image()
 {
     platform=$(/usr/bin/mb_detect -p)
-    image_platform_machine=$(echo $image_machine | sed "s/common_rglbmc/${platform}/g")
+    image_platform_machine=$(echo $image_build_machine | sed "s/common_rglbmc/${platform}/g")
     echo "ONIE: Platform Machine: $image_platform_machine"
 
     if [ "$onie_build_machine" != "$image_build_machine" ] && [ "$onie_build_machine" != "$image_platform_machine" ] ; then


### PR DESCRIPTION
Sorry for my fault.  Some variables were not discovered and replaced.  I checked them again carefully.  All `onie_machine` and `image_machine` in install-platforms are replaced to `onie_build_machine` and `image_build_machine` now.