### PR TITLE
Use more intelligent config merge from kernel distro

### DIFF
--- a/build-config/make/kernel.make
+++ b/build-config/make/kernel.make
@@ -79,9 +79,9 @@ $(KERNEL_PATCH_STAMP): $(KERNEL_SRCPATCHDIR)/* $(MACHINE_KERNEL_PATCHDIR)/* $(KE
 	$(Q) touch $@
 
 $(LINUXDIR)/.config : $(LINUX_CONFIG) $(KERNEL_PATCH_STAMP)
-	$(Q) echo "==== Copying $(LINUX_CONFIG) to $(LINUXDIR)/.config ===="
+	$(Q) echo "==== Merging $(LINUX_CONFIG) to $(LINUXDIR)/.config ===="
 	$(Q) cp -v $< $@
-	$(Q) cat $(MACHINE_KERNEL_PATCHDIR)/config >> $(LINUXDIR)/.config
+	$(Q) $(LINUXDIR)/scripts/kconfig/merge_config.sh -r -m $(LINUXDIR)/.config $(MACHINE_KERNEL_PATCHDIR)/config
 
 kernel-old-config: $(LINUXDIR)/.config
 	$(Q) $(MAKE) -C $(LINUXDIR) ARCH=$(KERNEL_ARCH) oldconfig


### PR DESCRIPTION
Instead of simple appending, it may be useful to allow more intelligent merge provided by the kernel distro itself.

For example, assume that default kernel config contains
`# CONFIG_CMDLINE_BOOL is not set`
and your machine/.../.../kernel/config contains
`CONFIG_CMDLINE_BOOL=y`

In case of appending machine/.../.../kernel/config to .config there will be a build error.
If we call merge_config.sh instead, it will handle such situation, so former line `# CONFIG_CMDLINE_BOOL is not set` will be removed, as line `CONFIG_CMDLINE_BOOL=y` will get more priority, so no build error will be triggered.