### PR TITLE
onie-syseeprom: accept mixed case TLV hex codes

### DIFF
--- a/patches/busybox/dhcp-additional-options.patch
+++ b/patches/busybox/dhcp-additional-options.patch
@@ -12,7 +12,7 @@ Enable the send/receive of additional DHCP options:
   DHCP_DEFAULT_URL
 
 diff --git a/networking/udhcp/common.c b/networking/udhcp/common.c
-index 0cf4dab..ad4522d 100644
+index 0cf4dab63c55..ad4522deb0b0 100644
 --- a/networking/udhcp/common.c
 +++ b/networking/udhcp/common.c
 @@ -26,7 +26,7 @@ const struct dhcp_optflag dhcp_optflags[] = {
@@ -108,7 +108,7 @@ index 0cf4dab..ad4522d 100644
  	[OPTION_STRING_HOST] = 1,  /* ignored by udhcp_str2optset */
  #if ENABLE_FEATURE_UDHCP_RFC3397
 diff --git a/networking/udhcp/dhcpc.c b/networking/udhcp/dhcpc.c
-index fc7b621..838c809 100644
+index fc7b6216d777..838c8093e969 100644
 --- a/networking/udhcp/dhcpc.c
 +++ b/networking/udhcp/dhcpc.c
 @@ -114,6 +114,7 @@ static const uint8_t len_of_option_as_string[] ALIGN1 = {

--- a/patches/busybox/feature-flash-erase-command.patch
+++ b/patches/busybox/feature-flash-erase-command.patch
@@ -10,7 +10,7 @@ Removed flash_eraseall command as its functionality is covered with
 "flash_erase /dev/mtd2 0 0".
 
 diff --git a/include/applets.src.h b/include/applets.src.h
-index 267a8f3..b9df5a1 100644
+index 267a8f3032c8..b9df5a1b3449 100644
 --- a/include/applets.src.h
 +++ b/include/applets.src.h
 @@ -135,7 +135,7 @@ IF_FDISK(APPLET(fdisk, BB_DIR_SBIN, BB_SUID_DROP))
@@ -23,7 +23,7 @@ index 267a8f3..b9df5a1 100644
  IF_FLASH_UNLOCK(APPLET_ODDNAME(flash_unlock, flash_lock_unlock, BB_DIR_USR_SBIN, BB_SUID_DROP, flash_unlock))
  IF_FLASHCP(APPLET(flashcp, BB_DIR_USR_SBIN, BB_SUID_DROP))
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index e5bc701..4d6425f 100644
+index e5bc7013bdf8..4d6425f7652f 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -279,12 +279,13 @@ config FLASH_UNLOCK
@@ -45,7 +45,7 @@ index e5bc701..4d6425f 100644
  config IONICE
  	bool "ionice"
 diff --git a/miscutils/Kbuild.src b/miscutils/Kbuild.src
-index 25382f5..9177818 100644
+index 25382f57efc4..917781898d36 100644
 --- a/miscutils/Kbuild.src
 +++ b/miscutils/Kbuild.src
 @@ -19,7 +19,7 @@ lib-$(CONFIG_DEVMEM)      += devmem.o
@@ -59,7 +59,7 @@ index 25382f5..9177818 100644
  lib-$(CONFIG_IONICE)      += ionice.o
 diff --git a/miscutils/flash_erase.c b/miscutils/flash_erase.c
 new file mode 100644
-index 0000000..aec6d3c
+index 000000000000..aec6d3c45740
 --- /dev/null
 +++ b/miscutils/flash_erase.c
 @@ -0,0 +1,253 @@
@@ -318,7 +318,7 @@ index 0000000..aec6d3c
 +}
 diff --git a/miscutils/flash_eraseall.c b/miscutils/flash_eraseall.c
 deleted file mode 100644
-index d95d214..0000000
+index d95d214d914c..000000000000
 --- a/miscutils/flash_eraseall.c
 +++ /dev/null
 @@ -1,207 +0,0 @@

--- a/patches/busybox/feature-iorw-command.patch
+++ b/patches/busybox/feature-iorw-command.patch
@@ -8,7 +8,7 @@ Add the iorw command, which allows root to peek/poke arbitrary memory
 locations.
 
 diff --git a/include/applets.src.h b/include/applets.src.h
-index caf3c82..267a8f3 100644
+index caf3c8259eae..267a8f3032c8 100644
 --- a/include/applets.src.h
 +++ b/include/applets.src.h
 @@ -170,6 +170,7 @@ IF_INETD(APPLET(inetd, BB_DIR_USR_SBIN, BB_SUID_DROP))
@@ -20,7 +20,7 @@ index caf3c82..267a8f3 100644
   || ENABLE_FEATURE_IP_ROUTE \
   || ENABLE_FEATURE_IP_LINK \
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index 6821736..e5bc701 100644
+index 682173640853..e5bc7013bdf8 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -375,6 +375,13 @@ config FEATURE_HDPARM_HDIO_GETSET_DMA
@@ -38,7 +38,7 @@ index 6821736..e5bc701 100644
  	bool "makedevs"
  	default y
 diff --git a/miscutils/Kbuild.src b/miscutils/Kbuild.src
-index 5d42ede..25382f5 100644
+index 5d42ede9f252..25382f57efc4 100644
 --- a/miscutils/Kbuild.src
 +++ b/miscutils/Kbuild.src
 @@ -24,6 +24,7 @@ lib-$(CONFIG_FLASH_LOCK)     += flash_lock_unlock.o
@@ -51,7 +51,7 @@ index 5d42ede..25382f5 100644
  ifeq ($(CONFIG_FEATURE_LAST_FANCY),y)
 diff --git a/miscutils/iorw.c b/miscutils/iorw.c
 new file mode 100644
-index 0000000..c397159
+index 000000000000..c397159d89c7
 --- /dev/null
 +++ b/miscutils/iorw.c
 @@ -0,0 +1,255 @@

--- a/patches/busybox/feature-onie-syseeprom-command.patch
+++ b/patches/busybox/feature-onie-syseeprom-command.patch
@@ -8,7 +8,7 @@ SPDX-License-Identifier:     GPL-2.0
 
 diff --git a/include/24cXX.h b/include/24cXX.h
 new file mode 100644
-index 0000000..5fb4641
+index 000000000000..5fb4641379ea
 --- /dev/null
 +++ b/include/24cXX.h
 @@ -0,0 +1,66 @@
@@ -79,7 +79,7 @@ index 0000000..5fb4641
 +
 +#endif
 diff --git a/include/applets.src.h b/include/applets.src.h
-index b9df5a1..71b8cbd 100644
+index b9df5a1b3449..71b8cbd94b87 100644
 --- a/include/applets.src.h
 +++ b/include/applets.src.h
 @@ -344,6 +344,7 @@ IF_WC(APPLET(wc, BB_DIR_USR_BIN, BB_SUID_DROP))
@@ -92,7 +92,7 @@ index b9df5a1..71b8cbd 100644
  	&& !defined(MAKE_LINKS) && !defined(MAKE_SUID)
 diff --git a/include/i2c-dev.h b/include/i2c-dev.h
 new file mode 100644
-index 0000000..23f7c2c
+index 000000000000..23f7c2cf071c
 --- /dev/null
 +++ b/include/i2c-dev.h
 @@ -0,0 +1,330 @@
@@ -428,7 +428,7 @@ index 0000000..23f7c2c
 +#endif /* _LINUX_I2C_DEV_H */
 diff --git a/include/onie_tlvinfo.h b/include/onie_tlvinfo.h
 new file mode 100644
-index 0000000..b602736
+index 000000000000..b602736287ec
 --- /dev/null
 +++ b/include/onie_tlvinfo.h
 @@ -0,0 +1,172 @@
@@ -606,7 +606,7 @@ index 0000000..b602736
 +void show_tlv_code_list(void);
 diff --git a/include/sys_eeprom.h b/include/sys_eeprom.h
 new file mode 100644
-index 0000000..94dfd5a
+index 000000000000..94dfd5a6ff23
 --- /dev/null
 +++ b/include/sys_eeprom.h
 @@ -0,0 +1,2 @@
@@ -614,7 +614,7 @@ index 0000000..94dfd5a
 +int write_sys_eeprom(void *eeprom_data, int len);
 diff --git a/miscutils/24cXX.c b/miscutils/24cXX.c
 new file mode 100644
-index 0000000..ccc0965
+index 000000000000..ccc09652494b
 --- /dev/null
 +++ b/miscutils/24cXX.c
 @@ -0,0 +1,182 @@
@@ -801,7 +801,7 @@ index 0000000..ccc0965
 +	}
 +}
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index 4d6425f..cdae45b 100644
+index 4d6425f7652f..cdae45b750b1 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -546,4 +546,108 @@ config WATCHDOG
@@ -914,7 +914,7 @@ index 4d6425f..cdae45b 100644
 +
  endmenu
 diff --git a/miscutils/Kbuild.src b/miscutils/Kbuild.src
-index 9177818..a78273d 100644
+index 917781898d36..a78273de6ca7 100644
 --- a/miscutils/Kbuild.src
 +++ b/miscutils/Kbuild.src
 @@ -51,3 +51,6 @@ lib-$(CONFIG_TTYSIZE)     += ttysize.o
@@ -926,7 +926,7 @@ index 9177818..a78273d 100644
 +lib-$(CONFIG_SYS_EEPROM_DEVICE_MTD) += sys_eeprom_mtd.o
 diff --git a/miscutils/onie_tlvinfo.c b/miscutils/onie_tlvinfo.c
 new file mode 100644
-index 0000000..5cf6463
+index 000000000000..5cf646322444
 --- /dev/null
 +++ b/miscutils/onie_tlvinfo.c
 @@ -0,0 +1,743 @@
@@ -1675,7 +1675,7 @@ index 0000000..5cf6463
 +}
 diff --git a/miscutils/sys_eeprom.c b/miscutils/sys_eeprom.c
 new file mode 100644
-index 0000000..3003bd6
+index 000000000000..3003bd634ce9
 --- /dev/null
 +++ b/miscutils/sys_eeprom.c
 @@ -0,0 +1,181 @@
@@ -1862,7 +1862,7 @@ index 0000000..3003bd6
 +}
 diff --git a/miscutils/sys_eeprom_i2c.c b/miscutils/sys_eeprom_i2c.c
 new file mode 100644
-index 0000000..ed3235b
+index 000000000000..ed3235bcc1c8
 --- /dev/null
 +++ b/miscutils/sys_eeprom_i2c.c
 @@ -0,0 +1,63 @@
@@ -1931,7 +1931,7 @@ index 0000000..ed3235b
 +}
 diff --git a/miscutils/sys_eeprom_mtd.c b/miscutils/sys_eeprom_mtd.c
 new file mode 100644
-index 0000000..119d77c
+index 000000000000..119d77c15c5c
 --- /dev/null
 +++ b/miscutils/sys_eeprom_mtd.c
 @@ -0,0 +1,126 @@

--- a/patches/busybox/feature-onie-syseeprom-command.patch
+++ b/patches/busybox/feature-onie-syseeprom-command.patch
@@ -1,6 +1,6 @@
 Add to support onie-syseeprom command.
 
-Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
+Copyright (C) 2013,2018 Curt Brune <curt@cumulusnetworks.com>
 Copyright (C) 2014,2016,2017 david_yang <david_yang@accton.com>
 Copyright (C) 2015 Ellen Wang <ellen@cumulusnetworks.com>
 
@@ -1675,10 +1675,10 @@ index 000000000000..5cf646322444
 +}
 diff --git a/miscutils/sys_eeprom.c b/miscutils/sys_eeprom.c
 new file mode 100644
-index 000000000000..3003bd634ce9
+index 000000000000..e34abf59782e
 --- /dev/null
 +++ b/miscutils/sys_eeprom.c
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,185 @@
 +#include "libbb.h"
 +#include "onie_tlvinfo.h"
 +#include <getopt.h>
@@ -1738,7 +1738,7 @@ index 000000000000..3003bd634ce9
 +    const size_t tlv_code_count = sizeof(tlv_code_list) /
 +	sizeof(tlv_code_list[0]);
 +
-+    char *tokens[tlv_code_count + 1];
++    char *tokens[(tlv_code_count*2) + 1];
 +    const char *short_options = "hels:g:";
 +    const struct option long_options[] = {
 +	{"help",    no_argument,          0,    'h'},
@@ -1750,10 +1750,13 @@ index 000000000000..3003bd634ce9
 +    };
 +
 +    for (i = 0; i < tlv_code_count; i++) {
-+	    tokens[i] = (char *) malloc(6);
-+	    sprintf(tokens[i], "0x%x", tlv_code_list[i].m_code);
++	    tokens[i*2] = malloc(6);
++	    snprintf(tokens[(i*2)], 6,     "0x%x", tlv_code_list[i].m_code);
++	    /* Allow for uppercase hex digits as well */
++	    tokens[(i*2) + 1] = malloc(6);
++	    snprintf(tokens[(i*2) + 1], 6, "0x%X", tlv_code_list[i].m_code);
 +    }
-+    tokens[tlv_code_count] = NULL;
++    tokens[tlv_code_count*2] = NULL;
 +
 +    while (TRUE) {
 +	c = getopt_long(argc, argv, short_options,
@@ -1856,7 +1859,8 @@ index 000000000000..3003bd634ce9
 +    }
 +syseeprom_err:
 +    for (i = 0; i < tlv_code_count; i++) {
-+	free(tokens[i]);
++	free(tokens[i*2]);
++	free(tokens[(i*2) + 1]);
 +    }
 +    return  (err == 0) ? 0 : 1;
 +}

--- a/patches/busybox/feature-onie-syseeprom-disk.patch
+++ b/patches/busybox/feature-onie-syseeprom-disk.patch
@@ -1,7 +1,7 @@
 Support "eeprom" on disk for platforms without a real eeprom.
 
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index cdae45b..290046a 100644
+index cdae45b750b1..290046a217c2 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -568,6 +568,9 @@ config SYS_EEPROM_DEVICE_I2C
@@ -50,7 +50,7 @@ index cdae45b..290046a 100644
  	default 2048
  	depends on SYS_EEPROM
 diff --git a/miscutils/Kbuild.src b/miscutils/Kbuild.src
-index a78273d..8ff4e98 100644
+index a78273de6ca7..8ff4e9853415 100644
 --- a/miscutils/Kbuild.src
 +++ b/miscutils/Kbuild.src
 @@ -54,3 +54,4 @@ lib-$(CONFIG_WATCHDOG)    += watchdog.o
@@ -60,7 +60,7 @@ index a78273d..8ff4e98 100644
 +lib-$(CONFIG_SYS_EEPROM_DEVICE_DISK) += sys_eeprom_disk.o
 diff --git a/miscutils/sys_eeprom_disk.c b/miscutils/sys_eeprom_disk.c
 new file mode 100644
-index 0000000..440b490
+index 000000000000..440b490b4824
 --- /dev/null
 +++ b/miscutils/sys_eeprom_disk.c
 @@ -0,0 +1,112 @@

--- a/patches/busybox/feature-onie-syseeprom-sysfs.patch
+++ b/patches/busybox/feature-onie-syseeprom-sysfs.patch
@@ -1,7 +1,7 @@
 Support for reading and writing sysfs based eeprom entries
 
 diff --git a/include/onie_tlvinfo.h b/include/onie_tlvinfo.h
-index b602736..2713b86 100644
+index b602736287ec..2713b8602443 100644
 --- a/include/onie_tlvinfo.h
 +++ b/include/onie_tlvinfo.h
 @@ -143,6 +143,7 @@ static inline const char* tlv_type2name(u_int8_t type)
@@ -13,7 +13,7 @@ index b602736..2713b86 100644
  #define SYS_EEPROM_OFFSET            CONFIG_SYS_EEPROM_OFFSET
  
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index 290046a..e97b0c3 100644
+index 290046a217c2..e97b0c3c24d0 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -571,6 +571,9 @@ config SYS_EEPROM_DEVICE_MTD
@@ -41,7 +41,7 @@ index 290046a..e97b0c3 100644
  	int "offset"
  	range 0 0 if SYS_EEPROM_DEVICE_DISK
 diff --git a/miscutils/Kbuild.src b/miscutils/Kbuild.src
-index 8ff4e98..72ddcd1 100644
+index 8ff4e9853415..72ddcd1ce9bf 100644
 --- a/miscutils/Kbuild.src
 +++ b/miscutils/Kbuild.src
 @@ -55,3 +55,4 @@ lib-$(CONFIG_SYS_EEPROM)  += sys_eeprom.o onie_tlvinfo.o
@@ -51,7 +51,7 @@ index 8ff4e98..72ddcd1 100644
 +lib-$(CONFIG_SYS_EEPROM_SYSFS_FILE) += sys_eeprom_sysfs_file.o
 diff --git a/miscutils/sys_eeprom_sysfs_file.c b/miscutils/sys_eeprom_sysfs_file.c
 new file mode 100644
-index 0000000..68f33c9
+index 000000000000..68f33c9cd51b
 --- /dev/null
 +++ b/miscutils/sys_eeprom_sysfs_file.c
 @@ -0,0 +1,85 @@

--- a/patches/busybox/fw_env-modify-crc-size-in-getenvsize.patch
+++ b/patches/busybox/fw_env-modify-crc-size-in-getenvsize.patch
@@ -1,6 +1,4 @@
 From 4e8f2e4f5974b75b3c2c876e1da6cc815036f1f6 Mon Sep 17 00:00:00 2001
-From: Zhao Qiang <qiang.zhao@nxp.com>
-Date: Thu, 21 Dec 2017 15:00:58 +0800
 Subject: [PATCH] fw_env: modify crc size in getenvsize
 
 In functin getenvsize, crc size is calcultated by sizeof(long),
@@ -13,12 +11,9 @@ long is the same size with uint32_t in some machines, but different
 in other machines, so modify it with sizeof(uint32_t)
 
 Signed-off-by: Zhao Qiang <qiang.zhao@nxp.com>
----
- miscutils/fw_env.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/miscutils/fw_env.c b/miscutils/fw_env.c
-index f6f0d27..777c369 100644
+index f6f0d2743c36..777c3697e4a5 100644
 --- a/miscutils/fw_env.c
 +++ b/miscutils/fw_env.c
 @@ -122,7 +122,7 @@ static int get_config (const char *);
@@ -30,6 +25,3 @@ index f6f0d27..777c369 100644
  
  	if (HaveRedundEnv)
  		rc -= sizeof (char);
--- 
-2.7.4
-

--- a/patches/busybox/gitignore.patch
+++ b/patches/busybox/gitignore.patch
@@ -7,7 +7,7 @@ SPDX-License-Identifier:     GPL-2.0
 
 diff --git a/.gitignore b/.gitignore
 new file mode 100644
-index 0000000..8e70baa
+index 000000000000..8e70baa4dc12
 --- /dev/null
 +++ b/.gitignore
 @@ -0,0 +1,83 @@

--- a/patches/busybox/series
+++ b/patches/busybox/series
@@ -1,4 +1,4 @@
-# This series applies on GIT commit fb8a447418ef69d7b2d08b0a534d0703c2fc3a0d
+# This series applies on GIT commit 842840d74efd22f48c23093c11722d7b5a64f48e
 gitignore.patch
 u-boot-env-tools.patch
 fw_env-modify-crc-size-in-getenvsize.patch

--- a/patches/busybox/series
+++ b/patches/busybox/series
@@ -1,4 +1,4 @@
-# This series applies on GIT commit 842840d74efd22f48c23093c11722d7b5a64f48e
+# This series applies on GIT commit 6bbd082c82c805ed17d4270ed18e41b5545c189b
 gitignore.patch
 u-boot-env-tools.patch
 fw_env-modify-crc-size-in-getenvsize.patch

--- a/patches/busybox/u-boot-env-tools.patch
+++ b/patches/busybox/u-boot-env-tools.patch
@@ -5,7 +5,7 @@ Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
 SPDX-License-Identifier:     GPL-2.0
 
 diff --git a/include/applets.src.h b/include/applets.src.h
-index 6e1b02f..caf3c82 100644
+index 6e1b02fc399c..caf3c8259eae 100644
 --- a/include/applets.src.h
 +++ b/include/applets.src.h
 @@ -321,6 +321,8 @@ IF_TRUE(APPLET_NOFORK(true, true, BB_DIR_BIN, BB_SUID_DROP, true))
@@ -19,7 +19,7 @@ index 6e1b02f..caf3c82 100644
  IF_UDPSVD(APPLET_ODDNAME(udpsvd, tcpudpsvd, BB_DIR_USR_BIN, BB_SUID_DROP, udpsvd))
 diff --git a/include/fw_env.h b/include/fw_env.h
 new file mode 100644
-index 0000000..ffec527
+index 000000000000..ffec527b4f2e
 --- /dev/null
 +++ b/include/fw_env.h
 @@ -0,0 +1,52 @@
@@ -76,7 +76,7 @@ index 0000000..ffec527
 +extern char *fw_getenv  (char *name);
 +extern int fw_setenv  (int argc, char *argv[]);
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index 06f1c52..6821736 100644
+index 06f1c52ba053..682173640853 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -513,6 +513,13 @@ config TTYSIZE
@@ -94,7 +94,7 @@ index 06f1c52..6821736 100644
  	bool "volname"
  	default y
 diff --git a/miscutils/Kbuild.src b/miscutils/Kbuild.src
-index 503f549..5d42ede 100644
+index 503f549047b6..5d42ede9f252 100644
 --- a/miscutils/Kbuild.src
 +++ b/miscutils/Kbuild.src
 @@ -47,5 +47,6 @@ lib-$(CONFIG_STRINGS)     += strings.o
@@ -106,7 +106,7 @@ index 503f549..5d42ede 100644
  lib-$(CONFIG_WATCHDOG)    += watchdog.o
 diff --git a/miscutils/fw_env.c b/miscutils/fw_env.c
 new file mode 100644
-index 0000000..f6f0d27
+index 000000000000..f6f0d2743c36
 --- /dev/null
 +++ b/miscutils/fw_env.c
 @@ -0,0 +1,1259 @@


### PR DESCRIPTION
Previously, the onie-syseeprom "--set" argument only accepted lower case TLV hex code.  This patch accepts both lower and upper case hex codes.

Closes: #731
