### PR TITLE
trivial: cleanup typos and white spaces

### DIFF
--- a/rootconf/default/bin/onie-nos-mode
+++ b/rootconf/default/bin/onie-nos-mode
@@ -44,7 +44,7 @@ usage()
     echo "usage: $this_script [-s] [-c] [-g] [-v] [-h]"
     cat <<EOF
 Get, set or clear the ONIE NOS mode.  When set, NOS mode indicates
-that a NOS has been installed.  When clear, NOS mode india tes that no
+that a NOS has been installed.  When clear, NOS mode indicates that no
 NOS is installed.
 
 Without any arguments the default is to print the NOS mode.
@@ -55,10 +55,10 @@ COMMAND LINE OPTIONS
 		Clear the NOS mode.
 
 	-s
-                Set the NOS mode to true.
+		Set the NOS mode to true.
 
 	-g
-                Get the current NOS mode.
+		Get the current NOS mode.
 
 	-v
 		Be verbose.  Print what is happening.


### PR DESCRIPTION
Clean up a typo and some white space problems introduced by commit
cf6e91cda5c5a.

Fixes: cf6e91cda5c5 ("NOS mode: a persistent NOS mode boot option")
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>