### PR TITLE
Add Alpha Networks SNJ-61D0-320F platforms

### DIFF
--- a/build-config/scripts/onie-build-targets.json
+++ b/build-config/scripts/onie-build-targets.json
@@ -97,7 +97,7 @@
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snh61d2_320f",    "BuildEnv": "Debian9", "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj60b0_320f",    "BuildEnv": "Debian9", "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj60d0_320f",    "BuildEnv": "Debian9", "Release": "2021.05br", "Architecture": "amd64",   "Notes": "No notes." },
-    { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj61d0_320f",    "BuildEnv": "Debian9", "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
+    { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj61d0_320f",    "BuildEnv": "Debian10","Release": "2021.11br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj62d0_640f",    "BuildEnv": "Debian10","Release": "2021.11br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snq6070_320f",    "BuildEnv": "Debian9", "Release": "2020.05br", "Architecture": "PowerPC", "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snq60a0_320f",    "BuildEnv": "Debian9", "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },

--- a/machine/alphanetworks/alphanetworks_snj61d0_320f/INSTALL
+++ b/machine/alphanetworks/alphanetworks_snj61d0_320f/INSTALL
@@ -2,25 +2,25 @@
 Installing ONIE on Alpha_Networks SNJ61D0-320F
 ==============================================
 
-Cross-Compiling ONIE
-====================
+Cross-Compiling r0 ONIE
+=======================
 
 Change directories to ``build-config`` to compile ONIE.
 
 To compile ONIE first change directories to ``build-config`` and then
-type ``"make MACHINEROOT=../machine/alphanetworks  MACHINE=alphanetworks_snj61d0_320f all"``.
+type ``"make MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snj61d0_320f VENDOR_REV=0 all"``.
 For example:
 
   $ cd build-config
-  $ make -j4 MACHINEROOT=../machine/alphanetworks  MACHINE=alphanetworks_snj61d0_320f all
+  $ make -j4 MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snj61d0_320f VENDOR_REV=0 all
 
 When complete, the ONIE binaries are located in
 ``build/images``:
 
--rw-r--r-- 1 5986340 Aug 10 15:28 alphanetworks_snj61d0_320f-r0.initrd
--rw-r--r-- 1 3091952 Aug 10 15:13 alphanetworks_snj61d0_320f-r0.vmlinuz
--rw-r--r-- 1 20774912 Aug 10 15:14 onie-recovery-x86_64-alphanetworks_snj61d0_320f-r0.iso
--rw-r--r-- 1 9135991 Aug 10 15:14 onie-updater-x86_64-alphanetworks_snj61d0_320f-r0
+-rw-r--r-- 1 build build 10553808 Dec 21 01:03 alphanetworks_snj61d0_320f-r0.initrd
+-rw-r--r-- 1 build build  3780688 Dec 21 01:06 alphanetworks_snj61d0_320f-r0.vmlinuz
+-rw-r--r-- 1 build build 32571392 Dec 21 01:06 onie-recovery-x86_64-alphanetworks_snj61d0_320f-r0.iso
+-rw-r--r-- 1 build build 14297082 Dec 21 01:06 onie-updater-x86_64-alphanetworks_snj61d0_320f-r0
 
 alphanetworks_snj61d0_320f-r0.vmlinuz -- This is the ONIE kernel image
 
@@ -33,6 +33,68 @@ onie-recovery-x86_64-alphanetworks_snj61d0_320f-r0.iso -- This is a recovery ISO
 image. This image can be used to create a bootable USB memory stick for 
 installing/recovery ONIE.
 
+Cross-Compiling r1 ONIE
+=======================
+
+Change directories to ``build-config`` to compile ONIE.
+
+To compile ONIE first change directories to ``build-config`` and then
+type ``"make MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snj61d0_320f VENDOR_REV=1 all"``.
+For example:
+
+  $ cd build-config
+  $ make -j4 MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snj61d0_320f VENDOR_REV=1 all
+
+When complete, the ONIE binaries are located in
+``build/images``:
+
+-rw-r--r-- 1 build build 10554564 Dec 21 00:54 alphanetworks_snj61d0_320f-r1.initrd
+-rw-r--r-- 1 build build  3780688 Dec 21 00:58 alphanetworks_snj61d0_320f-r1.vmlinuz
+-rw-r--r-- 1 build build 32571392 Dec 21 00:58 onie-recovery-x86_64-alphanetworks_snj61d0_320f-r1.iso
+-rw-r--r-- 1 build build 14297082 Dec 21 00:58 onie-updater-x86_64-alphanetworks_snj61d0_320f-r1
+
+alphanetworks_snj61d0_320f-r1.vmlinuz -- This is the ONIE kernel image
+
+alphanetworks_snj61d0_320f-r1.initrd  -- This is the ONIE initramfs (filesystem)
+
+onie-updater-x86_64-alphanetworks_snj61d0_320f-r1 -- This is the ONIE self-update
+image.  This image is a self-extracting archive used for installing ONIE.
+
+onie-recovery-x86_64-alphanetworks_snj61d0_320f-r1.iso -- This is a recovery ISO 
+image. This image can be used to create a bootable USB memory stick for 
+installing/recovery ONIE.
+
+Cross-Compiling r2 ONIE
+=======================
+
+Change directories to ``build-config`` to compile ONIE.
+
+To compile ONIE first change directories to ``build-config`` and then
+type ``"make MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snj61d0_320f all"``.
+For example:
+
+  $ cd build-config
+  $ make -j4 MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snj61d0_320f all
+
+When complete, the ONIE binaries are located in
+``build/images``:
+
+-rw-r--r-- 1 build build 10555556 Dec 21 02:43 alphanetworks_snj61d0_320f-r2.initrd
+-rw-r--r-- 1 build build  3780688 Dec 21 02:46 alphanetworks_snj61d0_320f-r2.vmlinuz
+-rw-r--r-- 1 build build 32571392 Dec 21 02:47 onie-recovery-x86_64-alphanetworks_snj61d0_320f-r2.iso
+-rw-r--r-- 1 build build 14297082 Dec 21 02:46 onie-updater-x86_64-alphanetworks_snj61d0_320f-r2
+
+alphanetworks_snj61d0_320f-r2.vmlinuz -- This is the ONIE kernel image
+
+alphanetworks_snj61d0_320f-r2.initrd  -- This is the ONIE initramfs (filesystem)
+
+onie-updater-x86_64-alphanetworks_snj61d0_320f-r2 -- This is the ONIE self-update
+image.  This image is a self-extracting archive used for installing ONIE.
+
+onie-recovery-x86_64-alphanetworks_snj61d0_320f-r2.iso -- This is a recovery ISO 
+image. This image can be used to create a bootable USB memory stick for 
+installing/recovery ONIE.
+
 Installing ONIE on a Blank Machine
 ==================================
 
@@ -42,12 +104,12 @@ create a bootable USB memory stick.
 Creating bootable USB stick
 ---------------------------
 
-Use ``dd`` to copy the .iso image to a USB stick and boot from that::
+Use ``dd`` to copy the .iso image to a USB stick and boot from that:
 
   dd if=<machine>.iso of=/dev/sdX bs=10M
 
-For example::
-  dd if=onie-recovery-x86_64-alphanetworks_snj61d0_320f-r0.iso of=/dev/sdb bs=10M
+For example:
+  dd if=onie-recovery-x86_64-alphanetworks_snj61d0_320f-r2.iso of=/dev/sdb bs=10M
 
 You can find the correct ``/dev/sdX`` by inspecing the ``dmesg``
 output after inserting the USB stick into your work station.
@@ -66,26 +128,27 @@ To enable booting from USB in the BIOS:
   In "Boot Option #1" select the device that corresponds to your
   device:
 
-    Boot-->FIXED BOOT ORDER Priorities-->Boot Option #1
+    Boot-->Boot Option Priorities-->Boot Option #1
 
   If the device name is not listed in "Boot Option #1", please
-  check the priorities in the FIXED BOOT ORDER Priorities.
+  check the priorities in the hard drive boot order:
 
-    Boot-->FIXED BOOT ORDER Priorities-->Boot Option #1
+    Boot-->Hard Drive BBS Priorities-->Boot Option #1
 
   Taking ``JetFlashTranscend 8GB 8.07`` as an example, the boot
   order will look like following:
 
-    FIXED BOOT ORDER Priorities
+    Boot Option Priorities
     Boot Option #1          [JetFlashTranscend 8...]
-    Boot Option #2          [UEFI: Built-in EFI ...]
-    Boot Option #3          [UEFI Network]
+    Boot Option #2          [ATP ATP IG eUSB 1100]
+    Boot Option #3          [IBA GE Slot 00A0 v1543]
+    Boot Option #4          [UEFI: Built-in EFI ...]
 
 4. Save and Exit the BIOS configuration
 
 5. After several seconds, you should see:
 
-                             GNU GRUB  version 2.02
+                             GNU GRUB  version 2.04
 
  +----------------------------------------------------------------------------+
  |*ONIE: Rescue                                                               |

--- a/machine/alphanetworks/alphanetworks_snj61d0_320f/installer.conf
+++ b/machine/alphanetworks/alphanetworks_snj61d0_320f/installer.conf
@@ -5,7 +5,24 @@ description="AlphaNetworks, SNJ61D0-320F"
 # Default ONIE block device
 install_device_platform()
 {
+    # find ata device on the system, return the 1st one.
+
+    ##
+    # find the sata dom
+    ##
+
+    for _device in /sys/block/sd*/device; do
+        # Denverton SATA 1 PCI Register (D:20,F:0).
+        if echo $(readlink -f $_device)|egrep -q "pci0000:00\/0000:00:14.0"; then
+            _disk=`echo $_device | cut -f4 -d/`
+            echo /dev/$_disk
+            return 0
+        fi
+    done
+
+    # nothing found, just return /dev/sda
     echo /dev/sda
+    return 1
 }
 
 # Local Variables:

--- a/machine/alphanetworks/alphanetworks_snj61d0_320f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snj61d0_320f/machine.make
@@ -1,13 +1,17 @@
-# Alpha Networks SNJ60D0-320F
+# Alpha Networks SNJ61D0-320F
 
 ONIE_ARCH ?= x86_64
 SWITCH_ASIC_VENDOR = bcm
 
-VENDOR_REV ?= 0
+VENDOR_REV ?= 2
 
 # Translate hardware revision to ONIE hardware revision
 ifeq ($(VENDOR_REV),0)
   MACHINE_REV = 0
+else ifeq ($(VENDOR_REV),1)
+  MACHINE_REV = 1
+else ifeq ($(VENDOR_REV),2)
+  MACHINE_REV = 2
 else
   $(warning Unknown VENDOR_REV '$(VENDOR_REV)' for MACHINE '$(MACHINE)')
   $(error Unknown VENDOR_REV)
@@ -36,9 +40,13 @@ UEFI_ENABLE = yes
 LINUX_VERSION		= 4.9
 LINUX_MINOR_VERSION	= 95
 
-# Older GCC required for older 3.14.27 kernel
-#GCC_VERSION = 4.9.2
+# Set GCC version
+GCC_VERSION = 8.3.0
 
+# Set uClibc-ng version
+XTOOLS_LIBC_VERSION = 1.0.35
+
+include $(MACHINEDIR)/rootconf/grub-machine.make
 
 #-------------------------------------------------------------------------------
 #

--- a/machine/alphanetworks/alphanetworks_snj61d0_320f/post-process.make
+++ b/machine/alphanetworks/alphanetworks_snj61d0_320f/post-process.make
@@ -1,0 +1,12 @@
+RECOVERY_ISO_GRUB_CONF ?= $(abspath ../build-config/recovery/grub-iso.cfg)
+RECOVERY_ISO_GRUB_CONF_ORI ?= $(MACHINEDIR)/rootconf/onie-grub/grub-iso.cfg.ori
+MACHINE_IMAGE_COMPLETE_STAMP = $(STAMPDIR)/machine-image-complete
+RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP = $(STAMPDIR)/iso-grub-machine-complete
+
+PHONY += machine-image-complete
+machine-image-complete: $(MACHINE_IMAGE_COMPLETE_STAMP)
+$(MACHINE_IMAGE_COMPLETE_STAMP): $(RECOVERY_ISO_STAMP)
+	$(Q) cp -f $(RECOVERY_ISO_GRUB_CONF_ORI) $(RECOVERY_ISO_GRUB_CONF)
+	$(Q) rm -f $(RECOVERY_ISO_GRUB_CONF_ORI)
+	$(Q) rm -f $(RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP)
+	$(Q) touch $@

--- a/machine/alphanetworks/alphanetworks_snj61d0_320f/rootconf/grub-machine.make
+++ b/machine/alphanetworks/alphanetworks_snj61d0_320f/rootconf/grub-machine.make
@@ -1,0 +1,36 @@
+#------------------------------------------------------------------------------
+#
+#
+#------------------------------------------------------------------------------
+#
+# This is a makefile fragment that replace configuration of grub menu
+# for SNJ-61D0-320F.
+#
+
+RECOVERY_ISO_GRUB_CONF = $(abspath ../build-config/recovery/grub-iso.cfg)
+RECOVERY_ISO_GRUB_CONF_ORI = $(MACHINEDIR)/rootconf/onie-grub/grub-iso.cfg.ori
+RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP = $(STAMPDIR)/iso-grub-machine-complete
+RECOVERY_ISO_GRUB_MACHINE_CONF = $(MACHINEDIR)/rootconf/onie-grub/grub-iso.cfg
+MACHINE_IMAGE_COMPLETE_STAMP = $(STAMPDIR)/machine-image-complete
+
+$(RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP) : $(RECOVERY_ISO_STAMP)
+	$(Q) cp -f $(RECOVERY_ISO_GRUB_CONF) $(RECOVERY_ISO_GRUB_CONF_ORI)
+	$(Q) cp -f $(RECOVERY_ISO_GRUB_MACHINE_CONF) $(RECOVERY_ISO_GRUB_CONF)
+	$(Q) touch $@
+
+sysroot-machine-clean:
+	$(Q) if [ -f "$(RECOVERY_ISO_GRUB_CONF_ORI)" ] ; then \
+	        cp -f $(RECOVERY_ISO_GRUB_CONF_ORI) $(RECOVERY_ISO_GRUB_CONF); \
+	        rm -f $(RECOVERY_ISO_GRUB_CONF_ORI); \
+	     fi;
+	$(Q) rm -f $(MACHINE_IMAGE_COMPLETE_STAMP)
+	$(Q) rm -f $(RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP)
+
+$(STAMPDIR)/recovery-iso: $(RECOVERY_ISO_GRUB_CONF_COMPLETE_STAMP)
+sysroot-clean: sysroot-machine-clean
+
+#------------------------------------------------------------------------------
+#
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/machine/alphanetworks/alphanetworks_snj61d0_320f/rootconf/onie-grub/grub-iso.cfg
+++ b/machine/alphanetworks/alphanetworks_snj61d0_320f/rootconf/onie-grub/grub-iso.cfg
@@ -1,0 +1,45 @@
+#  Copyright (C) 2014,2015,2017 Curt Brune <curt@cumulusnetworks.com>
+#  Copyright (C) 2014 david_yang <david_yang@accton.com>
+#  Copyright (C) 2014 Stephen Su <sustephen@juniper.net>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+if [ "<SERIAL_CONSOLE_ENABLE>" == "yes"  ] ; then
+  serial --port=<CONSOLE_PORT> --speed=<CONSOLE_SPEED> --word=8 --parity=no --stop=1
+  terminal_input serial
+  terminal_output serial
+  CONSOLE_CMDLINE_LINUX="console=tty0 console=ttyS<CONSOLE_DEV>,<CONSOLE_SPEED>n8"
+  export CONSOLE_CMDLINE_LINUX
+fi
+set timeout=3
+
+function onie_entry_start {
+  if [ "${grub_platform}" != "efi" ] ; then
+    acpi --no-ebda
+  fi
+}
+
+function onie_entry_end {
+  echo "Platform  : $onie_build_platform"
+  echo "Version   : $onie_version"
+  echo "Build Date: $onie_build_date"
+}
+
+ONIE_CMDLINE_LINUX="quiet ${CONSOLE_CMDLINE_LINUX} <EXTRA_CMDLINE_LINUX> boot_env=recovery"
+set default="<GRUB_DEFAULT_ENTRY>"
+
+menuentry "ONIE: Rescue" --class gnu-linux --class onie {
+  echo    "ONIE: Rescue Mode ..."
+  onie_entry_start
+  linux   /vmlinuz $ONIE_CMDLINE_LINUX boot_reason=rescue
+  initrd  /initrd.xz
+  onie_entry_end
+}
+
+menuentry "ONIE: Embed ONIE" --class gnu-linux --class onie {
+  echo    "ONIE: Embedding ONIE ..."
+  onie_entry_start
+  linux   /vmlinuz $ONIE_CMDLINE_LINUX boot_reason=embed install_url=file:///lib/onie/onie-updater
+  initrd  /initrd.xz
+  onie_entry_end
+}


### PR DESCRIPTION
The platforms are including:
 - x86_64-alphanetworks_snj61d0_320f-r1
 - x86_64-alphanetworks_snj61d0_320f-r2

Signed-off-by: SeanTai-ALPHA <Sean_Tai@alphanetworks.com>