### PR TITLE
demo: support UEFI secure boot installs

### DIFF
--- a/build-config/scripts/mk-grub-efi-image
+++ b/build-config/scripts/mk-grub-efi-image
@@ -91,6 +91,15 @@ GRUB_MODULES="
 	zfsinfo
 "
 
+# Make an embedded config that reads a grub.cfg from the EFI directory
+# where the final grub binary is running.
+tmp_config=$(mktemp)
+cat <<EOF > $tmp_config
+configfile \$cmdpath/grub.cfg
+EOF
+
 "$grub_mkimage" --format="${ARCH}-efi" --directory="$GRUB_TARGET_LIB_UEFI_DIR" \
-                --prefix="/EFI/onie" --output="$OUTPUT_IMAGE" \
+                --prefix="/bogus" --config="$tmp_config" --output="$OUTPUT_IMAGE" \
                 $GRUB_MODULES
+
+rm -f $tmp_config

--- a/demo/installer/grub-arch/install.sh
+++ b/demo/installer/grub-arch/install.sh
@@ -253,26 +253,59 @@ demo_install_uefi_grub()
         exit 1
     }
 
-    grub_install_log=$(mktemp)
-    grub-install \
-        --no-nvram \
-        --bootloader-id="$demo_volume_label" \
-        --efi-directory="/boot/efi" \
-        --boot-directory="$demo_mnt" \
-        --recheck \
-        "$blk_dev" > /$grub_install_log 2>&1 || {
-        echo "ERROR: grub-install failed on: $blk_dev"
-        cat $grub_install_log && rm -f $grub_install_log
-        exit 1
-    }
-    rm -f $grub_install_log
+    if [ "$onie_secure_boot" = "yes" ] ; then
+        # ONIE is booting via shim, so the demo needs to also
+        local loader_dir="/boot/efi/EFI/$demo_volume_label"
+        mkdir -p "$loader_dir" || {
+            echo "ERROR: Unable to create directory: $loader_dir"
+            exit 1
+        }
+        # Use ONIE's .efi binaries
+        cp -a /boot/efi/EFI/onie/*${onie_uefi_arch}.efi "$loader_dir" || {
+            echo "ERROR: Unable to copy ONIE .efi binaries to: $loader_dir"
+            exit 1
+        }
+
+        local demo_boot_uuid=$(grub-probe --target=fs_uuid $demo_mnt) || {
+            echo "ERROR: Unable to determine UUID of GRUB boot directory: $demo_mnt"
+            return 1
+        }
+
+        # Generate tiny grub config for monolithic image
+        cat<< EOF > "${loader_dir}/grub.cfg"
+search.fs_uuid $demo_boot_uuid root
+echo "Search for uuid $demo_boot_uuid"
+ecoh "Found root: \$root"
+set prefix=(\$root)'/grub'
+configfile \$prefix/grub.cfg
+EOF
+
+        # Install primary grub config in $demo_mnt
+        grub_dir="${demo_mnt}/grub"
+        mkdir -p "${grub_dir}/fonts" "${grub_dir}/locale"
+    else
+        # Regular GRUB install
+        grub_install_log=$(mktemp)
+        grub-install \
+            --no-nvram \
+            --bootloader-id="$demo_volume_label" \
+            --efi-directory="/boot/efi" \
+            --boot-directory="$demo_mnt" \
+            --recheck \
+            "$blk_dev" > /$grub_install_log 2>&1 || {
+            echo "ERROR: grub-install failed on: $blk_dev"
+            cat $grub_install_log && rm -f $grub_install_log
+            exit 1
+        }
+        rm -f $grub_install_log
+    fi
 
     # Configure EFI NVRAM Boot variables.  --create also sets the
     # new boot number as active.
     efibootmgr --quiet --create \
         --label "$demo_volume_label" \
         --disk $blk_dev --part $uefi_part \
-        --loader "/EFI/$demo_volume_label/${onie_grub_image_name}" || {
+        --loader "/EFI/$demo_volume_label/$onie_uefi_boot_loader" || {
         echo "ERROR: efibootmgr failed to create new boot variable on: $blk_dev"
         exit 1
     }


### PR DESCRIPTION
The recent work for UEFI secure boot broke how the DEMO OS installer
works.  The demo installer needed similar changes as the regular ONIE
installer to accommodate shimx64.efi and the monolithic grubx64.efi
binary.

In particular, the monolithic grubx64.efi binary with a hard coded
--prefix option was problematic to re-use in the DEMO OS context.

The fix here is to embed a grub.cfg into the monolithic image that
looks for another grub.cfg located in the same directory as the
grubx64.efi binary.

Fixes: a7b03d5, 0e56d23, b68ca41
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>