### PR TITLE
Use available interface for arping instead of default eth0

### DIFF
--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -97,13 +97,13 @@ config_ethmgmt_fallback()
         local test_ip="169.254.${rnd1}.${rnd2}"
 
         # use arping to check if IP is in use
-        arping -qD -c 5 $test_ip && {
+        arping -qD -c 5 -I $intf $test_ip && {
             # Claim this IP
             ip addr add ${test_ip}/$prefix dev $intf || {
                 log_failure_msg "Problems setting default IPv4 addr: ${intf}: ${test_ip}/$prefix"
                 return 1
             }
-            arping -c 3 -Uq -s $test_ip $test_ip
+            arping -c 3 -Uq -I $intf -s $test_ip $test_ip
             log_console_msg "Using link-local IPv4 addr: ${intf}: ${test_ip}/$prefix"
             break
         }


### PR DESCRIPTION
The NE0152T board has eth2 as it's mgmt port  instead of eth0

The arping command is by default using eth0 and should be using the available $intf interface. Use the -I option to make sure the active and available interface option is used.

Tested on NE0152T (uses eth2) and NE2572 (uses eth0)