### PR TITLE
machine.conf: add onie_grub_image_name for old NOS installers

### DIFF
--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -292,6 +292,7 @@ $(SYSROOT_COMPLETE_STAMP): $(SYSROOT_CHECK_STAMP)
 	$(Q) echo "onie_switch_asic=$(SWITCH_ASIC_VENDOR)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_skip_ethmgmt_macs=$(SKIP_ETHMGMT_MACS)" >> $(MACHINE_CONF)
 ifeq ($(UEFI_ENABLE),yes)
+	$(Q) echo "onie_grub_image_name=$(UEFI_BOOT_LOADER)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_uefi_boot_loader=$(UEFI_BOOT_LOADER)" >> $(MACHINE_CONF)
 	$(Q) echo "onie_uefi_arch=$(EFI_ARCH)" >> $(MACHINE_CONF)
 endif


### PR DESCRIPTION
In ONIE v2018.05, the variable is renamed to `onie_uefi_boot_loader`.

The previous version of demo OS installers or some old NOS installers
cannot register correct EFI boot entry without `onie_grub_image_name`.
With the incorrect boot entry, it will fall back to ONIE environment
directly.

The patch addes `onie_grub_image_name` for legacy NOS/demo OS installers
to create correct boot entry.

The patch has been tested on Accton AS5712_54X and AS5912_54X.

Fixes: 0e56d23