### PR TITLE
Compilation fixes for glibc2.27 and Perl 5.26

### DIFF
--- a/patches/crosstool-NG/local/automake/1.15/perl.patch
+++ b/patches/crosstool-NG/local/automake/1.15/perl.patch
@@ -1,0 +1,23 @@
+Without this change, Perl 5.22 complains "Unescaped left brace in
+regex is deprecated" and this is planned to become a hard error in
+Perl 5.26.  See:
+http://search.cpan.org/dist/perl-5.22.0/pod/perldelta.pod#A_literal_%22{%22_should_now_be_escaped_in_a_pattern
+* bin/automake.in (substitute_ac_subst_variables): Escape left brace.
+
+Backported from:
+http://git.savannah.gnu.org/cgit/automake.git/commit/?id=13f00eb4493c217269b76614759e452d8302955e
+Original author: Paul Eggert <eggert@cs.ucla.edu>
+Signed-off-by: Adam Duskett <aduskett@gmail.com>
+
+diff --git a/bin/automake.in b/bin/automake.in
+index a3a0aa3..2c8f31e 100644
+--- a/bin/automake.in
++++ b/bin/automake.in
+@@ -3878,7 +3878,7 @@ sub substitute_ac_subst_variables_worker
+ sub substitute_ac_subst_variables
+ {
+   my ($text) = @_;
+-  $text =~ s/\${([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
++  $text =~ s/\$[{]([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
+   return $text;
+ }

--- a/patches/crosstool-NG/local/make/4.2.1/glibc-2.27-glob.patch
+++ b/patches/crosstool-NG/local/make/4.2.1/glibc-2.27-glob.patch
@@ -1,0 +1,32 @@
+From http://www.linuxfromscratch.org/lfs/view/development/chapter05/make.html
+--- a/glob/glob.c.old	2018-06-10 14:34:22.950461728 +0200
++++ b/glob/glob.c	2018-06-10 14:34:25.156423130 +0200
+@@ -208,28 +208,9 @@
+ #endif /* __GNU_LIBRARY__ || __DJGPP__ */
+ 
+ 
+-#if !defined __alloca && !defined __GNU_LIBRARY__
+-
+-# ifdef	__GNUC__
+-#  undef alloca
+-#  define alloca(n)	__builtin_alloca (n)
+-# else	/* Not GCC.  */
+-#  ifdef HAVE_ALLOCA_H
+ #   include <alloca.h>
+-#  else	/* Not HAVE_ALLOCA_H.  */
+-#   ifndef _AIX
+-#    ifdef WINDOWS32
+-#     include <malloc.h>
+-#    else
+-extern char *alloca ();
+-#    endif /* WINDOWS32 */
+-#   endif /* Not _AIX.  */
+-#  endif /* sparc or HAVE_ALLOCA_H.  */
+-# endif	/* GCC.  */
+-
+ # define __alloca	alloca
+ 
+-#endif
+ 
+ #ifndef __GNU_LIBRARY__
+ # define __stat stat

--- a/patches/grub/2.02/gcc8.patch
+++ b/patches/grub/2.02/gcc8.patch
@@ -1,0 +1,64 @@
+When building with GCC 8, there are several errors regarding packed-not-aligned.
+
+
+./include/grub/gpt_partition.h:79:1: error: alignment 1 of ‘struct 
+grub_gpt_partentry’ is less than 8 [-Werror=packed-not-aligned]
+
+This patch tries to fix the build error by cleaning up the ambiguity of placing
+aligned structure in a packed one. In "struct grub_btrfs_time" and "struct
+grub_gpt_part_type", the aligned attribute seems to be superfluous, and also
+has to be packed, to ensure the structure is bit-to-bit mapped to the format
+laid on disk. I think we could blame to copy and paste error here for the
+mistake. In "struct efi_variable", we have to use grub_efi_packed_guid_t, as
+the name suggests. :)
+
+Signed-off-by: Michael Chang <mch...@suse.com>
+Tested-by: Michael Chang <mch...@suse.com>
+
+---
+ grub-core/fs/btrfs.c          | 2 +-
+ include/grub/efiemu/runtime.h | 2 +-
+ include/grub/gpt_partition.h  | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/fs/btrfs.c b/grub-core/fs/btrfs.c
+index 4849c1ceb..be195448d 100644
+--- a/grub-core/fs/btrfs.c
++++ b/grub-core/fs/btrfs.c
+@@ -175,7 +175,7 @@ struct grub_btrfs_time
+ {
+   grub_int64_t sec;
+   grub_uint32_t nanosec;
+-} __attribute__ ((aligned (4)));
++} GRUB_PACKED;
+ 
+ struct grub_btrfs_inode
+ {
+diff --git a/include/grub/efiemu/runtime.h b/include/grub/efiemu/runtime.h
+index 9b6b729f4..36d2dedf4 100644
+--- a/include/grub/efiemu/runtime.h
++++ b/include/grub/efiemu/runtime.h
+@@ -29,7 +29,7 @@ struct grub_efiemu_ptv_rel
+ 
+ struct efi_variable
+ {
+-  grub_efi_guid_t guid;
++  grub_efi_packed_guid_t guid;
+   grub_uint32_t namelen;
+   grub_uint32_t size;
+   grub_efi_uint32_t attributes;
+diff --git a/include/grub/gpt_partition.h b/include/grub/gpt_partition.h
+index 1b32f6725..9668a68c3 100644
+--- a/include/grub/gpt_partition.h
++++ b/include/grub/gpt_partition.h
+@@ -28,7 +28,7 @@ struct grub_gpt_part_type
+   grub_uint16_t data2;
+   grub_uint16_t data3;
+   grub_uint8_t data4[8];
+-} __attribute__ ((aligned(8)));
++} GRUB_PACKED;
+ typedef struct grub_gpt_part_type grub_gpt_part_type_t;
+ 
+ #define GRUB_GPT_PARTITION_TYPE_EMPTY \
+-- 
+2.13.6

--- a/patches/grub/2.02/series
+++ b/patches/grub/2.02/series
@@ -30,3 +30,4 @@ dont-fail-efi-warnings.patch
 set-default-graphics-mode-to-text.patch
 disable-build-of-documentation.patch
 include-compatible-unifont-bdf.patch
+gcc8.patch


### PR DESCRIPTION
I'll leave this here if you want these fixes. I needed to apply these to compile ONIE on Fedora 28.