### PR TITLE
docker-build: create ONIE build environment

### DIFF
--- a/contrib/build-env/Dockerfile
+++ b/contrib/build-env/Dockerfile
@@ -1,0 +1,43 @@
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  Modified with permission from Benayak Karki
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+FROM debian:9
+
+# Add initial development packages
+RUN apt-get update && apt-get install -y \
+    build-essential stgit u-boot-tools util-linux \
+    gperf device-tree-compiler python-all-dev xorriso \
+    autoconf automake bison flex texinfo libtool libtool-bin \
+    realpath gawk libncurses5 libncurses5-dev bc \
+    dosfstools mtools pkg-config git wget help2man libexpat1 \
+    libexpat1-dev fakeroot python-sphinx rst2pdf \
+    libefivar-dev libnss3-tools libnss3-dev libpopt-dev \
+    libssl-dev sbsigntool uuid-runtime uuid-dev cpio \
+    bsdmainutils curl sudo
+
+# Create build user
+RUN useradd -m -s /bin/bash build && \
+        adduser build sudo && \
+        echo "build:build" | chpasswd
+
+WORKDIR /home/build
+
+# Add /sbin and /usr/sbin to build user's path
+RUN echo export PATH="/sbin:/usr/sbin:\$PATH" >> .bashrc
+
+# Add common files, like .gitconfig
+COPY home .
+
+# Create /home/build/src as a mount point for sharing files with the
+# host system.
+RUN mkdir src
+
+# Make sure everything in /home/build is owned by the build user
+RUN chown -R build:build .
+
+USER build
+
+CMD ["/bin/bash", "--login"]

--- a/contrib/build-env/README.md
+++ b/contrib/build-env/README.md
@@ -1,0 +1,131 @@
+# Docker based ONIE Build Environment
+
+This Dockerfile creates a Debian 9 (stretch) build environment for
+ONIE.  The goal is to access a shell session as the 'build' user
+within the container environment and compile ONIE images.
+
+This example also clarifies how Docker could be used in a build
+workflow.
+
+Docker allows you to package an entire Linux environment into units
+called containers. Containers utilise [control
+groups](https://en.wikipedia.org/wiki/Cgroups "Wikipedia Cgroups"), a
+resource isolation & management feature of the Linux kernel, to
+execute their processes with allowances specific to their control
+group.
+
+## Container Preparation
+
+Install docker.io on your host system.  This varies by distribution,
+but for a Debian based system this looks like:
+```
+user@host:~$ sudo apt-get udpate
+user@host:~$ sudo apt-get install docker.io`
+```
+
+You may need to add your user id to the `docker` group.
+```
+user@host:~$ sudo adduser $USER docker
+```
+
+For that to take effect you have to logout and login again.
+Alternatively use `su - $USER` to avoid logging out.
+
+Build the image using Docker.  From the same directory as the
+Dockerfile run this:
+```
+user@host:~/src/onie/contrib/build-env$ docker build -t debian:build-env .
+```
+
+> Note: Should you want to rebuild the docker image after changing the
+> Dockerfile do this:
+* `docker stop onie`
+* `docker rm onie`
+
+Then run `docker build ...` again.
+
+Create a build directory on the host system that will be accessible
+from within the docker container.  Make sure the directory is
+write-able by the docker `build` user.
+
+```
+user@host:~$ mkdir --mode=0777 -p ${HOME}/src
+```
+
+This directory will be availabe from within the container as
+`/home/build/src`.
+
+## Login to Container
+
+Create a container from this image, and attach your terminal onto it.
+
+```
+user@host:~$ docker run -it -v ${HOME}/src:/home/build/src --name onie debian:build-env
+```
+
+The name of this container is `onie`.  You can use this name with the
+docker commands.
+
+After run the container, you should see a prompt that looks similar to
+this:
+
+```
+build@f1063a996da6:~$
+```
+
+> Note: Should you find yourself detached from your container
+> instance, you can use `docker attach onie` to re-attach onto a
+> running container.
+
+## Build Preparation
+As the `build` user, clone the ONIE repo using the provided
+`clone-onie` script:
+
+```
+build@f1063a996da6:~$ ./clone-onie
+```
+
+This clones the ONIE repo into `/home/build/src/onie`.
+
+Navigate to the ONIE build-config directory.
+
+```
+build@f1063a996da6:~$ cd src/onie/build-config
+build@f1063a996da6:~/src/onie/build-config$
+```
+
+## Building ONIE
+You are now ready to follow a target's build steps from the ONIE repository.
+
+Please review the 'INSTALL' file within a directory you'll find [here](https://github.com/opencomputeproject/onie/tree/master/machine "onie/machines").
+
+* For a KVM build: `make -j4 MACHINE=kvm_x86_64 all`
+
+* For an Accton platform: `make -j4 MACHINEROOT=../machine/accton MACHINE=accton_as7816_64x all`
+
+On the host system the ONIE build products are available in
+`${HOME}/src/onie/build/images`.
+
+```
+user@host:~$ ls -l ${HOME}/src/onie/build/images
+total 55116
+-rw-r--r-- 1 1000 1000  7557500 Apr  4 12:37 kvm_x86_64-r0.initrd
+-rw-r--r-- 1 1000 1000  3917760 Apr  4 12:35 kvm_x86_64-r0.vmlinuz
+-rw-r--r-- 1 1000 1000  3915856 Apr  4 12:35 kvm_x86_64-r0.vmlinuz.unsigned
+-rw-r--r-- 1 1000 1000 28704768 Apr  4 12:38 onie-recovery-x86_64-kvm_x86_64-r0.iso
+-rw-r--r-- 1 1000 1000 12330871 Apr  4 12:37 onie-updater-x86_64-kvm_x86_64-r0
+```
+
+## Caveats
+
+### .gitconfig
+
+The initial docker environment sets up a fake .gitconfig, defaulting
+to the name `Build User` with email `build@example.com`.  For serious
+development you will want to changes these to legitimate values.
+
+### user / group IDs
+
+The build user and group IDs within the container will not make sense
+when viewed from the host environment.  This is why the build
+directory is created with world writable permissions.

--- a/contrib/build-env/home/.gitconfig
+++ b/contrib/build-env/home/.gitconfig
@@ -1,0 +1,3 @@
+[user]
+	name = Build User
+	email = build@example.com

--- a/contrib/build-env/home/clone-onie
+++ b/contrib/build-env/home/clone-onie
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+#  Copyright (C) 2018 Curt Brune <curt@cumulusnetworks.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+ONIE_REPO="https://github.com/opencomputeproject/onie.git"
+DEST_DIR="/home/build/src/onie"
+
+mkdir -p $(dirname $DEST_DIR)
+git clone "$ONIE_REPO" "$DEST_DIR"


### PR DESCRIPTION
Create a docker container to use as an ONIE build environment.

See the README and Dockerfile for details.

Big thanks to Benayak Karki for providing the initial implementation
upon which this code based.

Closes: #724 #725
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>