### PR TITLE
Support system wide download cache at /var/cache/onie/download

### DIFF
--- a/build-config/scripts/fetch-package
+++ b/build-config/scripts/fetch-package
@@ -2,6 +2,7 @@
 
 #  Copyright (C) 2013-2014 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2016 Pankaj Bansal <pankajbansal3073@gmail.com>
+#  Copyright (C) 2019 Alex Doyle <adoyle@cumulusnetworks.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -22,6 +23,12 @@ The <SHA1 dir> contains <base file name>.sha1, which is verified
 after downloading.
 EOF
 }
+
+# Optional, system-wide directory to supplement downloads.
+# Once the local ./build/download directory is populated,
+# those packages can be copied here to be referenced should
+# the network become unavailable.
+DOWNLOAD_CACHE_DIR="/var/cache/onie/download"
 
 OUTDIR=$1
 SHA1DIR=$2
@@ -57,27 +64,44 @@ if [ -r "${OUTDIR}/${FILE}" ] ; then
     echo "Using cached ${OUTDIR}/${FILE}"
 else
     download=no
+
     while [ $# -ge 1 ] ; do
         URL="$1/$FILE"
+	echo "  Downloading $FILE from: $URL"
         wget --no-verbose --no-check-certificate -O "${OUTDIR}/${FILE}" $URL
         if [ $? -eq 0 ] ; then
             # stop
             download=yes
             break
         else
-            rm -f "${OUTDIR}/${FILE}"
+	    rm -f "${OUTDIR}/${FILE}"
         fi
         shift
     done
-    if [ "$download" != "yes" ] ; then
-        echo "ERROR:  Unable to download $FILE"
-        exit 1
+    if [ "$download" = "no" ] ; then
+	# Has a package cache has been set up on the local system, mirroring
+	# http://mirror.opencompute.org/onie/
+	# Look there too.
+	if [ -e "${DOWNLOAD_CACHE_DIR}"/"${FILE}" ];then
+	    echo "  Copying      $FILE from system cache at ${DOWNLOAD_CACHE_DIR}"
+	    cp ${DOWNLOAD_CACHE_DIR}/${FILE} "${OUTDIR}/${FILE}"
+	    download=yes
+	fi
     fi
+    if [ "$download" != "yes" ] ; then
+	    echo ""
+            echo "  ERROR:  Unable to download $FILE from $URL"
+	    echo ""
+            exit 1
+    else
+	echo "  Got          $FILE"
+    fi
+    echo ""
 fi
 
 # Verify SHA1
 cd $OUTDIR && sha1sum -c ${SHA1DIR}/${FILE}.sha1 || {
-    echo "ERROR: Unable to verify sha1 for ${FILE}"
+    echo " ERROR: Unable to verify sha1 for ${FILE}"
     exit 1
 }
 


### PR DESCRIPTION
The problem:

ONIE downloads specific versions of packages (most as compressed
tarfiles ) that get used in build. These packages are checksummed
against values stored in git, and are stored in onie/build/download.
These files are not removed on clean operations, although the compiled
versions of them are, so once created, onie/build/downloads is
fairly static, unless another ONIE build target is built, in which case
it may have to download additional packages, or different versions
of ones that it already has.

On a first-time checkout of the ONIE source code, this directory
gets populated by makefiles using ./scripts/fetch-package.

This script will iterate through a list of URLs to download the
source code. It starts with mirror.opencompute.org/onie, and
will then try other URLS, if any.

As some of the alternate URLs are old, they are no longer valid,
and mirror.opencompute.org/onie becomes the only reliable way to get them.

If something happens to this website, or the user has limited
Internet access, building ONIE becomes pretty much impossible.

...and it was the website going offline for a few days prompted this fix.

The solution:

The scripts/fetch-package script, as a last resort, will now
look for a system wide cache at /var/cache/onie/download.

Setting up this cache is entirely the responsibility of the
user, as it is not needed under normal circumstances. However if:

1 - Internet connectivity is, slow, intermittent, or non existent.
2 - or something happens to the mirror server.

...it might be nice to have a local copy of these files that
never change.

As of 10/31/19, the entire mirror takes up about 2GB of space, and
most users will only need a subset of these packages, so it
may be trimmed for individual use.

To set up the local copy:

One can either build all ONIE targets that one is interested in,
and copy the resulting onie/build/download folder to
/var/cache/onie/download

Or:

mkdir /var/cache/onie/download

...and poplulate it with the entire mirror using:

wget --recursive --cut-dirs=2 --no-host-directories \
 --no-parent --reject "index.html" http://mirror.opencompute.org/onie/

This was originally brought up in:
Bug URL: https://github.com/opencomputeproject/onie/issues/870

Fixes:  #870   ONIE build process missing packages
Signed-off-by: Alex Doyle <adoyle@cumulusnetworks.com>