### PR TITLE
Get only the first CONFIG_ENV_SECT_SIZE

### DIFF
--- a/build-config/scripts/onie-mk-bin.sh
+++ b/build-config/scripts/onie-mk-bin.sh
@@ -74,7 +74,7 @@ MACHINE_CONFIG="$uboot_src/include/configs/${uboot_machine}.h"
 
 if [ -z "$env_sector_size" ] ; then
     # try to figure it out from the $MACHINE_CONIFG
-    env_sector_size=$(grep CONFIG_ENV_SECT_SIZE $MACHINE_CONFIG | awk '{print $3}')
+    env_sector_size=$(grep -m 1 CONFIG_ENV_SECT_SIZE $MACHINE_CONFIG | awk '{print $3}')
 fi
 
 env_sector_size=$(( $env_sector_size + 0 ))


### PR DESCRIPTION
In the u-boot, some platforms configs have the "CONFIG_ENV_SECT_SIZE" referenced more than once in its <platform>.h.
This can causes the "build-config/scripts/onie-mk-bin.sh" to fail.

In my use case:
++ grep CONFIG_ENV_SECT_SIZE /home/build/src/onie/build/<vendor>_<platform>-r0/u-boot/u-boot-2013.01.01/include/configs/<platform>.h
++ awk '{print $3}'
+ env_sector_size='0x20000
(CONFIG_SYS_MONITOR_BASE
"\0"'
/home/build/src/onie/build-config/scripts/onie-mk-bin.sh: line 80: 0x20000
(CONFIG_SYS_MONITOR_BASE
"\0" + 0 : syntax error in expression (error token is "(CONFIG_SYS_MONITOR_BASE
"\0" + 0 ")
+ '[' '0x20000
(CONFIG_SYS_MONITOR_BASE
"\0"' = '' ']'
+ '[' '0x20000
(CONFIG_SYS_MONITOR_BASE
"\0"' = 0 ']'

Therefore I suggest adding the "-m 1" parameter to grep, in order to get only the first match.

Cheers,
Alex 