### PR TITLE
Prevent halt from bricking switch on NE2572 and NE10032

### DIFF
--- a/machine/lenovo/lenovo_ne10032/kernel/prevent_halt_issue.patch
+++ b/machine/lenovo/lenovo_ne10032/kernel/prevent_halt_issue.patch
@@ -1,0 +1,19 @@
+diff --git a/drivers/acpi/acpica/hwxfsleep.c b/drivers/acpi/acpica/hwxfsleep.c
+index 3b37676..4bbdf19 100644
+--- a/drivers/acpi/acpica/hwxfsleep.c
++++ b/drivers/acpi/acpica/hwxfsleep.c
+@@ -367,6 +367,14 @@ acpi_status acpi_enter_sleep_state(u8 sleep_state)
+ 
+ 	ACPI_FUNCTION_TRACE(acpi_enter_sleep_state);
+ 
++	/*
++	 * On Lenovo NE2572 and NE10032 if we tell the BIOS to go to sleep or power
++	 * down it takes it really seriously and shuts down permenantly. To wake it
++	 * up again the NVRAM has to be reset using a short which is ugly (power
++	 * cycle doesn't help). So use this kludge to avoid sleeping the BIOS
++	 */
++	return_ACPI_STATUS(AE_OK);
++
+ 	if ((acpi_gbl_sleep_type_a > ACPI_SLEEP_TYPE_MAX) ||
+ 	    (acpi_gbl_sleep_type_b > ACPI_SLEEP_TYPE_MAX)) {
+ 		ACPI_ERROR((AE_INFO, "Sleep values out of range: A=0x%X B=0x%X",

--- a/machine/lenovo/lenovo_ne10032/kernel/series
+++ b/machine/lenovo/lenovo_ne10032/kernel/series
@@ -1,0 +1,1 @@
+prevent_halt_issue.patch

--- a/machine/lenovo/lenovo_ne2572/kernel/prevent_halt_issue.patch
+++ b/machine/lenovo/lenovo_ne2572/kernel/prevent_halt_issue.patch
@@ -1,0 +1,19 @@
+diff --git a/drivers/acpi/acpica/hwxfsleep.c b/drivers/acpi/acpica/hwxfsleep.c
+index 3b37676..4bbdf19 100644
+--- a/drivers/acpi/acpica/hwxfsleep.c
++++ b/drivers/acpi/acpica/hwxfsleep.c
+@@ -367,6 +367,14 @@ acpi_status acpi_enter_sleep_state(u8 sleep_state)
+ 
+ 	ACPI_FUNCTION_TRACE(acpi_enter_sleep_state);
+ 
++	/*
++	 * On Lenovo NE2572 and NE10032 if we tell the BIOS to go to sleep or power
++	 * down it takes it really seriously and shuts down permenantly. To wake it
++	 * up again the NVRAM has to be reset using a short which is ugly (power
++	 * cycle doesn't help). So use this kludge to avoid sleeping the BIOS
++	 */
++	return_ACPI_STATUS(AE_OK);
++
+ 	if ((acpi_gbl_sleep_type_a > ACPI_SLEEP_TYPE_MAX) ||
+ 	    (acpi_gbl_sleep_type_b > ACPI_SLEEP_TYPE_MAX)) {
+ 		ACPI_ERROR((AE_INFO, "Sleep values out of range: A=0x%X B=0x%X",

--- a/machine/lenovo/lenovo_ne2572/kernel/series
+++ b/machine/lenovo/lenovo_ne2572/kernel/series
@@ -1,0 +1,1 @@
+prevent_halt_issue.patch


### PR DESCRIPTION
We have an issue on our NE2572 and NE10032 switches where if you do halt or poweroff the BIOS shuts down and then can't be recovered even by a power cycle. 
This is a fairly ugly, but simple, workaround to prevent that happening by preventing the ACPI message being sent to the BIOS that causes the problem. 
Let me know if any questions. 
Thanks
Mark