### PR TITLE
crosstool-NG: Direct support request to ONIE's issue tracker

### DIFF
--- a/patches/crosstool-NG/scripts-functions-Direct-support-request-to-ONIE-s-i.patch
+++ b/patches/crosstool-NG/scripts-functions-Direct-support-request-to-ONIE-s-i.patch
@@ -1,0 +1,42 @@
+From 0950deb627417761a4cc96404b150e26fb736a25 Mon Sep 17 00:00:00 2001
+From: Chris Packham <judge.packham@gmail.com>
+Date: Fri, 10 Nov 2023 10:53:55 +1300
+Subject: [PATCH] scripts/functions: Direct support request to ONIE's issue
+ tracker
+
+ONIE uses an old version of crosstool-ng. While that's completely the
+prerogative of the ONIE project, having users report issues that have
+already been fixed upstream adds unnecessary load to crosstool-ng's
+limited developer base.
+
+Update the error handling output to direct support requests to ONIEs
+issue tracker. This patch can probably be dropped if/when ONIE updates
+to a newer crosstool-ng version.
+
+Signed-off-by: Chris Packham <judge.packham@gmail.com>
+---
+ scripts/functions | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/scripts/functions b/scripts/functions
+index 09df03af..d4b69749 100644
+--- a/scripts/functions
++++ b/scripts/functions
+@@ -178,12 +178,10 @@ CT_OnError() {
+             CT_DoLog ERROR ">> closed without explanation."
+             CT_DoLog ERROR ">>"
+         fi
+-        CT_DoLog ERROR ">>  If you feel this is a bug in crosstool-NG, report it at:"
+-        CT_DoLog ERROR ">>      https://github.com/crosstool-ng/crosstool-ng/issues/"
++        CT_DoLog ERROR ">>  If you feel this is a bug in ONIE's crosstool-NG, report it at:"
++        CT_DoLog ERROR ">>      https://github.com/opencomputeproject/onie/issues/"
+         CT_DoLog ERROR ">>"
+         CT_DoLog ERROR ">>  Make sure your report includes all the information pertinent to this issue."
+-        CT_DoLog ERROR ">>  Read the bug reporting guidelines here:"
+-        CT_DoLog ERROR ">>      http://crosstool-ng.github.io/support/"
+ 
+         CT_DoLog ERROR ""
+         CT_DoEnd ERROR
+-- 
+2.41.0
+

--- a/patches/crosstool-NG/series
+++ b/patches/crosstool-NG/series
@@ -1,4 +1,4 @@
 # Previous patches not applied on new revisions.
 #allow-patching-custom-kernel-tarballs.patch
-
+scripts-functions-Direct-support-request-to-ONIE-s-i.patch
 


### PR DESCRIPTION
ONIE uses an old version of crosstool-ng. While that's completely the prerogative of the ONIE project, having users report issues that have already been fixed upstream adds unnecessary load to crosstool-ng's limited developer base.

Add a patch for crosstool-ng that updates the build failure output to point to ONIE's issue tracker.