### PR TITLE
Alphanetworks STX-60D0-062F: Use acpi --no-ebda in ISO recovery menu

### DIFF
--- a/machine/alphanetworks/alphanetworks_stx60d0_062f/machine.make
+++ b/machine/alphanetworks/alphanetworks_stx60d0_062f/machine.make
@@ -39,6 +39,7 @@ LINUX_MINOR_VERSION	= 95
 # Older GCC required for older 3.14.27 kernel
 #GCC_VERSION = 4.9.2
 
+include $(MACHINEDIR)/rootconf/grub-machine.make
 
 #-------------------------------------------------------------------------------
 #

--- a/machine/alphanetworks/alphanetworks_stx60d0_062f/post-process.make
+++ b/machine/alphanetworks/alphanetworks_stx60d0_062f/post-process.make
@@ -1,0 +1,10 @@
+RECOVERY_ISO_GRUB_CONF ?= $(abspath ../build-config/recovery/grub-iso.cfg)
+RECOVERY_ISO_GRUB_CONF_ORI ?= $(MACHINEDIR)/rootconf/onie-grub/grub-iso.cfg.ori
+MACHINE_IMAGE_COMPLETE_STAMP = $(STAMPDIR)/machine-image-complete
+
+PHONY += machine-image-complete
+machine-image-complete: $(MACHINE_IMAGE_COMPLETE_STAMP)
+$(MACHINE_IMAGE_COMPLETE_STAMP): $(RECOVERY_ISO_STAMP)
+	$(Q) cp -f $(RECOVERY_ISO_GRUB_CONF_ORI) $(RECOVERY_ISO_GRUB_CONF)
+	$(Q) rm -f $(RECOVERY_ISO_GRUB_CONF_ORI)
+	$(Q) touch $@

--- a/machine/alphanetworks/alphanetworks_stx60d0_062f/rootconf/grub-machine.make
+++ b/machine/alphanetworks/alphanetworks_stx60d0_062f/rootconf/grub-machine.make
@@ -1,0 +1,36 @@
+#------------------------------------------------------------------------------
+#
+#
+#------------------------------------------------------------------------------
+#
+# This is a makefile fragment that replace configuration of grub menu
+# for STX-60D0-062F.
+#
+
+RECOVERY_ISO_GRUB_CONF = $(abspath ../build-config/recovery/grub-iso.cfg)
+RECOVERY_ISO_GRUB_CONF_ORI = $(MACHINEDIR)/rootconf/onie-grub/grub-iso.cfg.ori
+RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP = $(STAMPDIR)/iso-grub-machine-complete
+RECOVERY_ISO_GRUB_MACHINE_CONF = $(MACHINEDIR)/rootconf/onie-grub/grub-iso.cfg
+MACHINE_IMAGE_COMPLETE_STAMP = $(STAMPDIR)/machine-image-complete
+
+$(RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP) : $(RECOVERY_ISO_STAMP)
+	$(Q) cp -f $(RECOVERY_ISO_GRUB_CONF) $(RECOVERY_ISO_GRUB_CONF_ORI)
+	$(Q) cp -f $(RECOVERY_ISO_GRUB_MACHINE_CONF) $(RECOVERY_ISO_GRUB_CONF)
+	$(Q) touch $@
+
+sysroot-machine-clean:
+	$(Q) if [ -f "$(RECOVERY_ISO_GRUB_CONF_ORI)" ] ; then \
+	        cp -f $(RECOVERY_ISO_GRUB_CONF_ORI) $(RECOVERY_ISO_GRUB_CONF); \
+	        rm -f $(RECOVERY_ISO_GRUB_CONF_ORI); \
+	     fi;
+	$(Q) rm -f $(MACHINE_IMAGE_COMPLETE_STAMP)
+	$(Q) rm -f $(RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP)
+
+$(STAMPDIR)/recovery-iso: $(RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP)
+sysroot-clean: sysroot-machine-clean
+
+#------------------------------------------------------------------------------
+#
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/machine/alphanetworks/alphanetworks_stx60d0_062f/rootconf/onie-grub/grub-iso.cfg
+++ b/machine/alphanetworks/alphanetworks_stx60d0_062f/rootconf/onie-grub/grub-iso.cfg
@@ -1,0 +1,45 @@
+#  Copyright (C) 2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+if [ "<SERIAL_CONSOLE_ENABLE>" == "yes"  ] ; then
+  serial --port=<CONSOLE_PORT> --speed=<CONSOLE_SPEED> --word=8 --parity=no --stop=1
+  terminal_input serial
+  terminal_output serial
+  CONSOLE_CMDLINE_LINUX="console=tty0 console=ttyS<CONSOLE_DEV>,<CONSOLE_SPEED>n8"
+  export CONSOLE_CMDLINE_LINUX
+fi
+set timeout=3
+
+function onie_entry_start {
+  if [ "${grub_platform}" != "efi" ] ; then
+    acpi --no-ebda
+  fi
+}
+
+function onie_entry_end {
+  echo "Platform  : $onie_build_platform"
+  echo "Version   : $onie_version"
+  echo "Build Date: $onie_build_date"
+}
+
+ONIE_CMDLINE_LINUX="quiet ${CONSOLE_CMDLINE_LINUX} <EXTRA_CMDLINE_LINUX> boot_env=recovery"
+set default="<GRUB_DEFAULT_ENTRY>"
+
+menuentry "ONIE: Rescue" --class gnu-linux --class onie {
+  echo    "ONIE: Rescue Mode ..."
+  onie_entry_start
+  linux   /vmlinuz $ONIE_CMDLINE_LINUX boot_reason=rescue
+  initrd  /initrd.xz
+  onie_entry_end
+}
+
+menuentry "ONIE: Embed ONIE" --class gnu-linux --class onie {
+  echo    "ONIE: Embedding ONIE ..."
+  onie_entry_start
+  linux   /vmlinuz $ONIE_CMDLINE_LINUX boot_reason=embed install_url=file:///lib/onie/onie-updater
+  initrd  /initrd.xz
+  onie_entry_end
+}


### PR DESCRIPTION
In the STX-60D0-062F, grub's "acpi" command cannot copy intact EBDA.
(Extended BIOS Data Area) if the EBDA size of BIOS is over 1K.
This command causes system hang.
Therefore the "acpi" command can only be executed with the
"--no-ebda" parameter.

This patch modifies the grub configuration of the recovery ISO prior to the
ISO file's creation, and the original grub-iso.cfg will be restored
after the ISO file is created.