### PR TITLE
Remove 'realpath' transitional debian package.

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -510,7 +510,7 @@ machine-prefix:
 DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools util-linux \
 				  gperf device-tree-compiler python-all-dev xorriso \
 				  autoconf automake bison flex texinfo libtool libtool-bin \
-				  realpath gawk libncurses5 libncurses5-dev bc \
+				  gawk libncurses5 libncurses5-dev bc \
 				  dosfstools mtools pkg-config git wget help2man libexpat1 \
 				  libexpat1-dev fakeroot python-sphinx rst2pdf \
 				  libefivar-dev libnss3-tools libnss3-dev libpopt-dev \


### PR DESCRIPTION
realpath is a coreutils transitional package. According to the package
description, it can be safely removed and exists only to facilitate
upgrades.