### PR TITLE
Update ipmitool to 1.8.18, and download url to github

### DIFF
--- a/build-config/make/ipmitool.make
+++ b/build-config/make/ipmitool.make
@@ -9,9 +9,9 @@
 # This is a makefile fragment that defines the build of ipmitool
 #
 
-IPMITOOL_VERSION		= 1.8.15
+IPMITOOL_VERSION		= 1.8.18
 IPMITOOL_TARBALL		= ipmitool-$(IPMITOOL_VERSION).tar.bz2
-IPMITOOL_TARBALL_URLS	+= $(ONIE_MIRROR) http://sourceforge.net/projects/ipmitool/files/ipmitool/$(IPMITOOL_VERSION)/$(IPMITOOL_TARBALL)/download
+IPMITOOL_TARBALL_URLS	+= $(ONIE_MIRROR) https://github.com/ipmitool/ipmitool/releases/download/IPMITOOL_$(subst .,_,$(IPMITOOL_VERSION))/
 IPMITOOL_BUILD_DIR	= $(USER_BUILDDIR)/ipmitool
 IPMITOOL_DIR		= $(IPMITOOL_BUILD_DIR)/ipmitool-$(IPMITOOL_VERSION)
 

--- a/upstream/ipmitool-1.8.18.tar.bz2.sha1
+++ b/upstream/ipmitool-1.8.18.tar.bz2.sha1
@@ -1,0 +1,1 @@
+f66b79902da95500a47d09ef916fc7bac4b94765  ipmitool-1.8.18.tar.bz2


### PR DESCRIPTION
The sourceforge site of ipmitool is obsolete
Refer to the link for more detail
https://sourceforge.net/projects/ipmitool/files/ipmitool/%21%21%21_READ_HERE_FIRST_%21%21%21/