### PR TITLE
pesign: use comment method to bypass -Werror=implicit-fallthrough

### DIFF
--- a/patches/pesign/implicit-fallthrough.patch
+++ b/patches/pesign/implicit-fallthrough.patch
@@ -1,12 +1,12 @@
-Summary: From: Curt Brune <curt@brune.net>
-
 implicit-fallthrough.patch
 
 When compiling using gcc-7 with -Werror=implicit-fallthrough enabled,
 implicit case statement fallthroughs are not permitted.
 
-This patch uses the gcc attribute "fallthrough" to make the
-fallthrough explicit.
+This patch uses the gcc "comment method" to make the fallthrough
+explicit.  Using the comment method is backwardly compatible with
+earlier versions of gcc.  See The gcc documentaion for the
+-Wimplicit-fallthrough=3 option.
 
 diff --git a/src/authvar.c b/src/authvar.c
 index ad659ca..0c5d752 100644
@@ -16,7 +16,7 @@ index ad659ca..0c5d752 100644
  	case IMPORT|SET:
  	case IMPORT|SIGN|SET:
  		fprintf(stderr, "authvar: not implemented\n");
-+		__attribute__ ((fallthrough));
++		/* fallthrough */
  	case IMPORT|SIGN|EXPORT:
  	default:
  		fprintf(stderr, "authvar: invalid flags: ");


### PR DESCRIPTION
The gcc attribute 'fallthrough' was introduced with gcc version 7 and
breaks compilation using older compilers.  To achieve portable code,
use the "comment method" described in the gcc documentation for the
-Wimplicit-fallthrough=3 gcc option.

Fixes: bae571195b87 ("pesign: update for compiling with gcc-7")
Signed-off-by: Curt Brune <curt@brune.net>