### PR TITLE
Add client ID to udhcp parameters.

### DIFF
--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -401,6 +401,8 @@ udhcpc_args()
     local udhcp_args="-q -S -V onie_vendor:${onie_platform}"
     # user_class - option 77 - string in hex
     local udhcp_user_class="-x 77:$(str2hex onie_dhcp_user_class)"
+    # client id - option 61 - serial number in hex
+    local udhcp_client_id="-x 61:00$(str2hex $(onie-sysinfo -s))"
     # vendor specific options - option 125 - string in hex
     # code 3 - machine
     # code 4 - CPU architecture
@@ -411,7 +413,7 @@ udhcpc_args()
     local payload="${udhcp_vivso_machine}${udhcp_vivso_arch}${udhcp_vivso_machine_rev}"
     local len=$(( ${#payload} / 2 ))
     local udhcp_vivso="-x 125:$(printf %08X%02X%s $onie_iana_enterprise $len $payload)"
-    echo "$udhcp_args" "$udhcp_user_class" "$udhcp_vivso"
+    echo "$udhcp_args" "$udhcp_user_class" "$udhcp_client_id" "$udhcp_vivso"
 }
 
 # Increment a MAC address by the specified integer


### PR DESCRIPTION
Sends the serial number of the device in the DHCP packet as option 61 (Client ID).

Untested. Addresses issue #697.