### PR TITLE
image.make: Fix DNS resolution issue by adding libnss_dns.so and libr…

### DIFF
--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -181,6 +181,8 @@ SYSROOT_LIBS	= ld-$(XTOOLS_LIBC_VERSION).so \
 		  libdl.so.2 libdl-$(XTOOLS_LIBC_VERSION).so \
 		  libpthread.so.0 libpthread-$(XTOOLS_LIBC_VERSION).so \
 		  librt.so.1 librt-$(XTOOLS_LIBC_VERSION).so \
+		  libnss_dns.so.2 libnss_dns-$(XTOOLS_LIBC_VERSION).so \
+		  libresolv.so.2 libresolv-$(XTOOLS_LIBC_VERSION).so  \
 		  libnss_files.so.2 libnss_files-$(XTOOLS_LIBC_VERSION).so
   ifeq ($(ARCH),arm64)
     SYSROOT_LIBS	+= ld-linux-aarch64.so.1

--- a/machine/delta/delta_tn48m/machine.make
+++ b/machine/delta/delta_tn48m/machine.make
@@ -1,6 +1,6 @@
 # Makefile fragment for Delta TN48M
 
-VENDOR_VERSION = -V03
+VENDOR_VERSION = -V04
 ONIE_ARCH ?= armv8a
 SWITCH_ASIC_VENDOR = mvl
 


### PR DESCRIPTION
…esolv.so to sysroot.

These libraries are required for DNS resolution, currently DNS resolution on armv8 platform using glibc does not work.
(like nslookup www.google.com , ping www.google.com, etc.)

Signed-off-by: Vincent Liu <vincent.liu@deltaww.com>