### PR TITLE
Use dmidecode for system information

### DIFF
--- a/build-config/make/dmidecode.make
+++ b/build-config/make/dmidecode.make
@@ -9,8 +9,8 @@
 # This is a makefile fragment that defines the build of dmidecode
 #
 
-DMIDECODE_VERSION		= 2.12
-DMIDECODE_TARBALL		= dmidecode-$(DMIDECODE_VERSION).tar.gz
+DMIDECODE_VERSION		= 3.1
+DMIDECODE_TARBALL		= dmidecode-$(DMIDECODE_VERSION).tar.xz
 DMIDECODE_TARBALL_URLS		+= $(ONIE_MIRROR) http://download.savannah.gnu.org/releases/dmidecode/
 DMIDECODE_BUILD_DIR		= $(USER_BUILDDIR)/dmidecode
 DMIDECODE_DIR			= $(DMIDECODE_BUILD_DIR)/dmidecode-$(DMIDECODE_VERSION)

--- a/patches/dmidecode/dmidecode-onie-cross-compile.patch
+++ b/patches/dmidecode/dmidecode-onie-cross-compile.patch
@@ -1,28 +1,17 @@
 dmidecode ONIE cross compile patch
 
-Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
 
 SPDX-License-Identifier:     GPL-2.0
 
 Small modifications to the dmidecode Makefile for cross compiling in
 the ONIE build environment.
+---
+ Makefile |    5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
-Main changes:
-
-- prefix gcc  with $(CROSS_PREFIX)
-Summary:
-
-diff --git a/.gitignore b/.gitignore
-new file mode 100644
-index 0000000..f03a162
---- /dev/null
-+++ b/.gitignore
-@@ -0,0 +1,3 @@
-+*.o
-+biosdecode
-+dmidecode
 diff --git a/Makefile b/Makefile
-index 55378bb..3913a44 100644
+index 1f54a1f..1d03628 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -12,7 +12,7 @@
@@ -33,13 +22,13 @@ index 55378bb..3913a44 100644
 +CC      = $(CROSS_COMPILE)gcc
  CFLAGS  = -W -Wall -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-qual \
            -Wcast-align -Wwrite-strings -Wmissing-prototypes -Winline -Wundef
- #CFLAGS += -DBIGENDIAN
-@@ -25,6 +25,9 @@ CFLAGS += -O2
+ 
+@@ -29,6 +29,9 @@ CFLAGS += -O2
  # Pass linker flags here
  LDFLAGS =
  
-+CFLAGS	+= $(ONIE_CXXFLAGS)
-+LDFLAGS	+= $(ONIE_LDFLAGS)
+++CFLAGS		+= $(ONIE_CFLAGS)
+++LDFLAGS	+= $(ONIE_LDFLAGS)
 +
  DESTDIR =
  prefix  = /usr/local

--- a/patches/dmidecode/series
+++ b/patches/dmidecode/series
@@ -1,2 +1,2 @@
-# This series applies on GIT commit d1c36ea8e948b8a607b8bf71eb27aaa4c1326363
+# This series applies on GIT commit 230d76a606e09f77b0e74e445e35dadeeac756ee
 dmidecode-onie-cross-compile.patch

--- a/rootconf/grub-arch/sysroot-lib-onie/sysinfo-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/sysinfo-arch
@@ -17,6 +17,11 @@ get_serial_num_arch()
         else
             log_console_msg "Unable to find 'Serial Number' TLV in EEPROM data."
         fi
+    elif [ -x /usr/bin/dmidecode ] ; then
+        sn="$(dmidecode -s system-serial-number)"
+        if [ $? -eq 0 -a -n "$sn" ] ; then
+            echo $sn
+        fi
     fi
 }
 
@@ -42,6 +47,11 @@ get_part_num_arch()
             echo $pn
         else
             log_console_msg "Unable to find 'Part Number' TLV in EEPROM data."
+        fi
+    elif [ -x /usr/bin/dmidecode ] ; then
+        pn="$(dmidecode -s system-product-name)"
+        if [ $? -eq 0 -a -n "$pn" ] ; then
+            echo $pn
         fi
     fi
 }

--- a/upstream/dmidecode-2.12.tar.gz.sha1
+++ b/upstream/dmidecode-2.12.tar.gz.sha1
@@ -1,1 +1,0 @@
-d190f1333e8a217cf02d2a6c98795dc5ced97ddc  dmidecode-2.12.tar.gz

--- a/upstream/dmidecode-3.1.tar.xz.sha1
+++ b/upstream/dmidecode-3.1.tar.xz.sha1
@@ -1,0 +1,1 @@
+d76b6897fda070965f61eff37c3f6bcf63b2b04d  dmidecode-3.1.tar.xz


### PR DESCRIPTION
For GRUB based architectures (x86_64 and arm64) fallback to using DMI/SMBIOS information when a system EEPROM is unavailable.
