### PR TITLE
onie-nos-mode: make callable from onie tools directory

### DIFF
--- a/rootconf/default/bin/onie-nos-mode
+++ b/rootconf/default/bin/onie-nos-mode
@@ -7,6 +7,7 @@
 # Get/set the NOS mode
 
 this_script=$(basename $(realpath $0))
+bin_dir="$(dirname $(realpath $0))"
 lib_dir="$(dirname $(realpath $0))/../lib/onie"
 
 

--- a/rootconf/grub-arch/sysroot-lib-onie/nos-mode-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/nos-mode-arch
@@ -16,7 +16,7 @@ nos_mode_set_arch()
 {
     onie_setenv onie_nos_mode "yes"
     # Also set ONIE boot mode to 'none'
-    onie-boot-mode -q -o none
+    ${bin_dir}/onie-boot-mode -q -o none
 }
 
 # Arch dependent NOS mode get interface.  Implemented in


### PR DESCRIPTION
The onie-nos-mode utility is included in the persistent ONIE tools
directory, /mnt/onie-boot/onie/tools/bin, so that a NOS can directly
access it.

The initial implementation did not account for the fact that
onie-nos-mode also calls out to the 'onie-boot-mode' command.  When
called from the NOS, onie-boot-mode is not in the $PATH variable.

This patch uses the assumption that onie-boot-mode and onie-nos-mode
both resided in the same directory to call onie-boot-mode directly.

Fixes: cf6e91cda5c5 ("NOS mode: a persistent NOS mode boot option")
Signed-off-by: Curt Brune <curt@cumulusnetworks.com>