### PR TITLE
CLI cleanup

### DIFF
--- a/rootconf/default/bin/install_url
+++ b/rootconf/default/bin/install_url
@@ -1,1 +1,15 @@
-onie-nos-install
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Deprecated legacy command
+
+prog=$(basename $0)
+echo "NOTICE: The '$prog' command is deprecated and will be removed in 2019.02."
+
+new_prog=onie-nos-install
+echo "NOTICE: Use '$new_prog' instead."
+
+$new_prog "$@"

--- a/rootconf/default/bin/onie-discovery-start
+++ b/rootconf/default/bin/onie-discovery-start
@@ -1,8 +1,15 @@
 #!/bin/sh
 
-#  Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
-# Stop the discovery process
-/etc/init.d/discover.sh start
+# Deprecated legacy command
+
+prog=$(basename $0)
+echo "NOTICE: The '$prog' command is deprecated and will be removed in 2019.02."
+
+new_prog=onie-start
+echo "NOTICE: Use '$new_prog' instead."
+
+$new_prog "$@"

--- a/rootconf/default/bin/onie-discovery-stop
+++ b/rootconf/default/bin/onie-discovery-stop
@@ -1,8 +1,15 @@
 #!/bin/sh
 
-#  Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
-# Stop the discovery process
-/etc/init.d/discover.sh stop
+# Deprecated legacy command
+
+prog=$(basename $0)
+echo "NOTICE: The '$prog' command is deprecated and will be removed in 2019.02."
+
+new_prog=onie-stop
+echo "NOTICE: Use '$new_prog' instead."
+
+$new_prog "$@"

--- a/rootconf/default/bin/onie-start
+++ b/rootconf/default/bin/onie-start
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Stop the discovery process
+/etc/init.d/discover.sh start

--- a/rootconf/default/bin/onie-stop
+++ b/rootconf/default/bin/onie-stop
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Stop the discovery process
+/etc/init.d/discover.sh stop

--- a/rootconf/default/bin/support
+++ b/rootconf/default/bin/support
@@ -1,1 +1,15 @@
-onie-support
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Deprecated legacy command
+
+prog=$(basename $0)
+echo "NOTICE: The '$prog' command is deprecated and will be removed in 2019.02."
+
+new_prog=onie-support
+echo "NOTICE: Use '$new_prog' instead."
+
+$new_prog "$@"

--- a/rootconf/default/bin/uninstaller
+++ b/rootconf/default/bin/uninstaller
@@ -1,1 +1,15 @@
-onie-uninstaller
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Deprecated legacy command
+
+prog=$(basename $0)
+echo "NOTICE: The '$prog' command is deprecated and will be removed in 2019.02."
+
+new_prog=onie-uninstaller
+echo "NOTICE: Use '$new_prog' instead."
+
+$new_prog "$@"

--- a/rootconf/default/bin/update_url
+++ b/rootconf/default/bin/update_url
@@ -1,1 +1,15 @@
-onie-self-update
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+# Deprecated legacy command
+
+prog=$(basename $0)
+echo "NOTICE: The '$prog' command is deprecated and will be removed in 2019.02."
+
+new_prog=onie-self-update
+echo "NOTICE: Use '$new_prog' instead."
+
+$new_prog "$@"


### PR DESCRIPTION
This PR cleans up a few CLI commands:

- renames `onie-discovery-[start|stop]` to `onie-[start|stop]`, keeping the old names for backward compatibility.

- adds "deprecated and this command will be removed in 2019.02" to several old command aliases.
