### PR TITLE
fix: add unzip to build tools

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -597,7 +597,7 @@ DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools util-linux \
 				  libexpat1-dev fakeroot python-sphinx rst2pdf \
 				  libefivar-dev libnss3-tools libnss3-dev libpopt-dev \
 				  libssl-dev sbsigntool uuid-runtime uuid-dev cpio \
-				  bsdmainutils
+				  bsdmainutils unzip
 
 PHONY += debian-prepare-build-host
 debian-prepare-build-host:

--- a/contrib/build-env/Dockerfile
+++ b/contrib/build-env/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     libexpat1-dev fakeroot python-sphinx rst2pdf \
     libefivar-dev libnss3-tools libnss3-dev libpopt-dev \
     libssl-dev sbsigntool uuid-runtime uuid-dev cpio \
-    bsdmainutils curl sudo
+    bsdmainutils curl sudo unzip
 
 # Create build user
 RUN useradd -m -s /bin/bash build && \


### PR DESCRIPTION
While toying around with getting the recovery-iso to build, I found that the make file build process depends on `unzip` however, this is not included in the docker image for the onie build environment and is not installed by the debian-prepare-build-host make target. This PR has two tiny commits to add the unzip package when using those tools. 