### PR TITLE
Fix "make clean" for gnu-efi, pesign and shim

### DIFF
--- a/build-config/make/gnu-efi.make
+++ b/build-config/make/gnu-efi.make
@@ -88,7 +88,7 @@ $(GNU_EFI_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(GNU_EFI_BUILD_STAMP)
 			install
 	$(Q) touch $@
 
-USERSPACE_CLEAN += gnu-efi-clean
+USER_CLEAN += gnu-efi-clean
 gnu-efi-clean:
 	$(Q) rm -rf $(GNU_EFI_BUILD_DIR)
 	$(Q) rm -f $(GNU_EFI_STAMP)

--- a/build-config/make/pesign.make
+++ b/build-config/make/pesign.make
@@ -78,7 +78,7 @@ $(PESIGN_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(PESIGN_BUILD_STAMP)
 	$(Q) $(MAKE) -C $(PESIGN_DIR) install DESTDIR=$(PESIGN_INSTALL_DIR)
 	$(Q) touch $@
 
-USERSPACE_CLEAN += pesign-clean
+USER_CLEAN += pesign-clean
 pesign-clean:
 	$(Q) rm -rf $(PESIGN_BUILD_DIR)
 	$(Q) rm -f $(PESIGN_STAMP)

--- a/build-config/make/shim.make
+++ b/build-config/make/shim.make
@@ -148,7 +148,7 @@ $(SHIM_SELF_SIGN_STAMP): $(SHIM_BUILD_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 		"$(SHIM_INSTALL_DIR)/shim$(EFI_ARCH).efi"
 	$(Q) touch $@
 
-USERSPACE_CLEAN += shim-clean
+MACHINE_CLEAN += shim-clean
 shim-clean:
 	$(Q) rm -rf $(SHIM_BUILD_DIR)
 	$(Q) rm -f $(SHIM_STAMP) $(SHIM_SELF_SIGN_STAMP)


### PR DESCRIPTION
The "make clean" target misses gnu-efi-clean, pesign-clean and shim-clean.

This patch adds these clean targets to user-clean or machine-clean.