### PR TITLE
Add patch for eMMC feature

### DIFF
--- a/machine/supermicro/supermicro_sse_g3748/kernel/0007-Modify-eMMC-setting-as-default-EVB.patch
+++ b/machine/supermicro/supermicro_sse_g3748/kernel/0007-Modify-eMMC-setting-as-default-EVB.patch
@@ -1,0 +1,34 @@
+From 790a0cedb23cbdfbe4d45feedc01b3bb1612548c Mon Sep 17 00:00:00 2001
+From: test <test.@abc>
+Date: Thu, 27 Jan 2022 10:36:46 +0800
+Subject: [PATCH] Modify eMMC setting as default EVB
+
+---
+ arch/arm64/boot/dts/marvell/ac5x_4G_db.dts | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/marvell/ac5x_4G_db.dts b/arch/arm64/boot/dts/marvell/ac5x_4G_db.dts
+index 009ce5f..d4ceeb1 100644
+--- a/arch/arm64/boot/dts/marvell/ac5x_4G_db.dts
++++ b/arch/arm64/boot/dts/marvell/ac5x_4G_db.dts
+@@ -14,16 +14,7 @@
+ #include "ac5.dtsi"
+ 
+ / {
+-	model = "Marvell AC5X 4G DB board";
+-};
+-
+-&mmc_dma {
+-	/* Host phy ram DMA mapping */
+-	dma-ranges = <0x2 0x0 0x2 0x80000000 0x1 0x0>;
+-};
+-
+-&sdhci0 {
+-	reg = <0x0 0x805c0000 0x0 0x300>, <0x0 0x80440230 0x0 0x4>;
++	model = "WNC Marvell AC5X 4G G3748 board";
+ };
+ 
+ &eth0 {
+-- 
+2.25.1
+

--- a/machine/supermicro/supermicro_sse_g3748/kernel/series
+++ b/machine/supermicro/supermicro_sse_g3748/kernel/series
@@ -4,3 +4,4 @@
 0004-Create-open-SPI-partitiony.patch
 0005-Add-uboot-env_size-attribute.patch
 0006-Remove-unused-eth1-interface.patch
+0007-Modify-eMMC-setting-as-default-EVB.patch


### PR DESCRIPTION
Change eMMC DMA mapping to default in device tree.

Signed-off-by: Yanhua <Yanhua.Huang@wnc.com.tw>