### PR TITLE
grub: make setting debug kernel arguments easier

### DIFF
--- a/installer/grub-arch/grub/grub-common.cfg
+++ b/installer/grub-arch/grub/grub-common.cfg
@@ -22,9 +22,6 @@ export onie_menu_embed
 
 set fallback="${onie_menu_rescue}"
 
-# default ONIE boot reason
-onie_boot_reason="install"
-
 onie_quiet="quiet"
 onie_linux="/onie/vmlinuz-${onie_kernel_version}-onie"
 onie_initrd="/onie/initrd.img-${onie_kernel_version}-onie"
@@ -65,11 +62,11 @@ function onie_bootcmd {
     return 1
   fi
   if [ -z "$GRUB_ONIE_CMDLINE_LINUX" ] ; then
-    onie_args="$onie_quiet $onie_initargs $onie_initargs_default $onie_platformargs $onie_debugargs $ONIE_EXTRA_CMDLINE_LINUX"
+    onie_args="$onie_quiet $onie_initargs $onie_initargs_default $onie_platformargs $ONIE_EXTRA_CMDLINE_LINUX"
   else
     onie_args="$GRUB_ONIE_CMDLINE_LINUX $ONIE_EXTRA_CMDLINE_LINUX"
   fi
-  linux   $onie_linux $onie_args boot_reason=$onie_boot_reason
+  linux   $onie_linux $onie_args boot_reason=$onie_boot_reason $onie_debugargs
   initrd  $onie_initrd
   onie_entry_end
   boot
@@ -129,22 +126,27 @@ elif [ "$onie_mode" = "diag" ] ; then
 fi
 
 menuentry "$onie_menu_install" {
+  onie_debugargs=""
   onie_install
 }
 
 menuentry "$onie_menu_rescue" {
+  onie_debugargs=""
   onie_rescue
 }
 
 menuentry "$onie_menu_uninstall" {
+  onie_debugargs=""
   onie_uninstall
 }
 
 menuentry "$onie_menu_update" {
+  onie_debugargs=""
   onie_update
 }
 
 menuentry "$onie_menu_embed" {
+  onie_debugargs=""
   onie_embed
 }
 


### PR DESCRIPTION
Since we call a GRUB shell function to generate the grub menu entries,
it is difficult to use the GRUB menu "edit" feature to append extra
args to the kernel.

For example, before this change, when editting the "Rescue" entry you
would see this:
```
            GNU GRUB  version 2.02

 +----------------------------------------------+
 |setparams 'ONIE: Rescue'                      |
 |                                              |
 |  onie_rescue                                 |
 +----------------------------------------------+
```
No clue how to add extra args with that definition.

This patch adds an empty "onie_debugargs=" setting to every GRUB menu
item.  To temporarily add additional kernel args, add values to
onie_debugargs.

After this change, the editting screen looks like
```
            GNU GRUB  version 2.02

 +----------------------------------------------+
 |setparams 'ONIE: Rescue'                      |
 |                                              |
 |  onie_debugargs=""                           |
 |  onie_rescue                                 |
```

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>