### PR TITLE
Fixes formatting of RFC3004 user class data

### DIFF
--- a/rootconf/default/lib/onie/functions
+++ b/rootconf/default/lib/onie/functions
@@ -388,6 +388,13 @@ str2hex()
     echo -n "$1" | hexdump -ve '1/1 "%.2x"'
 }
 
+# turn string into hex with prefixed length (as hex byte)
+str2lenhex()
+{
+    local str="$1"
+    printf "%02X%s" ${#str} $(str2hex $str)
+}
+
 make_str_opt()
 {
     local code="$1"
@@ -400,7 +407,7 @@ udhcpc_args()
 {
     local udhcp_args="-q -S -V onie_vendor:${onie_platform}"
     # user_class - option 77 - string in hex
-    local udhcp_user_class="-x 77:$(str2hex onie_dhcp_user_class)"
+    local udhcp_user_class="-x 77:$(str2lenhex onie_dhcp_user_class)"
     # vendor specific options - option 125 - string in hex
     # code 3 - machine
     # code 4 - CPU architecture


### PR DESCRIPTION
The RFC mandates that individual user class data items are prefixed with their length (in addition to the option length field).

See https://tools.ietf.org/html/rfc3004 for reference.

This causes issues with the DHCP packet, as seen in Wireshark:

<img width="689" alt="Screenshot 2020-01-16 at 20 42 14" src="https://user-images.githubusercontent.com/786420/72557266-b15ff480-38a0-11ea-8448-d4eda5b1020e.png">
