### PR TITLE
grub: reset onie_mode instead of setting 'none'

### DIFF
--- a/installer/grub-arch/grub/grub-common.cfg
+++ b/installer/grub-arch/grub/grub-common.cfg
@@ -1,7 +1,7 @@
 ## Begin grub-common.cfg
 
 #  Copyright (C) 2014,2018 Curt Brune <curt@cumulusnetworks.com>
-#  Copyright (C) 2015,2016,2017 david_yang <david_yang@accton.com>
+#  Copyright (C) 2015,2016,2017,2019 david_yang <david_yang@accton.com>
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
@@ -98,7 +98,7 @@ function onie_embed {
 }
 
 function reset_onie_mode {
-   set onie_mode="none"
+   unset onie_mode
    save_env onie_mode
 }
 


### PR DESCRIPTION
Doing `onie-boot-mode -o none` will reset onie_mode.  But it sets 'none'
to onie_mode in GRUB.  The patch revises it to reset onie_mode that
makes the behaviour in GRUB and Linux be consistent.

The patch has been tested on Accton AS7716_32X.