### PR TITLE
gen-config: remove double quotes from onie_platform

### DIFF
--- a/rootconf/default/etc/init.d/gen-config.sh
+++ b/rootconf/default/etc/init.d/gen-config.sh
@@ -47,7 +47,7 @@ EOF
     local onie_platform="${onie_arch}-${onie_machine}-r${onie_machine_rev}"
     cat <<EOF >> $machine_conf
 onie_machine=$onie_machine
-onie_platform="$onie_platform"
+onie_platform=$onie_platform
 EOF
 
 }


### PR DESCRIPTION
Some old version of NOSes does not take double quotes into consideration
so that onie_platform extracted from recent machine.conf will have
double quotes that would be taken as an unsupported platform.

The original onie_platform was not surrounded by double quotes.  The
patch changes it back to the original format.