### PR TITLE
discover: enclose IPv6 address URLs in square brackets

### DIFF
--- a/rootconf/default/bin/discover
+++ b/rootconf/default/bin/discover
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2018 Curt Brune <curt@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -56,7 +56,7 @@ neigh_discovery()
     # gather IPv4 neighbors
     ip -4 neigh show | awk '{print $1}' | tr '\n' ',' >> $onie_neigh_file
     # gather IPv6 neighbors
-    ip -6 neigh show | awk '{print $1 "-" $3}' | tr '\n' ',' >> $onie_neigh_file
+    ip -6 neigh show | awk '{print "[" $1 "-" $3 "]"}' | tr '\n' ',' >> $onie_neigh_file
     echo -n "##" >> $onie_neigh_file
     log_debug_msg "onie_neighs: $(cat $onie_neigh_file)"
 }

--- a/rootconf/default/bin/exec_installer
+++ b/rootconf/default/bin/exec_installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  Copyright (C) 2013-2015 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2013,2014,2015,2018 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2014 Matt Peterson <matt-github@peterson.org>
 #  Copyright (C) 2014,2015,2016,2017 david_yang <david_yang@accton.com>
 #
@@ -202,8 +202,10 @@ tftp_run()
     BOOTFILE=$2
 
     URL="tftp://$SERVER/$BOOTFILE"
+    # escape any % characters for printing with printf
+    print_exec_url=$(echo -n $URL | sed -e 's/%/%%/g')
     log_debug_msg "Running tftp get with: server: $SERVER, bootfile: $BOOTFILE"
-    log_info_msg "Attempting $URL ..."
+    log_info_msg "Attempting $print_exec_url ..."
     if [ "$onie_verbose" = "y" ] || [ "$from_cli" = "yes" ] ; then
         tftp_wrap -g -l $onie_installer -r $BOOTFILE $SERVER && run_installer "$URL" && return 0
     else


### PR DESCRIPTION
From RFC-3986, IPv6 address in URLs must be enclosed in square
brackets:

https://tools.ietf.org/html/rfc3986#section-3.2.2

The discover URLs now look like:

  http://[fe80::ae1f:6bff:fe0a:134a%eth0]/onie-installer-x86_64-bcm
  http://[fe80::ae1f:6bff:fe0a:134a%eth0]/onie-installer-x86_64-bcm.bin
  http://[fe80::ae1f:6bff:fe0a:134a%eth0]/onie-installer-x86_64
  http://[fe80::ae1f:6bff:fe0a:134a%eth0]/onie-installer-x86_64.bin
  http://[fe80::ae1f:6bff:fe0a:134a%eth0]/onie-installer
  http://[fe80::ae1f:6bff:fe0a:134a%eth0]/onie-installer.bin
  ...

Closes: #733
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>