### PR TITLE
Add empty dir for mounting USB device

### DIFF
--- a/rootconf/default/etc/init.d/makedev.sh
+++ b/rootconf/default/etc/init.d/makedev.sh
@@ -97,3 +97,5 @@ if grep -q securityfs /proc/filesystems ; then
 fi
 
 mkdir -p $ONIE_RUN_DIR
+
+mkdir -p $ONIE_USB_DIR

--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -55,6 +55,9 @@ get_default_filenames() {
     echo -n "$paths"
 }
 
+# Define USB directory for mountpoint
+ONIE_USB_DIR="/mnt/usb"
+
 # Default ONIE server name
 onie_server_name="onie-server"
 


### PR DESCRIPTION
The directory can avoid user mount over issue.
It would be more clear when user want to mount USB.

Signed-off-by: Phil Huang <phil_huang@edge-core.com>