### PR TITLE
Add copyright notices to machine.make files

### DIFF
--- a/machine/lenovo/lenovo_g8272/machine.make
+++ b/machine/lenovo/lenovo_g8272/machine.make
@@ -1,3 +1,19 @@
+# Copyright (C) 2018 Lenovo.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # Makefile fragment for Lenovo G8272
 
 ONIE_ARCH ?= powerpc-softfloat

--- a/machine/lenovo/lenovo_g8296/machine.make
+++ b/machine/lenovo/lenovo_g8296/machine.make
@@ -1,3 +1,19 @@
+# Copyright (C) 2018 Lenovo.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # Makefile fragment for Lenovo G8296
 
 ONIE_ARCH ?= powerpc-softfloat

--- a/machine/lenovo/lenovo_ne10032/machine.make
+++ b/machine/lenovo/lenovo_ne10032/machine.make
@@ -1,3 +1,19 @@
+# Copyright (C) 2018 Lenovo.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # Lenovo NE10032
 
 ONIE_ARCH ?= x86_64

--- a/machine/lenovo/lenovo_ne1032/machine.make
+++ b/machine/lenovo/lenovo_ne1032/machine.make
@@ -1,3 +1,19 @@
+# Copyright (C) 2018 Lenovo.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # Makefile fragment for Lenovo NE1032
 
 # Vendor's version number can be defined here.

--- a/machine/lenovo/lenovo_ne1032t/machine.make
+++ b/machine/lenovo/lenovo_ne1032t/machine.make
@@ -1,3 +1,19 @@
+# Copyright (C) 2018 Lenovo.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # Makefile fragment for Lenovo NE1032T
 
 # Vendor's version number can be defined here.

--- a/machine/lenovo/lenovo_ne1072t/machine.make
+++ b/machine/lenovo/lenovo_ne1072t/machine.make
@@ -1,3 +1,19 @@
+# Copyright (C) 2018 Lenovo.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # Makefile fragment for Lenovo NE1072T
 
 # Vendor's version number can be defined here.

--- a/machine/lenovo/lenovo_ne2572/machine.make
+++ b/machine/lenovo/lenovo_ne2572/machine.make
@@ -1,3 +1,19 @@
+# Copyright (C) 2018 Lenovo.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # Lenovo NE2572
 
 ONIE_ARCH ?= x86_64


### PR DESCRIPTION
Hi - I know this is a tedious one to review, but whilst internally reviewing our open source code for compliance it was pointed out to me that the GPL license is missing from the machine.make files.

I'm not 100% convinced the files deserve or need a GPL licence, but it was easy to add.

Let me know if any objections :)

Thanks
Mark