### PR TITLE
gen-config: remove comments from machine.conf

### DIFF
--- a/rootconf/default/etc/init.d/gen-config.sh
+++ b/rootconf/default/etc/init.d/gen-config.sh
@@ -26,17 +26,7 @@ gen_machine_config()
 
     gen_live_config > $live_conf
 
-    cat <<EOF > $machine_conf
-# /etc/machine.conf for onie
-
-#  Copyright (C) 2017 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2017 david_yang <david_yang@accton.com>
-#
-#  SPDX-License-Identifier:     GPL-2.0
-
-EOF
-
-    cat $build_conf $live_conf >> $machine_conf
+    cat $build_conf $live_conf > $machine_conf
     sed -i -e '/onie_machine=/d' $machine_conf
     sed -i -e '/onie_platform=/d' $machine_conf
 


### PR DESCRIPTION
Some NOSes do not accept '#' comments in config files. This causes the
installer to fail with a runtime error when parsing /etc/machine.conf

The original machine.conf did not contain comments. The patch changes
it back to the original format.