### PR TITLE
grub-arch: show BIOS mode during booting up

### DIFF
--- a/rootconf/grub-arch/sysroot-lib-onie/init-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/init-arch
@@ -1,7 +1,7 @@
 # Early boot time initializations for x86_64 architectures
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014,2018 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -112,6 +112,13 @@ EOF
 }
 
 init_uefi
+
+if [ -d /sys/firmware/efi/efivars ] ; then
+    bios_mode="UEFI"
+else
+    bios_mode="legacy"
+fi
+echo "Info: BIOS mode: $bios_mode"
 
 # Local Variables:
 # mode: shell-script


### PR DESCRIPTION
Showing a message to indicate that ONIE is booted up via which BIOS
mode (either legacy or UEFI).  The message would look like:

    Info: Mounting kernel filesystems... done.
    Info: Mounting ONIE-BOOT on /mnt/onie-boot ...
    Info: BIOS mode: legacy

or:

    Info: Mounting kernel filesystems... done.
    Info: Mounting ONIE-BOOT on /mnt/onie-boot ...
    Info: Mounting EFI System on /boot/efi ...
    Info: BIOS mode: UEFI

The patch has been tested on Accton AS7716_32X.