### PR TITLE
Update list of host build machine packages

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -514,7 +514,7 @@ DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools util-linux \
 				  dosfstools mtools pkg-config git wget help2man libexpat1 \
 				  libexpat1-dev fakeroot python-sphinx rst2pdf \
 				  libefivar-dev libnss3-tools libnss3-dev libpopt-dev \
-				  libssl-dev sbsigntool uuid-runtime
+				  libssl-dev sbsigntool uuid-runtime uuid-dev cpio
 
 PHONY += debian-prepare-build-host
 debian-prepare-build-host:


### PR DESCRIPTION
While building ONIE on a very minimal Debian 9 install, it was
discovered that a few essential host packages are missing.

Signed-off-by: Curt Brune <curt@cumulusnetworks.com>