### PR TITLE
Update dropbear to 2020.81, change its config: remove dss, add ed2551…

### DIFF
--- a/build-config/conf/dropbear.config.h
+++ b/build-config/conf/dropbear.config.h
@@ -1,356 +1,69 @@
-/* Dropbear SSH
- * Copyright (c) 2002,2003 Matt Johnston
- * All rights reserved. See LICENSE for the license. */
+#ifndef DROPBEAR_LOCAL_OPTIONS_H_
+#define DROPBEAR_LOCAL_OPTIONS_H_
 
-#ifndef DROPBEAR_OPTIONS_H_
-#define DROPBEAR_OPTIONS_H_
+#define NON_INETD_MODE 1
+#define INETD_MODE 0 /* -- ONIE not set */
 
-/* Define compile-time options below - the "#ifndef DROPBEAR_XXX .... #endif"
- * parts are to allow for commandline -DDROPBEAR_XXX options etc. */
+#define DROPBEAR_SMALL_CODE 0
 
-/* IMPORTANT: Many options will require "make clean" after changes */
+#define ENABLE_X11FWD 0 /* -- ONIE not set */
 
-#ifndef DROPBEAR_DEFPORT
-#define DROPBEAR_DEFPORT "22"
-#endif
+#define DROPBEAR_CLI_LOCALTCPFWD 1
+#define DROPBEAR_CLI_REMOTETCPFWD 1
 
-#ifndef DROPBEAR_DEFADDRESS
-/* Listen on all interfaces */
-#define DROPBEAR_DEFADDRESS ""
-#endif
+#define DROPBEAR_SVR_LOCALTCPFWD 1
+#define DROPBEAR_SVR_REMOTETCPFWD 1
 
-/* Default hostkey paths - these can be specified on the command line */
-#ifndef DSS_PRIV_FILENAME
-#define DSS_PRIV_FILENAME "/etc/dropbear/dropbear_dss_host_key"
-#endif
-#ifndef RSA_PRIV_FILENAME
-#define RSA_PRIV_FILENAME "/etc/dropbear/dropbear_rsa_host_key"
-#endif
-#ifndef ECDSA_PRIV_FILENAME
-#define ECDSA_PRIV_FILENAME "/etc/dropbear/dropbear_ecdsa_host_key"
-#endif
+#define DROPBEAR_SVR_AGENTFWD 1
+#define DROPBEAR_CLI_AGENTFWD 1
 
-/* Set NON_INETD_MODE if you require daemon functionality (ie Dropbear listens
- * on chosen ports and keeps accepting connections. This is the default.
- *
- * Set INETD_MODE if you want to be able to run Dropbear with inetd (or
- * similar), where it will use stdin/stdout for connections, and each process
- * lasts for a single connection. Dropbear should be invoked with the -i flag
- * for inetd, and can only accept IPv4 connections.
- *
- * Both of these flags can be defined at once, don't compile without at least
- * one of them. */
-#define NON_INETD_MODE
-/* #define INETD_MODE -- ONIE not set */
+#define DROPBEAR_CLI_PROXYCMD 1
+#define DROPBEAR_CLI_NETCAT 1
 
-/* Setting this disables the fast exptmod bignum code. It saves ~5kB, but is
- * perhaps 20% slower for pubkey operations (it is probably worth experimenting
- * if you want to use this) */
-/*#define NO_FAST_EXPTMOD*/
+#define DROPBEAR_USER_ALGO_LIST 1
+#define DROPBEAR_AES256 1
+#define DROPBEAR_AES128 1
+#define DROPBEAR_3DES 0
+#define DROPBEAR_TWOFISH256 0
+#define DROPBEAR_TWOFISH128 0
+#define DROPBEAR_CHACHA20POLY1305 1
 
-/* Set this if you want to use the DROPBEAR_SMALL_CODE option. This can save
-several kB in binary size however will make the symmetrical ciphers and hashes
-slower, perhaps by 50%. Recommended for small systems that aren't doing
-much traffic. */
-/*#define DROPBEAR_SMALL_CODE*/
+#define DROPBEAR_ENABLE_CTR_MODE 1
+#define DROPBEAR_ENABLE_CBC_MODE 0
+#define DROPBEAR_ENABLE_GCM_MODE 1
 
-/* Enable X11 Forwarding - server only */
-/* #define ENABLE_X11FWD -- ONIE not set */
+#define DROPBEAR_SHA1_HMAC 0
+#define DROPBEAR_SHA1_96_HMAC 0
+#define DROPBEAR_SHA2_256_HMAC 1
+#define DROPBEAR_SHA2_512_HMAC 1
+#define DROPBEAR_MD5_HMAC 0
 
-/* Enable TCP Fowarding */
-/* 'Local' is "-L" style (client listening port forwarded via server)
- * 'Remote' is "-R" style (server listening port forwarded via client) */
+#define DROPBEAR_RSA 1
+#define DROPBEAR_DSS 0
+#define DROPBEAR_ECDSA 1
+#define DROPBEAR_ED25519 1
 
-#define ENABLE_CLI_LOCALTCPFWD
-#define ENABLE_CLI_REMOTETCPFWD
+#define DROPBEAR_DEFAULT_RSA_SIZE 2048
 
-#define ENABLE_SVR_LOCALTCPFWD
-#define ENABLE_SVR_REMOTETCPFWD
-
-/* Enable Authentication Agent Forwarding */
-#define ENABLE_SVR_AGENTFWD
-#define ENABLE_CLI_AGENTFWD
-
-
-/* Note: Both ENABLE_CLI_PROXYCMD and ENABLE_CLI_NETCAT must be set to
- * allow multihop dbclient connections */
-
-/* Allow using -J <proxycommand> to run the connection through a 
-   pipe to a program, rather the normal TCP connection */
-#define ENABLE_CLI_PROXYCMD
-
-/* Enable "Netcat mode" option. This will forward standard input/output
- * to a remote TCP-forwarded connection */
-#define ENABLE_CLI_NETCAT
-
-/* Whether to support "-c" and "-m" flags to choose ciphers/MACs at runtime */
-#define ENABLE_USER_ALGO_LIST
-
-/* Encryption - at least one required.
- * Protocol RFC requires 3DES and recommends AES128 for interoperability.
- * Including multiple keysize variants the same cipher 
- * (eg AES256 as well as AES128) will result in a minimal size increase.*/
-#define DROPBEAR_AES128
-#define DROPBEAR_3DES
-#define DROPBEAR_AES256
-/* Compiling in Blowfish will add ~6kB to runtime heap memory usage */
-/*#define DROPBEAR_BLOWFISH*/
-#define DROPBEAR_TWOFISH256
-#define DROPBEAR_TWOFISH128
-
-/* Enable CBC mode for ciphers. This has security issues though
- * is the most compatible with older SSH implementations */
-#define DROPBEAR_ENABLE_CBC_MODE
-
-/* Enable "Counter Mode" for ciphers. This is more secure than normal
- * CBC mode against certain attacks. This adds around 1kB to binary 
- * size and is recommended for most cases */
-#define DROPBEAR_ENABLE_CTR_MODE
-
-/* You can compile with no encryption if you want. In some circumstances
- * this could be safe security-wise, though make sure you know what
- * you're doing. Anyone can see everything that goes over the wire, so
- * the only safe auth method is public key. */
-/* #define DROPBEAR_NONE_CIPHER */
-
-/* Message Integrity - at least one required.
- * Protocol RFC requires sha1 and recommends sha1-96.
- * sha1-96 is of use for slow links as it has a smaller overhead.
- *
- * There's no reason to disable sha1 or sha1-96 to save space since it's
- * used for the random number generator and public-key cryptography anyway.
- * Disabling it here will just stop it from being used as the integrity portion
- * of the ssh protocol.
- *
- * These hashes are also used for public key fingerprints in logs.
- * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
- * which are not the standard form. */
-#define DROPBEAR_SHA1_HMAC
-#define DROPBEAR_SHA1_96_HMAC
-#define DROPBEAR_SHA2_256_HMAC
-#define DROPBEAR_SHA2_512_HMAC
-#define DROPBEAR_MD5_HMAC
-
-/* You can also disable integrity. Don't bother disabling this if you're
- * still using a cipher, it's relatively cheap. If you disable this it's dead
- * simple for an attacker to run arbitrary commands on the remote host. Beware. */
-/* #define DROPBEAR_NONE_INTEGRITY */
-
-/* Hostkey/public key algorithms - at least one required, these are used
- * for hostkey as well as for verifying signatures with pubkey auth.
- * Removing either of these won't save very much space.
- * SSH2 RFC Draft requires dss, recommends rsa */
-#define DROPBEAR_RSA
-#define DROPBEAR_DSS
-/* ECDSA is significantly faster than RSA or DSS. Compiling in ECC
- * code (either ECDSA or ECDH) increases binary size - around 30kB
- * on x86-64 */
-#define DROPBEAR_ECDSA
-
-/* Generate hostkeys as-needed when the first connection using that key type occurs.
-   This avoids the need to otherwise run "dropbearkey" and avoids some problems
-   with badly seeded /dev/urandom when systems first boot.
-   This also requires a runtime flag "-R". This adds ~4kB to binary size (or hardly 
-   anything if dropbearkey is linked in a "dropbearmulti" binary) */
-#define DROPBEAR_DELAY_HOSTKEY
-
-/* Enable Curve25519 for key exchange. This is another elliptic
- * curve method with good security properties. Increases binary size
- * by ~8kB on x86-64 */
-#define DROPBEAR_CURVE25519
-
-/* Enable elliptic curve Diffie Hellman key exchange, see note about
- * ECDSA above */
-#define DROPBEAR_ECDH
-
-/* Key exchange algorithm.
- * group14_sha1 - 2048 bit, sha1
- * group14_sha256 - 2048 bit, sha2-256
- * group16 - 4096 bit, sha2-512
- * group1 - 1024 bit, sha1
- *
- * group14 is supported by most implementations.
- * group16 provides a greater strength level but is slower and increases binary size
- * group1 is too small for security though is necessary if you need 
-     compatibility with some implementations such as Dropbear versions < 0.53
- */ 
-#define DROPBEAR_DH_GROUP1 1
-#define DROPBEAR_DH_GROUP14_SHA1 1
+#define DROPBEAR_DH_GROUP14_SHA1 0
 #define DROPBEAR_DH_GROUP14_SHA256 1
-#define DROPBEAR_DH_GROUP16 0
+#define DROPBEAR_DH_GROUP16 1
+#define DROPBEAR_CURVE25519 1
+#define DROPBEAR_ECDH 1
+#define DROPBEAR_DH_GROUP1 0
 
-/* Control the memory/performance/compression tradeoff for zlib.
- * Set windowBits=8 for least memory usage, see your system's
- * zlib.h for full details.
- * Default settings (windowBits=15) will use 256kB for compression
- * windowBits=8 will use 129kB for compression.
- * Both modes will use ~35kB for decompression (using windowBits=15 for
- * interoperability) */
-#ifndef DROPBEAR_ZLIB_WINDOW_BITS
-#define DROPBEAR_ZLIB_WINDOW_BITS 15 
-#endif
+#define DROPBEAR_SVR_PASSWORD_AUTH 1
+#define DROPBEAR_SVR_PUBKEY_AUTH 1
+#define DROPBEAR_SVR_PUBKEY_OPTIONS 1
 
-/* Server won't allow zlib compression until after authentication. Prevents
-   flaws in the zlib library being unauthenticated exploitable flaws.
-   Some old ssh clients may not support the alternative zlib@openssh.com method */
-#define DROPBEAR_SERVER_DELAY_ZLIB 1
+#define DROPBEAR_CLI_PASSWORD_AUTH 1
+#define DROPBEAR_CLI_PUBKEY_AUTH 1
+#define DROPBEAR_CLI_INTERACT_AUTH 1
 
-/* Whether to do reverse DNS lookups. */
-/*#define DO_HOST_LOOKUP */
+#define DROPBEAR_USE_PASSWORD_ENV 0 /* -- ONIE not set */
 
-/* Whether to print the message of the day (MOTD). This doesn't add much code
- * size */
-#define DO_MOTD
-
-/* The MOTD file path */
-#ifndef MOTD_FILENAME
-#define MOTD_FILENAME "/etc/motd"
-#endif
-
-/* Authentication Types - at least one required.
-   RFC Draft requires pubkey auth, and recommends password */
-
-/* Note: PAM auth is quite simple and only works for PAM modules which just do
- * a simple "Login: " "Password: " (you can edit the strings in svr-authpam.c).
- * It's useful for systems like OS X where standard password crypts don't work
- * but there's an interface via a PAM module. It won't work for more complex
- * PAM challenge/response.
- * You can't enable both PASSWORD and PAM. */
-
-#define ENABLE_SVR_PASSWORD_AUTH
-/* PAM requires ./configure --enable-pam */
-/*#define ENABLE_SVR_PAM_AUTH */
-#define ENABLE_SVR_PUBKEY_AUTH
-
-/* Whether to take public key options in 
- * authorized_keys file into account */
-#ifdef ENABLE_SVR_PUBKEY_AUTH
-#define ENABLE_SVR_PUBKEY_OPTIONS
-#endif
-
-#define ENABLE_CLI_PASSWORD_AUTH
-#define ENABLE_CLI_PUBKEY_AUTH
-#define ENABLE_CLI_INTERACT_AUTH
-
-/* A default argument for dbclient -i <privatekey>. 
-   leading "~" is expanded */
-#define DROPBEAR_DEFAULT_CLI_AUTHKEY "~/.ssh/id_dropbear"
-
-/* This variable can be used to set a password for client
- * authentication on the commandline. Beware of platforms
- * that don't protect environment variables of processes etc. Also
- * note that it will be provided for all "hidden" client-interactive
- * style prompts - if you want something more sophisticated, use 
- * SSH_ASKPASS instead. Comment out this var to remove this functionality.*/
-/* #define DROPBEAR_PASSWORD_ENV "DROPBEAR_PASSWORD" -- ONIE not set */
-
-/* Define this (as well as ENABLE_CLI_PASSWORD_AUTH) to allow the use of
- * a helper program for the ssh client. The helper program should be
- * specified in the SSH_ASKPASS environment variable, and dbclient
- * should be run with DISPLAY set and no tty. The program should
- * return the password on standard output */
-/*#define ENABLE_CLI_ASKPASS_HELPER*/
-
-/* Save a network roundtrip by sendng a real auth request immediately after
- * sending a query for the available methods.  It is at the expense of < 100
- * bytes of extra network traffic. This is not yet enabled by default since it
- * could cause problems with non-compliant servers */
-/* #define DROPBEAR_CLI_IMMEDIATE_AUTH */
-
-/* Source for randomness. This must be able to provide hundreds of bytes per SSH
- * connection without blocking. In addition /dev/random is used for seeding
- * rsa/dss key generation */
 #define DROPBEAR_URANDOM_DEV "/dev/urandom"
 
-/* Set this to use PRNGD or EGD instead of /dev/urandom or /dev/random */
-/*#define DROPBEAR_PRNGD_SOCKET "/var/run/dropbear-rng"*/
+#define DROPBEAR_SFTPSERVER 0 /* -- ONIE not set */
 
-
-/* Specify the number of clients we will allow to be connected but
- * not yet authenticated. After this limit, connections are rejected */
-/* The first setting is per-IP, to avoid denial of service */
-#ifndef MAX_UNAUTH_PER_IP
-#define MAX_UNAUTH_PER_IP 5
-#endif
-
-/* And then a global limit to avoid chewing memory if connections 
- * come from many IPs */
-#ifndef MAX_UNAUTH_CLIENTS
-#define MAX_UNAUTH_CLIENTS 30
-#endif
-
-/* Maximum number of failed authentication tries (server option) */
-#ifndef MAX_AUTH_TRIES
-#define MAX_AUTH_TRIES 10
-#endif
-
-/* The default file to store the daemon's process ID, for shutdown
-   scripts etc. This can be overridden with the -P flag */
-#ifndef DROPBEAR_PIDFILE
-#define DROPBEAR_PIDFILE "/var/run/dropbear.pid"
-#endif
-
-/* The command to invoke for xauth when using X11 forwarding.
- * "-q" for quiet */
-#ifndef XAUTH_COMMAND
-#define XAUTH_COMMAND "/usr/bin/xauth -q"
-#endif
-
-/* if you want to enable running an sftp server (such as the one included with
- * OpenSSH), set the path below. If the path isn't defined, sftp will not
- * be enabled */
-#ifndef SFTPSERVER_PATH
-/* #define SFTPSERVER_PATH "/usr/libexec/sftp-server" -- ONIE not set */
-#endif
-
-/* This is used by the scp binary when used as a client binary. If you're
- * not using the Dropbear client, you'll need to change it */
-#define DROPBEAR_PATH_SSH_PROGRAM "/usr/bin/dbclient"
-
-/* Whether to log commands executed by a client. This only logs the 
- * (single) command sent to the server, not what a user did in a 
- * shell/sftp session etc. */
-/* #define LOG_COMMANDS */
-
-/* Window size limits. These tend to be a trade-off between memory
-   usage and network performance: */
-/* Size of the network receive window. This amount of memory is allocated
-   as a per-channel receive buffer. Increasing this value can make a
-   significant difference to network performance. 24kB was empirically
-   chosen for a 100mbit ethernet network. The value can be altered at
-   runtime with the -W argument. */
-#ifndef DEFAULT_RECV_WINDOW
-#define DEFAULT_RECV_WINDOW 24576
-#endif
-/* Maximum size of a received SSH data packet - this _MUST_ be >= 32768
-   in order to interoperate with other implementations */
-#ifndef RECV_MAX_PAYLOAD_LEN
-#define RECV_MAX_PAYLOAD_LEN 32768
-#endif
-/* Maximum size of a transmitted data packet - this can be any value,
-   though increasing it may not make a significant difference. */
-#ifndef TRANS_MAX_PAYLOAD_LEN
-#define TRANS_MAX_PAYLOAD_LEN 16384
-#endif
-
-/* Ensure that data is transmitted every KEEPALIVE seconds. This can
-be overridden at runtime with -K. 0 disables keepalives */
-#define DEFAULT_KEEPALIVE 0
-
-/* If this many KEEPALIVES are sent with no packets received from the
-other side, exit. Not run-time configurable - if you have a need
-for runtime configuration please mail the Dropbear list */
-#define DEFAULT_KEEPALIVE_LIMIT 3
-
-/* Ensure that data is received within IDLE_TIMEOUT seconds. This can
-be overridden at runtime with -I. 0 disables idle timeouts */
-#define DEFAULT_IDLE_TIMEOUT 0
-
-/* The default path. This will often get replaced by the shell */
-#define DEFAULT_PATH "/usr/bin:/bin"
-
-/* Some other defines (that mostly should be left alone) are defined
- * in sysoptions.h */
-#include "sysoptions.h"
-
-#endif /* DROPBEAR_OPTIONS_H_ */
+#endif /* DROPBEAR_LOCAL_OPTIONS_H_ */

--- a/build-config/make/dropbear.make
+++ b/build-config/make/dropbear.make
@@ -10,7 +10,7 @@
 # This is a makefile fragment that defines the build of dropbear
 #
 
-DROPBEAR_VERSION		= 2016.74
+DROPBEAR_VERSION		= 2020.81
 DROPBEAR_TARBALL		= dropbear-$(DROPBEAR_VERSION).tar.bz2
 DROPBEAR_TARBALL_URLS		+= $(ONIE_MIRROR) https://matt.ucc.asn.au/dropbear/releases
 DROPBEAR_BUILD_DIR		= $(USER_BUILDDIR)/dropbear
@@ -72,16 +72,17 @@ $(DROPBEAR_CONFIGURE_STAMP): $(DROPBEAR_SOURCE_STAMP) $(ZLIB_BUILD_STAMP) \
 		$(DROPBEAR_DIR)/configure			\
 		--prefix=/usr					\
 		--host=$(TARGET)				\
+		--disable-harden				\
 		CFLAGS="$(ONIE_CFLAGS)" 			\
 		LDFLAGS="$(ONIE_LDFLAGS)"
 	$(Q) touch $@
 
-$(DROPBEAR_DIR)/options.h: $(DROPBEAR_CONFIG_H) $(DROPBEAR_CONFIGURE_STAMP)
+$(DROPBEAR_DIR)/localoptions.h: $(DROPBEAR_CONFIG_H) $(DROPBEAR_CONFIGURE_STAMP)
 	$(Q) echo "==== Copying $(DROPBEAR_CONFIG_H) to $@ ===="
 	$(Q) cp -v $< $@
 
 dropbear-build: $(DROPBEAR_BUILD_STAMP)
-$(DROPBEAR_BUILD_STAMP): $(DROPBEAR_DIR)/options.h $(DROPBEAR_NEW_FILES)
+$(DROPBEAR_BUILD_STAMP): $(DROPBEAR_DIR)/localoptions.h $(DROPBEAR_NEW_FILES)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Building dropbear-$(DROPBEAR_VERSION) ===="
 	$(Q) PATH='$(CROSSBIN):$(PATH)'	$(MAKE) -C $(DROPBEAR_DIR) DESTDIR=$(DEV_SYSROOT) \

--- a/rootconf/default/etc/init.d/dropbear.sh
+++ b/rootconf/default/etc/init.d/dropbear.sh
@@ -18,23 +18,23 @@ daemon=/usr/sbin/$name
 ARGS="-m -B"
 
 RSA_KEY=/etc/dropbear/dropbear_rsa_host_key
-DSS_KEY=/etc/dropbear/dropbear_dss_host_key
 ECDSA_KEY=/etc/dropbear/dropbear_ecdsa_host_key
+ED25519_KEY=/etc/dropbear/dropbear_ed25519_host_key
 
 [ -r /lib/onie/dropbear-arch ] && . /lib/onie/dropbear-arch
 
 get_keys() {
     # If keys are already present just return
-    [ -r "$ECDSA_KEY" ] && [ -r "$RSA_KEY" ] && [ -r "$DSS_KEY" ] && return 0
+    [ -r "$ED25519_KEY" ] && [ -r "$ECDSA_KEY" ] && [ -r "$RSA_KEY" ] && return 0
 
     get_keys_arch || {
         # If problems just make new keys in ramdisk
+        # genereate ed25519 key
+        dropbearkey -t ed25519 -f $ED25519_KEY > /dev/null 2>&1
         # genereate ecdsa key
         dropbearkey -t ecdsa -s 256 -f $ECDSA_KEY > /dev/null 2>&1
         # genereate rsa key
         dropbearkey -t rsa -s 1024 -f $RSA_KEY > /dev/null 2>&1
-        # genereate dss key
-        dropbearkey -t dss -s 1024 -f $DSS_KEY > /dev/null 2>&1
     }
 }
 

--- a/rootconf/grub-arch/sysroot-lib-onie/dropbear-arch
+++ b/rootconf/grub-arch/sysroot-lib-onie/dropbear-arch
@@ -15,6 +15,15 @@ get_keys_arch() {
     # The ONIE-CONFIG partition is unavailable during recovery.
     [ "$boot_env" = "recovery" ] && return 1
 
+    if [ -r "$onie_config_dir/$ED25519_KEY" ] ; then
+        cp "$onie_config_dir/$ED25519_KEY" $ED25519_KEY
+    else
+        # genereate ed25519 key
+        dropbearkey -t ed25519 -f $ED25519_KEY > /dev/null 2>&1
+        mkdir -p "$(dirname $onie_config_dir/$ED25519_KEY)"
+        cp $ED25519_KEY "$onie_config_dir/$ED25519_KEY"
+    fi
+
     if [ -r "$onie_config_dir/$ECDSA_KEY" ] ; then
         cp "$onie_config_dir/$ECDSA_KEY" $ECDSA_KEY
     else
@@ -31,15 +40,6 @@ get_keys_arch() {
         dropbearkey -t rsa -s 1024 -f $RSA_KEY > /dev/null 2>&1
         mkdir -p "$(dirname $onie_config_dir/$RSA_KEY)"
         cp $RSA_KEY "$onie_config_dir/$RSA_KEY"
-    fi
-
-    if [ -r "$onie_config_dir/$DSS_KEY" ] ; then
-        cp "$onie_config_dir/$DSS_KEY" $DSS_KEY
-    else
-        # genereate dss key
-        dropbearkey -t dss -s 1024 -f $DSS_KEY > /dev/null 2>&1
-        mkdir -p "$(dirname $onie_config_dir/$DSS_KEY)"
-        cp $DSS_KEY "$onie_config_dir/$DSS_KEY"
     fi
 
 }

--- a/rootconf/u-boot-arch/sysroot-lib-onie/dropbear-arch
+++ b/rootconf/u-boot-arch/sysroot-lib-onie/dropbear-arch
@@ -5,14 +5,23 @@
 #
 #  SPDX-License-Identifier:     GPL-2.0
 
+ed25519_var=onie_dropbear_ed25519_host_key
 ecdsa_var=onie_dropbear_ecdsa_host_key
 rsa_var=onie_dropbear_rsa_host_key
-dss_var=onie_dropbear_dss_host_key
 
 # The RSA and DSS keys are stored in U-Boot environment variables.  If
 # the variables are empty generate the keys and store the results for
 # future boots.
 get_keys_arch() {
+    ed25519_val=$(fw_printenv -n "$ed25519_var" 2> /dev/null)
+    if [ -n "$ed25519_val" ] ; then
+        # decode base64 string
+        echo "$ed25519_val" | tr '@#' ' \n' | uudecode -o $ED25519_KEY
+    else
+        # genereate ed25519 key
+        dropbearkey -t ed25519 -f $ED25519_KEY > /dev/null 2>&1
+    fi
+
     ecdsa_val=$(fw_printenv -n "$ecdsa_var" 2> /dev/null)
     if [ -n "$ecdsa_val" ] ; then
         # decode base64 string
@@ -31,18 +40,13 @@ get_keys_arch() {
         dropbearkey -t rsa -s 1024 -f $RSA_KEY > /dev/null 2>&1
     fi
 
-    dss_val=$(fw_printenv -n "$dss_var" 2> /dev/null)
-    if [ -n "$dss_val" ] ; then
-        # decode base64 string
-        echo "$dss_val" | tr '@#' ' \n' | uudecode -o $DSS_KEY
-    else
-        # genereate dss key
-        dropbearkey -t dss -s 1024 -f $DSS_KEY > /dev/null 2>&1
-    fi
-
-    if [ -z "$ecdsa_val" ] || [ -z "$rsa_val" ] || [ -z "$dss_val" ] ; then
+    if [ -z "$ed25519_val" ] || [ -z "$ecdsa_val" ] || [ -z "$rsa_val" ] ; then
         tmp_env=$(mktemp)
         # encode key values
+        if [ -z "$ed25519_val" ] ; then
+            ed25519_val=$(uuencode -m $ED25519_KEY r | tr ' \n' '@#')
+            echo "$ed25519_var $ed25519_val" >> $tmp_env
+        fi
         if [ -z "$ecdsa_val" ] ; then
             ecdsa_val=$(uuencode -m $ECDSA_KEY r | tr ' \n' '@#')
             echo "$ecdsa_var $ecdsa_val" >> $tmp_env
@@ -50,10 +54,6 @@ get_keys_arch() {
         if [ -z "$rsa_val" ] ; then
             rsa_val=$(uuencode -m $RSA_KEY r | tr ' \n' '@#')
             echo "$rsa_var $rsa_val" >> $tmp_env
-        fi
-        if [ -z "$dss_val" ] ; then
-            dss_val=$(uuencode -m $DSS_KEY d | tr ' \n' '@#')
-            echo "$dss_var $dss_val" >> $tmp_env
         fi
         fw_setenv -f -s $tmp_env || {
             log_failure_msg "Unable to save dropbear ssh server keys"

--- a/upstream/dropbear-2020.81.tar.bz2.sha1
+++ b/upstream/dropbear-2020.81.tar.bz2.sha1
@@ -1,0 +1,1 @@
+c3d4fe27fa17ec8217dbedbd33dd73a1ca6cda2c  dropbear-2020.81.tar.bz2


### PR DESCRIPTION
…9 keys, harden ciphers set

Changes applied it this patch:
- use modern dropbear version
- new version has separate config header file for customizations
- parameters in config are now set with 0/1 value instead undefined/defined
- update sets of ciphers, hashes, sighature algorithms, etc. to the stronge ones
- remove ssh host dss key and add ed25512 key in config and scripts
- add "--disable-harden" to dropbear compile options for it to succeed