### PR TITLE
onie-fwpkg: correct preservation of update records

### DIFF
--- a/installer/grub-arch/install-arch
+++ b/installer/grub-arch/install-arch
@@ -731,8 +731,8 @@ install_image()
         exit 1
     }
 
-    # Create basic directories for installing and logging
-    mkdir -p $onie_root_dir $onie_update_dir $onie_update_results_dir $onie_update_pending_dir
+    # Create ONIE data directory
+    mkdir -p $onie_root_dir
 
     # Put the ONIE kernel and initramfs into place.
     kernel_name="vmlinuz-${image_kernel_version}-onie"
@@ -783,6 +783,9 @@ install_image()
     # Restore the previous update directory
     if [ "$preserve_update_dir" = "yes" ] ; then
         cp -a /tmp/preserve-update $onie_update_dir
+    else
+        # Create empty update logging directories
+        mkdir -p $onie_update_dir $onie_update_results_dir $onie_update_pending_dir
     fi
 
     # Return to default boot mode on the next boot.  Use this


### PR DESCRIPTION
The onie-fwpkg command is supposed to display the ONIE update (and
firmware update) history on the box.

During ONIE updates the entire ONIE data directory, which includes the
location of the ONIE update records, is reformatted.  During this
process the update records are first preserved and then, after the
reformatting, restored to the previous location.

However, the restore logic has a bug.

This patch fixes the bug, so that the restoration of update records
works as intended.

Closes: #679
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>