### PR TITLE
   Support the different platform name with the same design CPU board

### DIFF
--- a/machine/delta/delta_ag9032v2a/Supported_platform.md
+++ b/machine/delta/delta_ag9032v2a/Supported_platform.md
@@ -1,0 +1,14 @@
+There are some of platforms which use the same design of CPU board.
+So we share the same onie's source with defferent model name. 
+if using the default way to build onie and we will get the ag9032v2a platform.
+
+    $ cd build-config
+    $ make -j4 MACHINEROOT=../machine/delta MACHINE=delta_ag9032v2a all
+
+We use the delta_ag9032v2a as base to extend other model and list the externed model in the following.
+ 
+1. delta_agc7648sv1 
+    $ cd build-config
+    $ make -j4 MACHINEROOT=../machine/delta MACHINE=delta_ag9032v2a ONIE_BUILD_MACHINE=delta_agc7648sv1 all
+
+


### PR DESCRIPTION
   1. In order to share the same onie code base with different platforms name but have
       the same design on CPU board. We add the build option,ONIE_BUILD_MACHINE, to build the different platform name. Please see the attached file Supported_platform.md for more detail.

Signed-off-by: hans <hans.tseng@deltaww.com>