### PR TITLE
intel_coreboot_rangeley: add demo OS files

### DIFF
--- a/machine/intel/intel_coreboot_rangeley/demo/platform.conf
+++ b/machine/intel/intel_coreboot_rangeley/demo/platform.conf
@@ -1,0 +1,5 @@
+# intel_coreboot_rangeley specific info
+
+#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0


### PR DESCRIPTION
This platform never had the demo/ sub-directory containing demo OS
specific files.  Without these files we cannot build the demo OS for
this platform.

Building the demo OS is part of the ONIE certification process.

This patch adds a minimal demo/ sub-directory so that we can build the
demo OS for this platform.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>