### PR TITLE
Alphanetworks STX-60D0-062F: Modify the console setting for new BIOS version.

### DIFF
--- a/machine/alphanetworks/alphanetworks_stx60d0_062f/machine.make
+++ b/machine/alphanetworks/alphanetworks_stx60d0_062f/machine.make
@@ -27,7 +27,7 @@ VENDOR_ID = 31874
 I2CTOOLS_ENABLE = yes
 
 # Console parameters
-CONSOLE_DEV = 0
+CONSOLE_DEV = 1
 
 # Enable UEFI support
 UEFI_ENABLE = yes


### PR DESCRIPTION
Modify the console setting for new BIOS (Version 20191003 and later version).