### PR TITLE
Remove year from LSB_RELEASE_TAG to avoid Y2.02K bug

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -285,7 +285,7 @@ $(TREE_STAMP): $(PROJECT_STAMP)
 ONIE_RELEASE_TAG	?= $(shell [ -r ./conf/onie-release ] && cat ./conf/onie-release)
 ifeq ($(ONIE_RELEASE_TAG),)
   GIT_BRANCH = $(shell cd $(MACHINEDIR) && git rev-parse --abbrev-ref HEAD)
-  BUILD_DATE = $(shell date +%Y%m%d%H%M)
+  BUILD_DATE = $(shell date +%m%d%H%M)
   ifneq ($(RELEASE),)
     # Optional: If RELEASE specified on the command line insert the
     # string after the branch name.


### PR DESCRIPTION
Ticket 893 https://github.com/opencomputeproject/onie/issues/893
has a more thorough write up on this.

The summary is that the date format:  +%Y%m%d%H%M
Puts a 2020 in for the year (as one would expect) but when this string
is used to name the tools generated by crosstools-ng, configuration
changes and linker failures occur.

The fix is to remove the date from the year, as the second pair
of bytes will never be more than '12', while still providing enough
time related context to create unique values.

And really, in practice, that's probably not really needed at all.

Branched code will have a build-config/conf/onie-release file that
has a shorter version string in it ( 2019.11br, for example ) that
does not suffer from this issue. However, if a historical build is
checked out and the onie-release file removed, the LSB_RELEASE_TAG
gets auto generated for master, and old builds will fail the same
way the latest ones do - so this bug has been around for forever,
and it's just being hit in 2020.

Tested enabling/disabling of the fix with kvm_x86_64 build
Signed-off-by: Alex Doyle <adoyle@cumulusnetworks.com>
Closes: #893