### PR TITLE
Improve checking for missing libraries at build time

### DIFF
--- a/build-config/scripts/check-libs
+++ b/build-config/scripts/check-libs
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Verify that all binaries and libraries are represented in the final
+# sysroot.
+
+set -e
+
+check_dir() {
+    find_type="$1"
+
+    case "$find_type" in
+        files)
+            find_opts="-type f" ;;
+        symlinks)
+            find_opts="-type l" ;;
+        *)
+            echo "ERROR: unexpected find_type: $find_type"
+            exit 1
+    esac
+
+
+    (cd "$SYSROOTDIR" && find . $find_opts | LC_ALL=C sort > "$SYSFILES")
+    (cd "$CHECKDIR" && find . $find_opts | LC_ALL=C sort > "$CHECKFILES")
+
+    diff -q "$SYSFILES" "$CHECKFILES" > /dev/null 2>&1 || {
+        echo "ERROR: Missing/unexpected $find_type in SYSROOTDIR:"
+        diff "$SYSFILES" "$CHECKFILES"
+        exit 1
+    }
+}
+
+POPULATE_CMD="$1"
+
+[ -x "$POPULATE_CMD" ] || {
+    echo "ERROR: Unable to find populate executable: $POPULATE_CMD"
+    exit 1
+}
+
+DEV_SYSROOT="$2"
+[ -f "${DEV_SYSROOT}/usr/lib/libc.a" ] || {
+    echo "ERROR: Unable to find valid DEV_SYSROOT: $DEV_SYSROOT"
+    exit 1
+}
+
+SYSROOTDIR="$3"
+[ -d "${SYSROOTDIR}/var/log" ] || {
+    echo "ERROR: Unable to find valid SYSROOTDIR: $SYSROOTDIR"
+    exit 1
+}
+
+CHECKROOT="$4"
+mkdir -p "$CHECKROOT"
+
+CHECKDIR="${CHECKROOT}/checkdir"
+
+CHECKFILES="${CHECKROOT}/checkfiles.txt"
+SYSFILES="${CHECKROOT}/sysfiles.txt"
+
+"$POPULATE_CMD" -r "$DEV_SYSROOT" \
+		-s "$SYSROOTDIR" \
+		-d "$CHECKDIR"
+
+check_dir files
+check_dir symlinks


### PR DESCRIPTION
The method for validating that the sysroot contains all the necessary
libraries from the dev-sysroot has a small flaw.  The check only
validates that the file names in the two trees are identical.

In the case of libraries, sometimes the trees would differ because one
file was a symlink, while the other file was a real file.

This patch moves the validation checking out into a stand alone
script.  The logic was becoming too complex to implement inside of a
Makefile.

The new validation algorithm first checks that all the "real files"
are identical and then checks that all the "symlinks" are identical.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>