### PR TITLE
Pegatron common_bde: add three platforms to support ONIE 

### DIFF
--- a/build-config/scripts/onie-build-targets.json
+++ b/build-config/scripts/onie-build-targets.json
@@ -223,7 +223,7 @@
     { "Vendor": "nxp", "Platform": "nxp_p2041rdb",      "BuildEnv": "Debian9",  "Release": "None",      "Architecture": "PowerPC",  "Notes": "Compile error" },
     { "Vendor": "nxp", "Platform": "nxp_t2080rdb",      "BuildEnv": "Debian9",  "Release": "None",      "Architecture": "PowerPC",  "Notes": "Compile error" },
 
-    { "Vendor": "pegatron", "Platform": "pegatron_common_bde",   "BuildEnv": "Debian9",  "Release": "2021.05br", "Architecture": "amd64",   "Notes": "No notes." },
+    { "Vendor": "pegatron", "Platform": "pegatron_common_bde",   "BuildEnv": "Debian10", "Release": "2022.08br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "pegatron", "Platform": "pegatron_common_rgl",   "BuildEnv": "Debian9",  "Release": "2021.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "pegatron", "Platform": "pegatron_fn_6254_dn_f", "BuildEnv": "Debian9",  "Release": "2021.05br", "Architecture": "amd64",   "Notes": "No notes." },
 

--- a/machine/pegatron/pegatron_common_bde/INSTALL
+++ b/machine/pegatron/pegatron_common_bde/INSTALL
@@ -33,6 +33,9 @@ detection, please refer to ``rootconf/sysroot-lib-onie/gen-config-platform``
    1x100GbE QSFP28 port, 1xSFP+ port and
    eight 25GbE SFP28 (port 1-6: eCPRI/CPRI, port 7-8 eCPRI)
 
+ - Pegatron_fn8656_bnf
+   48x50GbE/100GbE DSFP ports, 8x400GbE QSFP-DD ports
+
   Specification
 ===============
  - Modularized CPU board design

--- a/machine/pegatron/pegatron_common_bde/INSTALL
+++ b/machine/pegatron/pegatron_common_bde/INSTALL
@@ -29,6 +29,10 @@ detection, please refer to ``rootconf/sysroot-lib-onie/gen-config-platform``
  - Pegatron_fn8032_baf
    32x400GbE QSFP-DD ports with BMC
 
+ - Pegatron_dm6209_7
+   1x100GbE QSFP28 port, 1xSFP+ port and
+   eight 25GbE SFP28 (port 1-6: eCPRI/CPRI, port 7-8 eCPRI)
+
   Specification
 ===============
  - Modularized CPU board design

--- a/machine/pegatron/pegatron_common_bde/busybox/patches/add-dm6209-7-platform-support.patch
+++ b/machine/pegatron/pegatron_common_bde/busybox/patches/add-dm6209-7-platform-support.patch
@@ -1,0 +1,77 @@
+From 9eb37417fb53aef82bc10b0c5eba13031ce5255a Mon Sep 17 00:00:00 2001
+From: Wolf Lin <Wolf_Lin@pegatroncorp.com>
+Date: Wed, 17 Nov 2021 09:58:15 +0800
+Subject: [PATCH] Add 'dm6209-7' platform support.
+
+---
+ include/mb_detect.h        | 1 +
+ miscutils/mb_detect.c      | 7 ++++---
+ miscutils/sys_eeprom_i2c.c | 8 ++++++++
+ 3 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/include/mb_detect.h b/include/mb_detect.h
+index 6fffdfb..8ea1a92 100644
+--- a/include/mb_detect.h
++++ b/include/mb_detect.h
+@@ -40,6 +40,7 @@ enum {
+ 	ASTONMARTINWITHBMC,
+ 	GEMINI,
+ 	GEMINIWITHBMC,
++	FHGW,
+ 	MB_LAST
+ };
+ 
+diff --git a/miscutils/mb_detect.c b/miscutils/mb_detect.c
+index ba88636..98271c0 100644
+--- a/miscutils/mb_detect.c
++++ b/miscutils/mb_detect.c
+@@ -13,7 +13,8 @@ SysBoardInfo sysBoardInfo[] = {
+ 	{ 0x08, "astonMartin",		"FN8032_BNF\0", "fn8032_bnf\0", 0, 0 },
+ 	{ 0x08, "astonMartin(BMC)",	"FN8032_BAF\0", "fn8032_baf\0", 0, 1 },
+ 	{ 0x09, "gemini",		"FM6256_BNF\0", "fm6256_bnf\0", 0, 0 },
+-	{ 0x09, "gemini(BMC)",		"FM6256_BAF\0", "fm6256_baf\0", 0, 1 }
++	{ 0x09, "gemini(BMC)",		"FM6256_BAF\0", "fm6256_baf\0", 0, 1 },
++	{ 0x0A, "fhgw",			"DM6209_7\0", "dm6209_7\0", 0, 0 }
+ };
+ 
+ static u32 mb_id_get_from_cpld(int cpld)
+@@ -273,7 +274,7 @@ static int fan_status_info_get (SysBoardInfo *bdinfo)
+ 	int offset = len - 1;
+ 
+ 	if (bdinfo->motherboard_id == 0xA) {
+-		offset = len - 2;
++		return 0;
+ 	}
+ 
+ 	type = bdinfo->productName[offset];
+@@ -307,7 +308,7 @@ static int bmc_chip_info_get (SysBoardInfo *bdinfo)
+ 		return 0;
+ 
+ 	if (bdinfo->motherboard_id == 0xA) {
+-		offset = len - 4;
++		return 0;
+ 	}
+ 
+ 	type = bdinfo->productName[offset];
+diff --git a/miscutils/sys_eeprom_i2c.c b/miscutils/sys_eeprom_i2c.c
+index bc451da..3b9dfd4 100644
+--- a/miscutils/sys_eeprom_i2c.c
++++ b/miscutils/sys_eeprom_i2c.c
+@@ -71,6 +71,14 @@ struct mb_info mb_i2c_info[] = {
+ 		.wp_disable = 0x00,
+ 		.wp_enable = 0x04
+ 	},
++	{
++		.motherboard_id = 0xA, /* FHGW */
++		.mux = {.addr = 0x73, .channel = 1},
++		.eeprom_addr = 0x75,
++		.eeprom_offset = 0x14,
++		.wp_disable = 0x01,
++		.wp_enable = 0x03
++	},
+ 	{
+ 		.motherboard_id = 0xff,
+ 		.mux = {.addr = 0xff, .channel = 0xff},
+-- 
+2.25.1
+

--- a/machine/pegatron/pegatron_common_bde/busybox/patches/add-fn8032-bnf-r1-platform-support.patch
+++ b/machine/pegatron/pegatron_common_bde/busybox/patches/add-fn8032-bnf-r1-platform-support.patch
@@ -1,0 +1,80 @@
+From 000db99a9ffa89ccada5f00627daf5a82f6b1c46 Mon Sep 17 00:00:00 2001
+From: Wolf Lin <Wolf_Lin@pegatroncorp.com>
+Date: Wed, 17 Nov 2021 10:05:19 +0800
+Subject: [PATCH] Add 'fn8032_bnf-r1' platform support.
+
+---
+ miscutils/mb_detect.c | 43 ++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 42 insertions(+), 1 deletion(-)
+
+diff --git a/miscutils/mb_detect.c b/miscutils/mb_detect.c
+index 2d79dd4..f209220 100644
+--- a/miscutils/mb_detect.c
++++ b/miscutils/mb_detect.c
+@@ -189,6 +189,32 @@ static int find_i2c_busses(char* adapter_name)
+ 	return dev_bus;
+ }
+ 
++static int find_cpu_model(char* cpu_model)
++{
++	const char *const cpu_info_path = "/proc/cpuinfo";
++	char name[128];
++	char *pos;
++	FILE *fp;
++	int ret = 0;
++
++	fp = fopen(cpu_info_path, "r");
++	if (fp != NULL) {
++		while (fgets(name, sizeof(name), fp)) {
++			pos = strstr(name, "model name");
++			if (pos == NULL)
++				continue;
++
++			pos = strstr(name, cpu_model);
++			if (pos != NULL)
++				ret = 1;
++			break;
++		}
++		fclose(fp);
++	}
++
++	return ret;
++}
++
+ static int fan_status_get_from_i2c (u8 *type)
+ {
+ 	u32 status = 0;
+@@ -336,6 +362,21 @@ static int bmc_chip_info_get (SysBoardInfo *bdinfo)
+ 	return 0;
+ }
+ 
++static int cpu_info_get (SysBoardInfo *bdinfo)
++{
++	u32 machine_rev = 0;
++	int ret;
++
++	if (bdinfo->motherboard_id == 0x08) {
++		ret = find_cpu_model("D-1627");
++		if (ret)
++			machine_rev = 1;
++		bdinfo->machine_rev = machine_rev;
++	}
++
++	return 0;
++}
++
+ /*
+  *  This macro defines the mbdetect command line command.
+  */
+@@ -461,7 +502,7 @@ s32 sys_board_info_get(SysBoardInfo *bdinfo)
+ 
+ 		bmc_chip_info_get(bdinfo);
+ 		fan_status_info_get(bdinfo);
+-
++		cpu_info_get(bdinfo);
+ 		return 0;
+ 	}
+ 
+-- 
+2.25.1
+

--- a/machine/pegatron/pegatron_common_bde/busybox/patches/add-fn8656-bnf-platform.patch
+++ b/machine/pegatron/pegatron_common_bde/busybox/patches/add-fn8656-bnf-platform.patch
@@ -1,0 +1,69 @@
+From 45940566364253368751c7551221522be1af3c91 Mon Sep 17 00:00:00 2001
+From: Wolf Lin <Wolf_Lin@pegatroncorp.com>
+Date: Wed, 17 Nov 2021 10:04:16 +0800
+Subject: [PATCH] Add 'fn8656_bnf' platform support.
+
+---
+ include/mb_detect.h        | 1 +
+ miscutils/mb_detect.c      | 6 ++++--
+ miscutils/sys_eeprom_i2c.c | 8 ++++++++
+ 3 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/include/mb_detect.h b/include/mb_detect.h
+index 8ea1a92..37410c1 100644
+--- a/include/mb_detect.h
++++ b/include/mb_detect.h
+@@ -41,6 +41,7 @@ enum {
+ 	GEMINI,
+ 	GEMINIWITHBMC,
+ 	FHGW,
++	CORVETTE,
+ 	MB_LAST
+ };
+ 
+diff --git a/miscutils/mb_detect.c b/miscutils/mb_detect.c
+index 98271c0..2d79dd4 100644
+--- a/miscutils/mb_detect.c
++++ b/miscutils/mb_detect.c
+@@ -14,7 +14,8 @@ SysBoardInfo sysBoardInfo[] = {
+ 	{ 0x08, "astonMartin(BMC)",	"FN8032_BAF\0", "fn8032_baf\0", 0, 1 },
+ 	{ 0x09, "gemini",		"FM6256_BNF\0", "fm6256_bnf\0", 0, 0 },
+ 	{ 0x09, "gemini(BMC)",		"FM6256_BAF\0", "fm6256_baf\0", 0, 1 },
+-	{ 0x0A, "fhgw",			"DM6209_7\0", "dm6209_7\0", 0, 0 }
++	{ 0x0A, "fhgw",			"DM6209_7\0", "dm6209_7\0", 0, 0 },
++	{ 0x0B, "corvette",		"FN8656_BNF\0", "fn8656_bnf\0", 0, 0 }
+ };
+ 
+ static u32 mb_id_get_from_cpld(int cpld)
+@@ -414,7 +415,8 @@ u32 bmc_is_available(void)
+ 	s32 rv = 0;
+ 	u32 board_id = mb_id_get();
+ 
+-	if (board_id < 0x08)
++	if ( (board_id < 0x08) ||
++		 (board_id == 0x0B) )
+ 		return 0;
+ 
+ 	//Detect BMC is available now or not.
+diff --git a/miscutils/sys_eeprom_i2c.c b/miscutils/sys_eeprom_i2c.c
+index 3b9dfd4..335c361 100644
+--- a/miscutils/sys_eeprom_i2c.c
++++ b/miscutils/sys_eeprom_i2c.c
+@@ -79,6 +79,14 @@ struct mb_info mb_i2c_info[] = {
+ 		.wp_disable = 0x01,
+ 		.wp_enable = 0x03
+ 	},
++	{
++		.motherboard_id = 0xB, /* Corvette */
++		.mux = {.addr = 0x73, .channel = 0},
++		.eeprom_addr = 0x74,
++		.eeprom_offset = 0x01,
++		.wp_disable = 0xfd,
++		.wp_enable = 0x02
++	},
+ 	{
+ 		.motherboard_id = 0xff,
+ 		.mux = {.addr = 0xff, .channel = 0xff},
+-- 
+2.25.1
+

--- a/machine/pegatron/pegatron_common_bde/busybox/patches/series
+++ b/machine/pegatron/pegatron_common_bde/busybox/patches/series
@@ -10,3 +10,5 @@ onie-syseeprom-support-ipmi.patch
 change-the-platform-name-in-multiple-platforms.patch
 enhance-mbdetect-command-to-generate-onieid-by-hardware.patch
 add-dm6209-7-platform-support.patch
+add-fn8656-bnf-platform.patch
+add-fn8032-bnf-r1-platform-support.patch

--- a/machine/pegatron/pegatron_common_bde/busybox/patches/series
+++ b/machine/pegatron/pegatron_common_bde/busybox/patches/series
@@ -9,3 +9,4 @@ add-fn-8032-bn-f-platform.patch
 onie-syseeprom-support-ipmi.patch
 change-the-platform-name-in-multiple-platforms.patch
 enhance-mbdetect-command-to-generate-onieid-by-hardware.patch
+add-dm6209-7-platform-support.patch

--- a/machine/pegatron/pegatron_common_bde/rootconf/grub/grub-common.cfg
+++ b/machine/pegatron/pegatron_common_bde/rootconf/grub/grub-common.cfg
@@ -1,5 +1,6 @@
 ## Begin grub-common.cfg
 
+#  Copyright (C) 2021 Andriy Dobush <andriyd@nvidia.com>
 #  Copyright (C) 2014,2018 Curt Brune <curt@cumulusnetworks.com>
 #  Copyright (C) 2015,2016,2017 david_yang <david_yang@accton.com>
 #
@@ -103,10 +104,11 @@ function reset_onie_mode {
 }
 
 # Load environment variables
+# Use --skip-sig to allow booting of preconfigured options.
 if [ -f "/grub/grubenv" ] ; then
 load_env -f /grub/grubenv
 else
-load_env
+load_env --skip-sig
 fi
 
 
@@ -143,27 +145,28 @@ else
    fi
 fi
 
-menuentry "$onie_menu_install" {
+# --unrestricted = useable without a password
+menuentry "$onie_menu_install" --unrestricted {
   onie_debugargs=""
   onie_install
 }
 
-menuentry "$onie_menu_rescue" {
+menuentry "$onie_menu_rescue" --unrestricted {
   onie_debugargs=""
   onie_rescue
 }
 
-menuentry "$onie_menu_uninstall" {
+menuentry "$onie_menu_uninstall" --unrestricted {
   onie_debugargs=""
   onie_uninstall
 }
 
-menuentry "$onie_menu_update" {
+menuentry "$onie_menu_update" --unrestricted {
   onie_debugargs=""
   onie_update
 }
 
-menuentry "$onie_menu_embed" {
+menuentry "$onie_menu_embed" --unrestricted {
   onie_debugargs=""
   onie_embed
 }
@@ -171,13 +174,13 @@ menuentry "$onie_menu_embed" {
 search --no-floppy --label --set=diag_dev "PEGATRON-DIAG"
 if [ -n "$diag_dev" ] ; then
   if [ -f "($diag_dev)/grub/grub.cfg" ] ; then
-     menuentry "PEGATRON-DIAG" {
+     menuentry "PEGATRON-DIAG" --unrestricted {
        root=$diag_dev
        configfile /grub/grub.cfg
      }
   fi
   if [ -f "($diag_dev)/boot/grub/grub.cfg" ] ; then
-     menuentry "PEGATRON-DIAG" {
+     menuentry "PEGATRON-DIAG" --unrestricted {
        root=$diag_dev
        configfile /boot/grub/grub.cfg
      }

--- a/machine/pegatron/pegatron_common_bde/rootconf/sysroot-bin/uninstall-diag
+++ b/machine/pegatron/pegatron_common_bde/rootconf/sysroot-bin/uninstall-diag
@@ -206,6 +206,41 @@ erase_diag_storage()
     fi
 }
 
+# Remove UEFI Boot numbers that reference non-existent files
+uefi_diag_rm_stale_bootnum()
+{
+    efibootmgr -v | grep ')/File(' | awk '{ print $1 }' | while read boot_num ; do
+        local boot_num=${boot_num%\*}
+        local boot_path=$(efibootmgr -v | grep $boot_num | sed -e 's/.*)\/File(//' -e 's/).*//' -e 's/\\/\//g')
+        [ -f "$uefi_esp_mnt/$boot_path" ] || {
+            boot_num=${boot_num#Boot}
+            efibootmgr --quiet -b $boot_num -B
+        }
+    done
+}
+
+uefi_diag_clean_up()
+{
+    # Remove unused files from /boot/efi
+    ls -d $uefi_esp_mnt/EFI/* | while read dir ; do
+        case "$dir" in
+            *-DIAG)
+                # remove the rest
+                rm -rf $dir
+        esac
+    done
+
+    uefi_diag_rm_stale_bootnum
+}
+
+# For UEFI firmware, configure the system to boot ONIE into install
+# mode at the next boot.
+uefi_diag_boot_onie_install()
+{
+    # Return to install mode on the next boot
+    onie-boot-mode -q -o install
+}
+
 uninstall_system()
 {
     # Clean up block device that contains ONIE
@@ -215,6 +250,11 @@ uninstall_system()
         echo "Error: Unable to determine block device of ONIE install"
         exit 1
     }
+
+    if [ "${firmware}" = "uefi" ] ; then
+        uefi_diag_clean_up
+        uefi_diag_boot_onie_install
+    fi
 
     erase_diag_storage $blk_dev
     

--- a/machine/pegatron/pegatron_common_bde/rootconf/sysroot-lib-onie/force2fhgw.sh
+++ b/machine/pegatron/pegatron_common_bde/rootconf/sysroot-lib-onie/force2fhgw.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+sed -i "s/onie_machine=.*/onie_machine=pegatron_dm6209_7/g" /etc/machine.conf
+sed -i "s/onie_machine_rev=.*/onie_machine_rev=0/g" /etc/machine.conf
+sed -i "s/onie_platform=.*/onie_platform=x86_64-pegatron_dm6209_7-r0/g" /etc/machine.conf
+onie-syseeprom -f -s 0x21=DM6209_7
+onie-syseeprom -f -s 0x27=pegatron_dm6209_7
+onie-syseeprom -f -s 0x28=x86_64-pegatron_dm6209_7-r0
+onie-syseeprom -f -s 0x2b=PEGATRON
+onie-syseeprom -f -s 0x2c=TW
+onie-syseeprom -f -s 0x2d=PEGATRON
+onie-syseeprom -f -s 0x2e=0
+onie-syseeprom -f -s 0x2f=0
+if [ ! -z $1 ]; then
+    MAC_ADDRESS=$(echo $1 | egrep "^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$") 
+    if [ ! -z ${MAC_ADDRESS} ]; then
+        onie-syseeprom -f -s 0x24=${MAC_ADDRESS}
+    fi
+fi

--- a/machine/pegatron/pegatron_common_bde/rootconf/sysroot-lib-onie/gen-config-platform
+++ b/machine/pegatron/pegatron_common_bde/rootconf/sysroot-lib-onie/gen-config-platform
@@ -56,7 +56,7 @@ gen_live_config()
 # Runtime ONIE Machine
 onie_machine=$live_machine
 onie_machine_rev=${live_dev_version}
-onie_platform=${onie_arch}-${live_machine}-r${onie_machine_rev}
+onie_platform=${onie_arch}-${live_machine}-r${live_dev_version}
 EOF
     fi
     


### PR DESCRIPTION
Add below model support into pegatron_common_bde:

    1. Pegatron_dm6209_7:
       with Marvell Falcon 98DX8515 x1
       1x100GbE QSFP28 port, 1xSFP+ port
       and 8x25GbE SFP28 ports.

    The CPU is a Intel Broadwell-DE D1527

    2. Pegatron_fn8656_bnf:
       with Nephos Leo NP8579 x1
       48x50GbE/100GbE DSFP ports and 8x400GbE QSFP-DD ports
    
    3. Pegatron_fn8032_bnf-r1
       with Nephos Leo NP8579 x1
       32x400GbE QSFP-DD ports
    
    The CPU is a Intel Broadwell-DE D1627