### PR TITLE
image-discovery: update TFTP server search order

### DIFF
--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -314,13 +314,13 @@ tftp_download()
 $onie_server_name
 # BOOTP next-server IP
 $onie_disco_siaddr
-# DHCP server IP (DHCP opt 54)
-$onie_disco_serverid
-# DHCP TFTP server name (DHCP opt 66)
+# TFTP server name (DHCP opt 66)
 # Requires DNS
 $onie_disco_tftp
 # TFTP server IP (DHCP opt 150)
 $onie_disco_tftpsiaddr
+# DHCP server IP (DHCP opt 54)
+$onie_disco_serverid
 ")
 
     # Busybox sets "boot_file" for the BOOTP boot file and sets


### PR DESCRIPTION
ONIE commit b760ede inadvertently changed the TFTP server search
order:

  commit b760eded3b54c9104f5c80c1bed01794546a7a9d
  Author: Curt Brune <curt@cumulusnetworks.com>
  Date:   Mon Apr 24 13:55:59 2017 -0700

    Add $onie_disco_serverid and $onie_server_name to TFTP waterfall

In the list of servers to try, that commit inserted "DHCP Server
IP" (DHCP option 54) before TFTP server name (DHCP option 66). Since
option 54 is pretty much universally set by the DHCP server, we will
always hit that before we get to TFTP server name (DHCP option 66).

The fix here is to put "DHCP Server IP" (DHCP option 54) *last* in the
search order.  Compared to "TFTP server name" and "TFTP server IP",
the IP address of the DHCP server is the least specified.

Closes: #648
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>