### PR TITLE
NOS installed mode

### DIFF
--- a/build-config/arch/armv8a.make
+++ b/build-config/arch/armv8a.make
@@ -58,7 +58,8 @@ endif
 
 ifeq ($(UEFI_ENABLE),yes)
   UPDATER_IMAGE_PARTS = $(UPDATER_VMLINUZ) $(UPDATER_INITRD) $(UPDATER_ONIE_TOOLS) \
-			$(ROOTCONFDIR)/grub-arch/sysroot-lib-onie/onie-blkdev-common
+			$(ROOTCONFDIR)/grub-arch/sysroot-lib-onie/onie-blkdev-common \
+			$(ROOTCONFDIR)/grub-arch/sysroot-lib-onie/nos-mode-arch
   UPDATER_IMAGE_PARTS_COMPLETE = $(KERNEL_INSTALL_STAMP) $(UPDATER_INITRD) $(UPDATER_ONIE_TOOLS)
 else
   UPDATER_IMAGE_PARTS = $(UPDATER_ITB) $(UPDATER_UBOOT)

--- a/build-config/arch/x86_64.make
+++ b/build-config/arch/x86_64.make
@@ -89,7 +89,8 @@ ifeq ($(PXE_EFI64_ENABLE),yes)
 endif
 
 UPDATER_IMAGE_PARTS = $(UPDATER_VMLINUZ) $(UPDATER_INITRD) $(UPDATER_ONIE_TOOLS) \
-			$(ROOTCONFDIR)/grub-arch/sysroot-lib-onie/onie-blkdev-common
+			$(ROOTCONFDIR)/grub-arch/sysroot-lib-onie/onie-blkdev-common \
+			$(ROOTCONFDIR)/grub-arch/sysroot-lib-onie/nos-mode-arch
 
 UPDATER_IMAGE_PARTS_COMPLETE = $(KERNEL_INSTALL_STAMP) $(UPDATER_INITRD) $(UPDATER_ONIE_TOOLS)
 

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -29,6 +29,7 @@ ONIE_TOOLS_DIR	= $(abspath ../tools)
 ONIE_SYSROOT_TOOLS_LIST = \
 	lib/onie \
 	bin/onie-boot-mode \
+	bin/onie-nos-mode \
 	bin/onie-fwpkg
 
 IMAGE_BIN_STAMP		= $(STAMPDIR)/image-bin

--- a/demo/installer/grub-arch/install.sh
+++ b/demo/installer/grub-arch/install.sh
@@ -466,3 +466,10 @@ umount $demo_mnt || {
 }
 
 cd /
+
+if [ "$demo_type" = "OS" ] ; then
+    # Set NOS mode if available -- skip this for diag installers
+    if [ -x /bin/onie-nos-mode ] ; then
+        /bin/onie-nos-mode -s
+    fi
+fi

--- a/demo/installer/u-boot-arch/install.sh
+++ b/demo/installer/u-boot-arch/install.sh
@@ -38,3 +38,10 @@ EOF
 fw_setenv -f -s /tmp/env.txt
 
 cd /
+
+# Set NOS mode if available.  For manufacturing diag installers, you
+# probably want to skip this step so that the system remains in ONIE
+# "installer" mode for installing a true NOS later.
+if [ -x /bin/onie-nos-mode ] ; then
+    /bin/onie-nos-mode -s
+fi

--- a/installer/grub-arch/grub/grub-common.cfg
+++ b/installer/grub-arch/grub/grub-common.cfg
@@ -1,6 +1,6 @@
 ## Begin grub-common.cfg
 
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2018 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2015,2016,2017 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -104,6 +104,14 @@ function reset_onie_mode {
 
 # Load environment variables
 load_env
+
+# The default GRUB boot entry is controlled by two persistent grub
+# environment variables, "onie_mode" and "onie_nos_mode".  If
+# onie_mode is set, it controls which GRUB menu to load by default.
+# If onie_mode is clear, then nos_mode is consulted.  If onie_nos_mode
+# is "yes", then the GRUB menu will default to "rescue" mode.  If both
+# variables are clear the default GRUB menu is "install mode".
+
 if [ "$onie_mode" = "install" ] ; then
    set default="${onie_menu_install}"
 elif [ "$onie_mode" = "uninstall" ] ; then
@@ -123,6 +131,11 @@ elif [ "$onie_mode" = "diag" ] ; then
        set default="${diag_menu}"
    fi
    reset_onie_mode
+else
+   # Consult nos_mode
+   if [ "$onie_nos_mode" = "yes" ] ; then
+      set default="${onie_menu_rescue}"
+   fi
 fi
 
 menuentry "$onie_menu_install" {

--- a/installer/grub-arch/install-arch
+++ b/installer/grub-arch/install-arch
@@ -1,6 +1,6 @@
 # x86_64 specific ONIE installer functions
 
-#  Copyright (C) 2014,2015,2016 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2015,2016,2018 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014,2015,2016 david_yang <david_yang@accton.com>
 #  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
 #  Copyright (C) 2014 Mandeep Sandhu <mandeep.sandhu@cyaninc.com>
@@ -866,6 +866,10 @@ install_image()
     # Return to default boot mode on the next boot.  Use this
     # installer's version of onie-boot-mode.
     $onie_root_dir/tools/bin/onie-boot-mode -q -o none
+    if [ "$onie_boot_reason" = "embed" ] ; then
+        # Also clear out the NOS mode
+        $onie_root_dir/tools/bin/onie-nos-mode -c
+    fi
 
     if [ -n "$post_install_hook" ]; then
         eval $post_install_hook || {

--- a/rootconf/default/bin/onie-nos-mode
+++ b/rootconf/default/bin/onie-nos-mode
@@ -1,0 +1,135 @@
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Get/set the NOS mode
+
+this_script=$(basename $(realpath $0))
+lib_dir="$(dirname $(realpath $0))/../lib/onie"
+
+
+# Arch dependent NOS mode set interface.  Implemented in
+# nos-mode-arch.
+nos_mode_set_arch()
+{
+    false
+}
+
+# Arch dependent NOS mode get interface.  Implemented in
+# nos-mode-arch.
+nos_mode_get_arch()
+{
+    false
+}
+
+# Arch dependent NOS mode clear interface.  Implemented in
+# nos-mode-arch.
+nos_mode_clear_arch()
+{
+    false
+}
+
+if [ -r "$lib_dir/nos-mode-arch" ] ; then
+    . "$lib_dir/nos-mode-arch"
+else
+    echo "ERROR: $this_script: unable to locate $lib_dir/nos-mode-arch"
+fi
+
+args="hcsgv"
+
+usage()
+{
+    echo "usage: $this_script [-s] [-c] [-g] [-v] [-h]"
+    cat <<EOF
+Get, set or clear the ONIE NOS mode.  When set, NOS mode indicates
+that a NOS has been installed.  When clear, NOS mode india tes that no
+NOS is installed.
+
+Without any arguments the default is to print the NOS mode.
+
+COMMAND LINE OPTIONS
+
+	-c
+		Clear the NOS mode.
+
+	-s
+                Set the NOS mode to true.
+
+	-g
+                Get the current NOS mode.
+
+	-v
+		Be verbose.  Print what is happening.
+
+	-h
+		Help.  Print this message.
+EOF
+}
+
+
+clear=no
+set=no
+get=no
+verbose=no
+
+while getopts "$args" a ; do
+    case $a in
+        h)
+            usage
+            exit 0
+            ;;
+        c)
+            clear=yes
+            ;;
+        s)
+            set=yes
+            ;;
+        g)
+            get=yes
+            ;;
+        v)
+            verbose=yes
+            ;;
+        *)
+            echo "Unknown argument: $a"
+            usage
+            exit 1
+    esac
+done
+
+if [ "$clear" = "yes" -a "$set" = "yes" ] ; then
+    echo "ERROR: $this_script: Only one of '-c' or '-s' can be specified"
+    exit 1
+fi
+
+if [ "$set" = "yes" ] ; then
+    [ "$verbose" = "yes" ] && echo "Enabling NOS mode."
+    nos_mode_set_arch || {
+        echo "ERROR: $this_script: Enabling NOS mode failed."
+        exit 1
+    }
+elif [ "$clear" = "yes" ] ; then
+    [ "$verbose" = "yes" ] && echo "Disabling NOS mode."
+    nos_mode_clear_arch || {
+        echo "ERROR: $this_script: Clearing NOS mode failed."
+        exit 1
+    }
+else
+    # default to displaying the current mode
+    get=yes
+fi
+
+if [ "$get" = "yes" ] ; then
+    mode=$(nos_mode_get_arch) || {
+        echo "ERROR: $this_script: Reading NOS mode failed."
+        exit 1
+    }
+    mode=${mode:-none}
+    if [ "$verbose" = "yes" ] ; then
+        echo "Current NOS mode: $mode"
+    else
+        echo "$mode"
+    fi
+fi

--- a/rootconf/default/bin/onie-uninstaller
+++ b/rootconf/default/bin/onie-uninstaller
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2018 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -43,6 +43,9 @@ uninstall_system || {
     printf "${log_pre}ERROR: Problems uninstalling system..."
     exit 1
 }
+
+# Clear the NOS mode
+onie-nos-mode -c
 
 printf "${log_pre}Uninstall complete.  Rebooting...\n"
 

--- a/rootconf/grub-arch/sysroot-lib-onie/boot-mode-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/boot-mode-arch
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  Copyright (C) 2014-2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2015,2018 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2015 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
@@ -15,6 +15,24 @@
 rescue_revert_default_arch()
 {
     return 0
+}
+
+# Check whether we are running in NOS mode (after a successful NOS
+# install) or not.  If we are running in NOS mode, then make
+# architecture specific changes to turn the current install mode into
+# a one time operation.
+check_nos_mode_arch()
+{
+    local nos_mode="$(onie-nos-mode -g)"
+    if [ "$nos_mode" = "yes" ] ; then
+        # Clear the current boot mode to prevent install mode from
+        # being sticky.
+        onie-boot-mode -q -o none
+        return 0
+    fi
+
+    # non-zero indicates NOS mode was not set
+    return 1
 }
 
 # We want install mode booting to be sticky, e.g. if you boot into

--- a/rootconf/grub-arch/sysroot-lib-onie/nos-mode-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/nos-mode-arch
@@ -1,0 +1,34 @@
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# GRUB architecture implementation for manipulating the NOS mode.
+
+if [ -r "$lib_dir/onie-blkdev-common" ] ; then
+    . "$lib_dir/onie-blkdev-common"
+else
+    echo "ERROR: $this_script: unable to locate $lib_dir/onie-blkdev-common"
+fi
+
+# Arch dependent NOS mode set interface.  Implemented in
+# nos-mode-arch.
+nos_mode_set_arch()
+{
+    onie_setenv onie_nos_mode "yes"
+    # Also set ONIE boot mode to 'none'
+    onie-boot-mode -q -o none
+}
+
+# Arch dependent NOS mode get interface.  Implemented in
+# nos-mode-arch.
+nos_mode_get_arch()
+{
+    onie_getenv onie_nos_mode
+}
+
+# Arch dependent NOS mode clear interface.  Implemented in
+# nos-mode-arch.
+nos_mode_clear_arch()
+{
+    onie_setenv onie_nos_mode
+}

--- a/rootconf/u-boot-arch/sysroot-bin/onie-env-get
+++ b/rootconf/u-boot-arch/sysroot-bin/onie-env-get
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-#  Copyright (C) 2014,2015 Curt Brune <curt@cumulusnetworks.com>
-#
-#  SPDX-License-Identifier:     GPL-2.0
-
-# wrapper for fw_printenv
-/usr/sbin/fw_printenv "$@"

--- a/rootconf/u-boot-arch/sysroot-bin/onie-env-set
+++ b/rootconf/u-boot-arch/sysroot-bin/onie-env-set
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-#  Copyright (C) 2014,2015 Curt Brune <curt@cumulusnetworks.com>
-#
-#  SPDX-License-Identifier:     GPL-2.0
-
-# wrapper for fw_setenv
-/usr/sbin/fw_setenv "$@"

--- a/rootconf/u-boot-arch/sysroot-lib-onie/boot-mode-arch
+++ b/rootconf/u-boot-arch/sysroot-lib-onie/boot-mode-arch
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  Copyright (C) 2014,2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014,2015,2018 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -15,6 +15,25 @@ rescue_revert_default_arch()
     # The onie_boot_reason variable may not be set, which is ok.
     # Ignore failures.
     return 0
+}
+
+# Check whether we are running in NOS mode (after a successful NOS
+# install) or not.  If we are running in NOS mode, then make
+# architecture specific changes to turn the current install mode into
+# a one time operation.
+check_nos_mode_arch()
+{
+    local nos_mode="$(onie-nos-mode -g)"
+    if [ "$nos_mode" = "yes" ] ; then
+        # Clear the current boot reason to prevent install mode from
+        # being sticky.
+        fw_setenv -f onie_boot_reason > /dev/null 2>&1
+        # The onie_boot_reason variable may not be set, which is ok.
+        return 0
+    fi
+
+    # non-zero indicates NOS mode was not set
+    return 1
 }
 
 # We want install mode booting to be sticky, i.e. if you boot into

--- a/rootconf/u-boot-arch/sysroot-lib-onie/nos-mode-arch
+++ b/rootconf/u-boot-arch/sysroot-lib-onie/nos-mode-arch
@@ -1,0 +1,26 @@
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# U-Boot architecture implementation for manipulating the NOS mode.
+
+# Arch dependent NOS mode set interface.  Implemented in
+# nos-mode-arch.
+nos_mode_set_arch()
+{
+    fw_setenv -f onie_nos_mode "yes"
+}
+
+# Arch dependent NOS mode get interface.  Implemented in
+# nos-mode-arch.
+nos_mode_get_arch()
+{
+    fw_printenv -n onie_nos_mode 2> /dev/null || true
+}
+
+# Arch dependent NOS mode clear interface.  Implemented in
+# nos-mode-arch.
+nos_mode_clear_arch()
+{
+    fw_setenv -f onie_nos_mode > /dev/null 2>&1
+}


### PR DESCRIPTION
    This patch adds the notion of "NOS installed" mode.  This persistent
    state is set to true after a successful NOS install.
    
    This patch changes the following behavior for all CPU architectures:
    
    1. Upon a successful NOS install, the system sets a persistent
       environment variable, onie_nos_mode, to "yes".
    
    2. When onie_nos_mode is 'yes', entering install mode is no longer
       sticky. I.e. entering install mode is no longer a one-way trap
       door.
    
    Furthermore, for GRUB architectures, the default GRUB menu item now
    defaults to "rescue" mode, instead of "install" mode.
    
    For GRUB architectures, this patch adds an "-n" option to the
    "onie-boot-mode" command to set the persistent NOS installed boot
    mode.  The NOS mode is consulted when no default boot mode is set.
    
    The default GRUB boot entry is now controlled by two persistent grub
    environment variables, "onie_mode" and "onie_nos_mode".
    
    Previously, only the onie_mode variable existed.  Its usage is
    unchanged by this commit.  If onie_mode is set, it controls which GRUB
    menu to load by default.
    
    If onie_mode is clear, then the new variable, 'onie_nos_mode', is
    consulted.  If onie_nos_mode is "yes", then the GRUB menu will default
    to "rescue" mode.
    
    If both onie_mode and onie_nos_mode are clear then the default GRUB
    menu is "install mode".
    
    The idea here is make the default GRUB menu item and the "install"
    mode more forgiving when a NOS is installed.
