### PR TITLE
Support gcc-7 on the build host

### DIFF
--- a/patches/crosstool-NG/series
+++ b/patches/crosstool-NG/series
@@ -1,3 +1,4 @@
-# This series applies on GIT commit 160b95d0bf622a54620be9cfbe4553e9c5a14505
+# This series applies on GIT commit 51f53747556bd77a13f0d035deace0907f57353d
 allow-patching-custom-kernel-tarballs.patch
 allow-obsolete-isl-0-12-2-with-custom-gcc-version.patch
+ubsan-fix-check-empty-string.patch

--- a/patches/crosstool-NG/ubsan-fix-check-empty-string.patch
+++ b/patches/crosstool-NG/ubsan-fix-check-empty-string.patch
@@ -1,0 +1,45 @@
+ubsan-fix-check-empty-string.patch
+
+Fix ubsan compilation error using host gcc version 7.
+
+Take from upstream commit 4d360c3c
+
+  Author: Kirill K. Smirnov <kirill.k.smirnov@gmail.com>
+  Date:   Sat May 27 21:34:09 2017 +0300
+
+    patches: Add patch that fixes gcc6 with gcc7
+
+diff --git a/patches/gcc/6.3.0/1100-ubsan-fix-check-empty-string.patch b/patches/gcc/6.3.0/1100-ubsan-fix-check-empty-string.patch
+new file mode 100644
+index 0000000..c012719
+--- /dev/null
++++ b/patches/gcc/6.3.0/1100-ubsan-fix-check-empty-string.patch
+@@ -0,0 +1,28 @@
++From 8db2cf6353c13f2a84cbe49b689654897906c499 Mon Sep 17 00:00:00 2001
++From: kyukhin <kyukhin@138bc75d-0d04-0410-961f-82ee72b054a4>
++Date: Sat, 3 Sep 2016 10:57:05 +0000
++Subject: [PATCH] gcc/ 	* ubsan.c (ubsan_use_new_style_p): Fix check for empty
++ string.
++
++git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@239971 138bc75d-0d04-0410-961f-82ee72b054a4
++
++Upstream-Status: Backport
++Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>
++
++---
++ gcc/ubsan.c   | 2 +-
++ 2 files changed, 5 insertions(+), 1 deletion(-)
++
++Index: gcc-6.3.0/gcc/ubsan.c
++===================================================================
++--- gcc-6.3.0.orig/gcc/ubsan.c
+++++ gcc-6.3.0/gcc/ubsan.c
++@@ -1471,7 +1471,7 @@ ubsan_use_new_style_p (location_t loc)
++ 
++   expanded_location xloc = expand_location (loc);
++   if (xloc.file == NULL || strncmp (xloc.file, "\1", 2) == 0
++-      || xloc.file == '\0' || xloc.file[0] == '\xff'
+++      || xloc.file[0] == '\0' || xloc.file[0] == '\xff'
++       || xloc.file[1] == '\xff')
++     return false;
++ 

--- a/patches/grub/2.02/gcc7.patch
+++ b/patches/grub/2.02/gcc7.patch
@@ -1,0 +1,23 @@
+When building grub using gcc-7, with -Werror=unused-value enabled, we
+hit this error:
+
+  grub_script.yy.c:19:22: error: statement with no effect [-Werror=unused-value]
+   #define fprintf(...) 0
+
+This patch follows the approach from the gcc manual,
+https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html, and casts the
+0 value to (void).
+
+diff --git a/grub-core/script/yylex.l b/grub-core/script/yylex.l
+index 95b2191..71d288f 100644
+--- a/grub-core/script/yylex.l
++++ b/grub-core/script/yylex.l
+@@ -91,7 +91,7 @@ typedef size_t yy_size_t;
+ #define stdin  0
+ #define stdout 0
+ 
+-#define fprintf(...) 0
++#define fprintf(...) ((void)0)
+ #define exit(...) grub_fatal("fatal error in lexer")
+ #endif
+ 

--- a/patches/grub/2.02/series
+++ b/patches/grub/2.02/series
@@ -31,3 +31,4 @@ set-default-graphics-mode-to-text.patch
 disable-build-of-documentation.patch
 include-compatible-unifont-bdf.patch
 gcc8.patch
+gcc7.patch

--- a/patches/pesign/implicit-fallthrough.patch
+++ b/patches/pesign/implicit-fallthrough.patch
@@ -1,0 +1,22 @@
+Summary: From: Curt Brune <curt@brune.net>
+
+implicit-fallthrough.patch
+
+When compiling using gcc-7 with -Werror=implicit-fallthrough enabled,
+implicit case statement fallthroughs are not permitted.
+
+This patch uses the gcc attribute "fallthrough" to make the
+fallthrough explicit.
+
+diff --git a/src/authvar.c b/src/authvar.c
+index ad659ca..0c5d752 100644
+--- a/src/authvar.c
++++ b/src/authvar.c
+@@ -511,6 +511,7 @@ main(int argc, char *argv[])
+ 	case IMPORT|SET:
+ 	case IMPORT|SIGN|SET:
+ 		fprintf(stderr, "authvar: not implemented\n");
++		__attribute__ ((fallthrough));
+ 	case IMPORT|SIGN|EXPORT:
+ 	default:
+ 		fprintf(stderr, "authvar: invalid flags: ");

--- a/patches/pesign/series
+++ b/patches/pesign/series
@@ -1,2 +1,3 @@
-# This series applies on GIT commit e8f5465bebda5f734f63b64035fe58a153862a3b
+# This series applies on GIT commit 3fc75c97acf42f6f7a472f6ab5081d00d1d4f945
 brace-initialization.patch
+implicit-fallthrough.patch


### PR DESCRIPTION
It got kind of annoying not being able to build ONIE on Ubuntu-18.04, which uses gcc-7 be default.

Here are a few patches that enable building ONIE using gcc-7 on the host.