### PR TITLE
machine_accton_wedge_16x:  Allow using m.2 storage

### DIFF
--- a/machine/accton/accton_wedge_16x/installer.conf
+++ b/machine/accton/accton_wedge_16x/installer.conf
@@ -5,12 +5,13 @@ description="Accton, wedge_16x"
 # Default ONIE block device
 install_device_platform()
 {
-    mass_bus="target4:0:0"
-    for i in a b c d e ; do
-        if $(ls -l /sys/block/sd$i/device 2>/dev/null | grep -q "$mass_bus") ; then
-            echo "/dev/sd$i"
-            return 0
-        fi
+    for mass_bus in 'target4:0:0' 'target5:0:0' ; do
+        for i in a b c d e ; do
+            if $(ls -l /sys/block/sd$i/device 2>/dev/null | grep -q "$mass_bus") ; then
+                echo "/dev/sd$i"
+                return 0
+            fi
+        done
     done
     echo "storage-not-found"
     return 1


### PR DESCRIPTION
Accton Wedge 16x micro server have both mSATA and m.2 slots. Currently, ONIE works only with mSATA devices because of the storage device detection function.

This patch allows to use either mSATA or m.2 storage.
