### PR TITLE
onie-syseeprom: Allow multiple vendor extension TLVs

### DIFF
--- a/patches/busybox/feature-onie-syseeprom-command.patch
+++ b/patches/busybox/feature-onie-syseeprom-command.patch
@@ -8,7 +8,7 @@ SPDX-License-Identifier:     GPL-2.0
 
 diff --git a/include/24cXX.h b/include/24cXX.h
 new file mode 100644
-index 000000000000..5fb4641379ea
+index 0000000..5fb4641
 --- /dev/null
 +++ b/include/24cXX.h
 @@ -0,0 +1,66 @@
@@ -79,7 +79,7 @@ index 000000000000..5fb4641379ea
 +
 +#endif
 diff --git a/include/applets.src.h b/include/applets.src.h
-index b9df5a1b3449..71b8cbd94b87 100644
+index b9df5a1..71b8cbd 100644
 --- a/include/applets.src.h
 +++ b/include/applets.src.h
 @@ -344,6 +344,7 @@ IF_WC(APPLET(wc, BB_DIR_USR_BIN, BB_SUID_DROP))
@@ -92,7 +92,7 @@ index b9df5a1b3449..71b8cbd94b87 100644
  	&& !defined(MAKE_LINKS) && !defined(MAKE_SUID)
 diff --git a/include/i2c-dev.h b/include/i2c-dev.h
 new file mode 100644
-index 000000000000..23f7c2cf071c
+index 0000000..23f7c2c
 --- /dev/null
 +++ b/include/i2c-dev.h
 @@ -0,0 +1,330 @@
@@ -428,10 +428,10 @@ index 000000000000..23f7c2cf071c
 +#endif /* _LINUX_I2C_DEV_H */
 diff --git a/include/onie_tlvinfo.h b/include/onie_tlvinfo.h
 new file mode 100644
-index 000000000000..b602736287ec
+index 0000000..23ec9c5
 --- /dev/null
 +++ b/include/onie_tlvinfo.h
-@@ -0,0 +1,172 @@
+@@ -0,0 +1,173 @@
 +/*
 + *  The Definition of the TlvInfo EEPROM format can be found at onie.org or
 + *  github.com/onie
@@ -599,6 +599,7 @@ index 000000000000..b602736287ec
 +int read_eeprom(u_int8_t *eeprom);
 +int prog_eeprom(u_int8_t * eeprom);
 +void update_eeprom_header(u_int8_t *eeprom);
++bool tlvinfo_multiple_tcode_allowed(int tcode);
 +bool tlvinfo_find_tlv(u_int8_t *eeprom, u_int8_t tcode, int *eeprom_index);
 +bool tlvinfo_delete_tlv(u_int8_t * eeprom, u_int8_t code);
 +bool tlvinfo_add_tlv(u_int8_t * eeprom, int tcode, char * strval);
@@ -606,7 +607,7 @@ index 000000000000..b602736287ec
 +void show_tlv_code_list(void);
 diff --git a/include/sys_eeprom.h b/include/sys_eeprom.h
 new file mode 100644
-index 000000000000..94dfd5a6ff23
+index 0000000..94dfd5a
 --- /dev/null
 +++ b/include/sys_eeprom.h
 @@ -0,0 +1,2 @@
@@ -614,7 +615,7 @@ index 000000000000..94dfd5a6ff23
 +int write_sys_eeprom(void *eeprom_data, int len);
 diff --git a/miscutils/24cXX.c b/miscutils/24cXX.c
 new file mode 100644
-index 000000000000..ccc09652494b
+index 0000000..ccc0965
 --- /dev/null
 +++ b/miscutils/24cXX.c
 @@ -0,0 +1,182 @@
@@ -801,7 +802,7 @@ index 000000000000..ccc09652494b
 +	}
 +}
 diff --git a/miscutils/Config.src b/miscutils/Config.src
-index 4d6425f7652f..cdae45b750b1 100644
+index 4d6425f..cdae45b 100644
 --- a/miscutils/Config.src
 +++ b/miscutils/Config.src
 @@ -546,4 +546,108 @@ config WATCHDOG
@@ -914,7 +915,7 @@ index 4d6425f7652f..cdae45b750b1 100644
 +
  endmenu
 diff --git a/miscutils/Kbuild.src b/miscutils/Kbuild.src
-index 917781898d36..a78273de6ca7 100644
+index 9177818..a78273d 100644
 --- a/miscutils/Kbuild.src
 +++ b/miscutils/Kbuild.src
 @@ -51,3 +51,6 @@ lib-$(CONFIG_TTYSIZE)     += ttysize.o
@@ -926,10 +927,10 @@ index 917781898d36..a78273de6ca7 100644
 +lib-$(CONFIG_SYS_EEPROM_DEVICE_MTD) += sys_eeprom_mtd.o
 diff --git a/miscutils/onie_tlvinfo.c b/miscutils/onie_tlvinfo.c
 new file mode 100644
-index 000000000000..5cf646322444
+index 0000000..26b6ec5
 --- /dev/null
 +++ b/miscutils/onie_tlvinfo.c
-@@ -0,0 +1,743 @@
+@@ -0,0 +1,754 @@
 +#include "libbb.h"
 +#include "onie_tlvinfo.h"
 +#include "sys_eeprom.h"
@@ -1463,6 +1464,17 @@ index 000000000000..5cf646322444
 +}
 +
 +/*
++ *  tlvinfo_multiple_tcode_allowed
++ *
++ *  This function returns true if the supplied type code is allowed to appear
++ *  multiple times.
++ */
++bool tlvinfo_multiple_tcode_allowed(int tcode)
++{
++    return(tcode == TLV_CODE_VENDOR_EXT);
++}
++
++/*
 + *  tlvinfo_find_tlv
 + *
 + *  This function finds the TLV with the supplied code in the EERPOM.
@@ -1675,10 +1687,10 @@ index 000000000000..5cf646322444
 +}
 diff --git a/miscutils/sys_eeprom.c b/miscutils/sys_eeprom.c
 new file mode 100644
-index 000000000000..e34abf59782e
+index 0000000..a24d6bb
 --- /dev/null
 +++ b/miscutils/sys_eeprom.c
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,188 @@
 +#include "libbb.h"
 +#include "onie_tlvinfo.h"
 +#include <getopt.h>
@@ -1714,8 +1726,9 @@ index 000000000000..e34abf59782e
 +	"   -g --get <code>\n"
 +	"      Look up a TLV by code and write the value to stdout.\n"
 +	"   -s --set <code>=<value>,<code>=<value>...\n"
-+	"      Set a TLV code to a value.\n"
-+	"      If no value, TLV is deleted.\n";
++	"      Set a TLV code to a value. Replaces existing TLV code, if any,\n"
++	"         except for Vendor Extension TLV code which can be added\n"
++	"         multiple times. If no value, TLV is deleted.\n";
 +
 +    fprintf(stderr, "%s", usage);
 +    exit(1);
@@ -1797,8 +1810,10 @@ index 000000000000..e34abf59782e
 +			    tname = tlv_code_list[i].m_name;
 +			}
 +		    }
-+		    if (tlvinfo_delete_tlv(eeprom, tcode) == TRUE) {
++		    if (!tlvinfo_multiple_tcode_allowed(tcode) || !value) {
++			if (tlvinfo_delete_tlv(eeprom, tcode) == TRUE) {
 +			    printf("Deleting TLV 0x%x: %s\n", tcode, tname);
++			}
 +		    }
 +		    if (value) {
 +			if (!tlvinfo_add_tlv(eeprom, tcode, value)) {
@@ -1866,7 +1881,7 @@ index 000000000000..e34abf59782e
 +}
 diff --git a/miscutils/sys_eeprom_i2c.c b/miscutils/sys_eeprom_i2c.c
 new file mode 100644
-index 000000000000..ed3235bcc1c8
+index 0000000..ed3235b
 --- /dev/null
 +++ b/miscutils/sys_eeprom_i2c.c
 @@ -0,0 +1,63 @@
@@ -1935,7 +1950,7 @@ index 000000000000..ed3235bcc1c8
 +}
 diff --git a/miscutils/sys_eeprom_mtd.c b/miscutils/sys_eeprom_mtd.c
 new file mode 100644
-index 000000000000..119d77c15c5c
+index 0000000..119d77c
 --- /dev/null
 +++ b/miscutils/sys_eeprom_mtd.c
 @@ -0,0 +1,126 @@


### PR DESCRIPTION
Issue #768 

This patch modifies the behavior of the onie-syseeprom -s (--set) command. If a TLV type code is specified which is allowed to appear multiple times in the EEPROM, then the TLV, if present, is not removed from the EEPROM before the new TLV value is added to the EEPROM. Currently, the only TLV type code which can appear multiple times within the EEPROM is the Vendor Extension (0xFD). Like all other TLVs added with the -s option, vendor extension TLVs are added at the end of the EEPROM, just before the CRC TLV. Deleting a vendor extension TLV with the "onie-syseeprom -s 0xfd" (no value) command will remove the first vendor extension TLV in the EEPROM. This command can be used multiple times to remove all vendor extension TLVs.

Testing has been done on an Accton 5712 platform by adding/deleting/replacing both vendor extension and MAC address TLVs.

Signed-off-by: Scott Emery <scotte@cumulusnetworks.com>