### PR TITLE
Fix for issue#574 onie-discovery-stop does not kill the entire discov…

### DIFF
--- a/rootconf/default/etc/init.d/discover.sh
+++ b/rootconf/default/etc/init.d/discover.sh
@@ -78,6 +78,7 @@ do_stop() {
     log_begin_msg "Stopping: $daemon"
     start-stop-daemon -q -K -s TERM -p /var/run/${daemon}.pid
     killall -q $onie_installer exec_installer wget tftp 
+    pkill -P $(cat /var/run/${daemon}.pid)
     log_end_msg
 }
 

--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -84,6 +84,12 @@ config_ethmgmt_fallback()
     local intf=$1
     shift
 
+    local ipaddr=$(ifconfig $intf |grep 'inet '|sed -e 's/:/ /g'|awk '{ print $3 " / " $7 }')
+    if [ -n "$ipaddr" ] ; then
+       log_console_msg "Found already assigned IP address $ipaddr to $intf"
+       return 0
+    fi
+
     # Remove any previously configured, IPv4 addresses
     ip -f inet addr flush dev $intf
 


### PR DESCRIPTION
…ery process immediately

Addition of pkill in discovery stop function is as per the email thread listed in jira.

In function config_ethmgmt_fallback, added code to prevent onie from over-riding the user assigned IP
address with default one after discovery-stop, as pkill usually takes some time.
With these changes, the recommend sequence is:

1. onie-discovery-stop
2. assign manual IP address to management i/f.