### PR TITLE
[armv8a] fix bug for compile qemu armv8a image for issues 940

### DIFF
--- a/build-config/scripts/onie-mk-iso.sh
+++ b/build-config/scripts/onie-mk-iso.sh
@@ -64,14 +64,16 @@ RECOVERY_ISO_IMAGE=${12}
     echo "ERROR: Unable to read recovery config directory: $RECOVERY_CONF_DIR"
     exit 1
 }
-[ -r "${GRUB_TARGET_LIB_I386_DIR}/biosdisk.mod" ] || {
-    echo "ERROR: Does not look like valid GRUB i386-pc library directory: $GRUB_TARGET_LIB_I386_DIR"
-    exit 1
-}
-[ -x "${GRUB_HOST_BIN_I386_DIR}/grub-mkimage" ] || {
-    echo "ERROR: Does not look like valid GRUB i386-pc bin directory: $GRUB_HOST_BIN_I386_DIR"
-    exit 1
-}
+if [ "$UEFI_ENABLE" != "yes" ] ; then
+    [ -r "${GRUB_TARGET_LIB_I386_DIR}/biosdisk.mod" ] || {
+        echo "ERROR: Does not look like valid GRUB i386-pc library directory: $GRUB_TARGET_LIB_I386_DIR"
+        exit 1
+    }
+    [ -x "${GRUB_HOST_BIN_I386_DIR}/grub-mkimage" ] || {
+        echo "ERROR: Does not look like valid GRUB i386-pc bin directory: $GRUB_HOST_BIN_I386_DIR"
+        exit 1
+    }
+fi
 if [ "$UEFI_ENABLE" = "yes" ] ; then
     [ -r "${GRUB_TARGET_LIB_UEFI_DIR}/efinet.mod" ] || {
         echo "ERROR: Does not look like valid GRUB ${ARCH}-efi library directory: $GRUB_TARGET_LIB_UEFI_DIR"
@@ -207,7 +209,6 @@ if [ "$UEFI_ENABLE" = "yes" ] ; then
 	loadenv
 	loopback
 	linux
-	linuxefi
 	lsefi
 	lsefimmap
 	lsefisystab
@@ -242,6 +243,10 @@ if [ "$UEFI_ENABLE" = "yes" ] ; then
 	zfscrypt
 	zfsinfo
 "
+
+    if [ ${ARCH} != "arm64" ]; then
+        GRUB_MODULES=$GRUB_MODULES" linuxefi"
+    fi
     # Generate UEFI format GRUB image
     mkdir -p $RECOVERY_EFI_BOOT_DIR
     $GRUB_HOST_BIN_UEFI_DIR/grub-mkimage \

--- a/machine/qemu_armv8a/machine.make
+++ b/machine/qemu_armv8a/machine.make
@@ -48,6 +48,8 @@ PXE_EFI64_ENABLE = yes
 
 LINUX_VERSION = 4.4
 LINUX_MINOR_VERSION = 30
+KERNEL_DTB = arm/vexpress-v2f-1xv7-ca53x2.dtb
+KERNEL_DTB_PATH = dts/$(KERNEL_DTB)
 
 # The VENDOR_VERSION string is appended to the overal ONIE version
 # string.  HW vendors can use this to appended their own versioning


### PR DESCRIPTION
Fix bug for compile qemu armv8a image for issues 940

build:
cd onie/build-config
make -j4 MACHINE=qemu_armv8a all demo

run:
qemu-img create -f qcow2 onie-aarch64-demo.img 1G
wget http://releases.linaro.org/components/kernel/uefi-linaro/16.02/release/qemu64/QEMU_EFI.fd
cat QEMU_EFI.fd /dev/zero | dd iflag=fullblock bs=1M count=64 of=flash0.img
dd if=/dev/zero of=flash1.img bs=1M count=64
qemu-system-aarch64 -machine virt -m 1024M -cpu cortex-a57 -nographic -drive if=none,file=onie-aarch64-demo.img,id=hd0 -device virtio-blk-device,drive=hd0 -cdrom onie-recovery-arm64-qemu_armv8a-r0.iso -pflash flash0.img -pflash flash1.img