### PR TITLE
Add Alpha Networks SCG60D0-484T platforms

### DIFF
--- a/build-config/scripts/onie-build-targets.json
+++ b/build-config/scripts/onie-build-targets.json
@@ -80,7 +80,7 @@
 
     { "Vendor": "agema", "Platform": "agema_ag7648c",  "BuildEnv": "Debian9",  "Release": "None", "Architecture": "amd64",   "Notes": "Busybox patch fails." },
 
-    { "Vendor": "alphanetworks", "Platform": "alphanetworks_scg60d0_484t",    "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
+    { "Vendor": "alphanetworks", "Platform": "alphanetworks_scg60d0_484t",    "BuildEnv": "Debian10", "Release": "2022.02br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snc60a0_486f",    "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snc60a0_488f",    "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snc60d0_488f",    "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },

--- a/machine/alphanetworks/alphanetworks_scg60d0_484t/INSTALL
+++ b/machine/alphanetworks/alphanetworks_scg60d0_484t/INSTALL
@@ -2,25 +2,25 @@
 Installing ONIE on Alpha_Networks SCG60D0_484T
 ==============================================
 
-Cross-Compiling ONIE
-====================
+Cross-Compiling r0 ONIE
+=======================
 
 Change directories to ``build-config`` to compile ONIE.
 
 To compile ONIE first change directories to ``build-config`` and then
-type ``"make MACHINEROOT=../machine/alphanetworks  MACHINE=alphanetworks_scg60d0_484t all"``.
-For example::
+type ``"make MACHINEROOT=../machine/alphanetworks  MACHINE=alphanetworks_scg60d0_484t VENDOR_REV=0 all"``.
+For example:
 
   $ cd build-config
-  $ make -j4 MACHINEROOT=../machine/alphanetworks  MACHINE=alphanetworks_scg60d0_484t all
+  $ make -j4 MACHINEROOT=../machine/alphanetworks  MACHINE=alphanetworks_scg60d0_484t VENDOR_REV=0 all
 
 When complete, the ONIE binaries are located in
-``build/images``::
+``build/images``:
 
--rw-r--r-- 1 5986340 Aug 10 15:28 alphanetworks_scg60d0_484t-r0.initrd
--rw-r--r-- 1 3091952 Aug 10 15:13 alphanetworks_scg60d0_484t-r0.vmlinuz
--rw-r--r-- 1 20774912 Aug 10 15:14 onie-recovery-x86_64-alphanetworks_scg60d0_484t-r0.iso
--rw-r--r-- 1 9135991 Aug 10 15:14 onie-updater-x86_64-alphanetworks_scg60d0_484t-r0
+-rw-r--r-- 1 10829736 Jan 28 02:35 alphanetworks_scg60d0_484t-r0.initrd
+-rw-r--r-- 1  3801168 Jan 28 02:33 alphanetworks_scg60d0_484t-r0.vmlinuz
+-rw-r--r-- 1 33161216 Jan 28 02:36 onie-recovery-x86_64-alphanetworks_scg60d0_484t-r0.iso
+-rw-r--r-- 1 14594042 Jan 28 02:35 onie-updater-x86_64-alphanetworks_scg60d0_484t-r0
 
 alphanetworks_scg60d0_484t-r0.vmlinuz -- This is the ONIE kernel image
 
@@ -33,6 +33,37 @@ onie-recovery-x86_64-alphanetworks_scg60d0_484t-r0.iso -- This is a recovery ISO
 image. This image can be used to create a bootable USB memory stick for 
 installing/recovery ONIE.
 
+Cross-Compiling r1 ONIE
+=======================
+
+Change directories to ``build-config`` to compile ONIE.
+
+To compile ONIE first change directories to ``build-config`` and then
+type ``"make MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_scg60d0_484t all"``.
+For example:
+
+  $ cd build-config
+  $ make -j4 MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_scg60d0_484t all
+
+When complete, the ONIE binaries are located in
+``build/images``:
+
+-rw-r--r-- 1 10825056 Jan 28 02:57 alphanetworks_scg60d0_484t-r1.initrd
+-rw-r--r-- 1  3801168 Jan 28 02:41 alphanetworks_scg60d0_484t-r1.vmlinuz
+-rw-r--r-- 1 33161216 Jan 28 02:58 onie-recovery-x86_64-alphanetworks_scg60d0_484t-r1.iso
+-rw-r--r-- 1 14594042 Jan 28 02:57 onie-updater-x86_64-alphanetworks_scg60d0_484t-r1
+
+alphanetworks_scg60d0_484t-r1.vmlinuz -- This is the ONIE kernel image
+
+alphanetworks_scg60d0_484t-r1.initrd  -- This is the ONIE initramfs (filesystem)
+
+onie-updater-x86_64-alphanetworks_scg60d0_484t-r1 -- This is the ONIE self-update
+image.  This image is a self-extracting archive used for installing ONIE.
+
+onie-recovery-x86_64-alphanetworks_scg60d0_484t-r1.iso -- This is a recovery ISO 
+image. This image can be used to create a bootable USB memory stick for 
+installing/recovery ONIE.
+
 Installing ONIE on a Blank Machine
 ==================================
 
@@ -42,12 +73,12 @@ create a bootable USB memory stick.
 Creating bootable USB stick
 ---------------------------
 
-Use ``dd`` to copy the .iso image to a USB stick and boot from that::
+Use ``dd`` to copy the .iso image to a USB stick and boot from that:
 
   dd if=<machine>.iso of=/dev/sdX bs=10M
 
-For example::
-  dd if=onie-recovery-x86_64-alphanetworks_scg60d0_484t-r0.iso of=/dev/sdb bs=10M
+For example:
+  dd if=onie-recovery-x86_64-alphanetworks_scg60d0_484t-r1.iso of=/dev/sdb bs=10M
 
 You can find the correct ``/dev/sdX`` by inspecing the ``dmesg``
 output after inserting the USB stick into your work station.
@@ -64,17 +95,17 @@ To enable booting from USB in the BIOS:
 3. Set the hard drive boot order:
 
   In "Boot Option #1" select the device that corresponds to your
-  device::
+  device:
 
     Boot-->Boot Option Priorities-->Boot Option #1
 
   If the device name is not listed in "Boot Option #1", please
-  check the priorities in the hard drive boot order::
+  check the priorities in the hard drive boot order:
 
     Boot-->Hard Drive BBS Priorities-->Boot Option #1
 
   Taking ``JetFlashTranscend 8GB 8.07`` as an example, the boot
-  order will look like following::
+  order will look like following:
 
     Boot Option Priorities
     Boot Option #1          [JetFlashTranscend 8...]
@@ -86,7 +117,7 @@ To enable booting from USB in the BIOS:
 
 5. After several seconds, you should see:
 
-                     GNU GRUB  version 2.02~beta2+e4a1fe391
+                     GNU GRUB  version 2.02
 
  +----------------------------------------------------------------------------+
  |*ONIE: Rescue                                                               |

--- a/machine/alphanetworks/alphanetworks_scg60d0_484t/installer.conf
+++ b/machine/alphanetworks/alphanetworks_scg60d0_484t/installer.conf
@@ -5,7 +5,24 @@ description="AlphaNetworks, SCG60D0-484T"
 # Default ONIE block device
 install_device_platform()
 {
+    # find ata device on the system, return the 1st one.
+
+    ##
+    # find the sata dom
+    ##
+
+    for _device in /sys/block/sd*/device; do
+        # Denverton SATA 1 PCI Register (D:20,F:0).
+        if echo $(readlink -f $_device)|egrep -q "pci0000:00\/0000:00:14.0"; then
+            _disk=`echo $_device | cut -f4 -d/`
+            echo /dev/$_disk
+            return 0
+        fi
+    done
+
+    # nothing found, just return /dev/sda
     echo /dev/sda
+    return 1
 }
 
 # Local Variables:

--- a/machine/alphanetworks/alphanetworks_scg60d0_484t/machine.make
+++ b/machine/alphanetworks/alphanetworks_scg60d0_484t/machine.make
@@ -3,11 +3,13 @@
 ONIE_ARCH ?= x86_64
 SWITCH_ASIC_VENDOR = bcm
 
-VENDOR_REV ?= 0
+VENDOR_REV ?= 1
 
 # Translate hardware revision to ONIE hardware revision
 ifeq ($(VENDOR_REV),0)
   MACHINE_REV = 0
+else ifeq ($(VENDOR_REV),1)
+  MACHINE_REV = 1
 else
   $(warning Unknown VENDOR_REV '$(VENDOR_REV)' for MACHINE '$(MACHINE)')
   $(error Unknown VENDOR_REV)
@@ -36,11 +38,14 @@ CONSOLE_DEV = 1
 UEFI_ENABLE = yes
 
 # Set Linux kernel version
-LINUX_VERSION		= 4.9
-LINUX_MINOR_VERSION	= 95
+LINUX_VERSION = 4.9
+LINUX_MINOR_VERSION = 95
 
-# Older GCC required for older 3.14.27 kernel
-#GCC_VERSION = 4.9.2
+# Set GCC version
+GCC_VERSION = 8.3.0
+
+# Set uClibc-ng version
+XTOOLS_LIBC_VERSION = 1.0.38
 
 include $(MACHINEDIR)/rootconf/grub-machine.make
 


### PR DESCRIPTION
This supports the following platforms:
 - x86_64-alphanetworks_scg60d0_484t-r0
 - x86_64-alphanetworks_scg60d0_484t-r1

Signed-off-by: SeanTai-ALPHA <Sean_Tai@alphanetworks.com>