### PR TITLE
Add libpcap.make and tcpdump.make for tcpdump command/target

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -502,6 +502,14 @@ ifeq ($(SHIM_ENABLE),yes)
   include make/shim.make
 endif
 
+ifeq ($(LIBPCAP_ENABLE),yes)
+  include make/libpcap.make
+endif
+
+ifeq ($(TCPDUMP_ENABLE),yes)
+  include make/tcpdump.make
+endif
+
 include make/images.make
 include make/demo.make
 

--- a/build-config/make/images.make
+++ b/build-config/make/images.make
@@ -122,6 +122,14 @@ ifeq ($(SECURE_GRUB),no)
   GPG_SIGN_SECRING = ''
 endif
 
+ifeq ($(LIBPCAP_ENABLE),yes)
+  PACKAGES_INSTALL_STAMPS += $(LIBPCAP_STAMP)
+endif
+
+ifeq ($(TCPDUMP_ENABLE),yes)
+  PACKAGES_INSTALL_STAMPS += $(TCPDUMP_STAMP)
+endif
+
 ifndef MAKE_CLEAN
 SYSROOT_NEW_FILES = $(shell \
 			test -d $(ROOTCONFDIR)/default && \

--- a/build-config/make/libpcap.make
+++ b/build-config/make/libpcap.make
@@ -1,0 +1,114 @@
+#-------------------------------------------------------------------------------
+#
+#  Copyright (C) 2024 Abhisit Sangjan <abhisit.sangjan@gmail.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+#
+#-------------------------------------------------------------------------------
+#
+# This is a makefile fragment that defines the build of libpcap
+#
+
+LIBPCAP_VERSION			= 1.10.4
+LIBPCAP_TARBALL			= libpcap-$(LIBPCAP_VERSION).tar.gz
+LIBPCAP_TARBALL_URLS	+= $(ONIE_MIRROR) \
+			   https://www.tcpdump.org/release
+LIBPCAP_BUILD_DIR	=  $(USER_BUILDDIR)/libpcap
+LIBPCAP_DIR		=  $(LIBPCAP_BUILD_DIR)/libpcap-$(LIBPCAP_VERSION)
+
+LIBPCAP_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/libpcap-download
+LIBPCAP_SOURCE_STAMP	= $(USER_STAMPDIR)/libpcap-source
+LIBPCAP_CONFIGURE_STAMP	= $(USER_STAMPDIR)/libpcap-configure
+LIBPCAP_BUILD_STAMP	= $(USER_STAMPDIR)/libpcap-build
+LIBPCAP_INSTALL_STAMP	= $(STAMPDIR)/libpcap-install
+LIBPCAP_STAMP		= $(LIBPCAP_DOWNLOAD_STAMP)	\
+			  $(LIBPCAP_SOURCE_STAMP)	\
+			  $(LIBPCAP_CONFIGURE_STAMP)	\
+			  $(LIBPCAP_BUILD_STAMP)	\
+			  $(LIBPCAP_INSTALL_STAMP)
+
+PHONY += libpcap \
+	 libpcap-download \
+	 libpcap-source \
+	 libpcap-configure \
+	 libpcap-build \
+	 libpcap-install \
+	 libpcap-clean \
+	 libpcap-download-clean
+
+libpcap: $(LIBPCAP_STAMP)
+
+DOWNLOAD += $(LIBPCAP_DOWNLOAD_STAMP)
+
+libpcap-download: $(LIBPCAP_DOWNLOAD_STAMP)
+$(LIBPCAP_DOWNLOAD_STAMP): $(PROJECT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Getting upstream libpcap ===="
+	$(Q) $(SCRIPTDIR)/fetch-package $(DOWNLOADDIR) $(UPSTREAMDIR) \
+		$(LIBPCAP_TARBALL) $(LIBPCAP_TARBALL_URLS)
+	$(Q) touch $@
+
+SOURCE += $(LIBPCAP_SOURCE_STAMP)
+
+libpcap-source: $(LIBPCAP_SOURCE_STAMP)
+$(LIBPCAP_SOURCE_STAMP): $(USER_TREE_STAMP) | $(LIBPCAP_DOWNLOAD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Extracting upstream libpcap ===="
+	$(Q) $(SCRIPTDIR)/extract-package $(LIBPCAP_BUILD_DIR) $(DOWNLOADDIR)/$(LIBPCAP_TARBALL)
+	$(Q) touch $@
+
+ifndef MAKE_CLEAN
+LIBPCAP_NEW_FILES = $( \
+			shell test -d $(LIBPCAP_DIR) && \
+			test -f $(LIBPCAP_BUILD_STAMP) && \
+			find -L $(LIBPCAP_DIR) -newer $(LIBPCAP_BUILD_STAMP) -type f -print -quit \
+		)
+endif
+
+libpcap-configure: $(LIBPCAP_CONFIGURE_STAMP)
+$(LIBPCAP_CONFIGURE_STAMP): $(LIBPCAP_SOURCE_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "====  Configure libpcap-$(LIBPCAP_VERSION) ===="
+	$(Q) cd $(LIBPCAP_DIR) &&		\
+		$(LIBPCAP_DIR)/configure	\
+		--host=$(TARGET)		\
+		--prefix=/usr
+	$(Q) touch $@
+
+libpcap-build: $(LIBPCAP_BUILD_STAMP)
+$(LIBPCAP_BUILD_STAMP): $(LIBPCAP_CONFIGURE_STAMP) $(LIBPCAP_NEW_FILES) | $(DEV_SYSROOT_INIT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "====  Building libpcap-$(LIBPCAP_VERSION) ===="
+	$(Q) PATH='$(CROSSBIN):$(PATH)'						\
+		$(MAKE) -C $(LIBPCAP_DIR)					\
+		CC=$(CROSSPREFIX)gcc
+	$(Q) PATH='$(CROSSBIN):$(PATH)'						\
+		$(MAKE) -C $(LIBPCAP_DIR) install DESTDIR=$(DEV_SYSROOT)	\
+		CC=$(CROSSPREFIX)gcc
+	$(Q) touch $@
+
+libpcap-install: $(LIBPCAP_INSTALL_STAMP)
+$(LIBPCAP_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(LIBPCAP_BUILD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Installing libpcap in $(SYSROOTDIR) ===="
+	$(Q) mkdir -p $(SYSROSYSROOTDIROT)/usr/lib/
+	$(Q) cp -av $(DEV_SYSROOT)/usr/lib/libpcap.so $(SYSROOTDIR)/usr/lib/
+	$(Q) cp -av $(DEV_SYSROOT)/usr/lib/libpcap.so.1 $(SYSROOTDIR)/usr/lib/
+	$(Q) cp -av $(DEV_SYSROOT)/usr/lib/libpcap.so.$(LIBPCAP_VERSION) $(SYSROOTDIR)/usr/lib/
+	$(Q) touch $@
+
+USER_CLEAN += libpcap-clean
+libpcap-clean:
+	$(Q) rm -rf $(LIBPCAP_BUILD_DIR)
+	$(Q) rm -f $(LIBPCAP_STAMP)
+	$(Q) echo "=== Finished making $@ for $(PLATFORM)"
+
+DOWNLOAD_CLEAN += libpcap-download-clean
+libpcap-download-clean:
+	$(Q) rm -f $(LIBPCAP_DOWNLOAD_STAMP) $(DOWNLOADDIR)/$(LIBPCAP_TARBALL)
+
+#-------------------------------------------------------------------------------
+#
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/build-config/make/tcpdump.make
+++ b/build-config/make/tcpdump.make
@@ -1,0 +1,115 @@
+#-------------------------------------------------------------------------------
+#
+#  Copyright (C) 2024 Abhisit Sangjan <abhisit.sangjan@gmail.com>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+#
+#-------------------------------------------------------------------------------
+#
+# This is a makefile fragment that defines the build of tcpdump
+#
+
+TCPDUMP_VERSION		= 4.99.4
+TCPDUMP_TARBALL		= tcpdump-$(TCPDUMP_VERSION).tar.gz
+TCPDUMP_TARBALL_URLS	+= $(ONIE_MIRROR) \
+			   https://www.tcpdump.org/release
+TCPDUMP_BUILD_DIR	= $(USER_BUILDDIR)/tcpdump
+TCPDUMP_DIR		= $(TCPDUMP_BUILD_DIR)/tcpdump-$(TCPDUMP_VERSION)
+
+TCPDUMP_DOWNLOAD_STAMP	= $(DOWNLOADDIR)/tcpdump-download
+TCPDUMP_SOURCE_STAMP	= $(USER_STAMPDIR)/tcpdump-source
+TCPDUMP_CONFIGURE_STAMP	= $(USER_STAMPDIR)/tcpdump-configure
+TCPDUMP_BUILD_STAMP	= $(USER_STAMPDIR)/tcpdump-build
+TCPDUMP_INSTALL_STAMP	= $(STAMPDIR)/tcpdump-install
+TCPDUMP_STAMP		= $(TCPDUMP_DOWNLOAD_STAMP) \
+			  $(TCPDUMP_SOURCE_STAMP) \
+			  $(TCPDUMP_CONFIGURE_STAMP) \
+			  $(TCPDUMP_BUILD_STAMP) \
+			  $(TCPDUMP_INSTALL_STAMP)
+
+PHONY += tcpdump \
+	 tcpdump-download \
+	 tcpdump-source \
+	 tcpdump-configure \
+	 tcpdump-build \
+	 tcpdump-install \
+	 tcpdump-clean \
+	 tcpdump-download-clean
+
+tcpdump: $(TCPDUMP_STAMP)
+
+DOWNLOAD += $(TCPDUMP_DOWNLOAD_STAMP)
+
+tcpdump-download: $(TCPDUMP_DOWNLOAD_STAMP)
+$(TCPDUMP_DOWNLOAD_STAMP): $(PROJECT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Getting upstream tcpdump ===="
+	$(Q) $(SCRIPTDIR)/fetch-package $(DOWNLOADDIR) $(UPSTREAMDIR) \
+		$(TCPDUMP_TARBALL) $(TCPDUMP_TARBALL_URLS)
+	$(Q) touch $@
+
+SOURCE += $(TCPDUMP_SOURCE_STAMP)
+
+tcpdump-source: $(TCPDUMP_SOURCE_STAMP)
+$(TCPDUMP_SOURCE_STAMP): $(USER_TREE_STAMP) | $(TCPDUMP_DOWNLOAD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Extracting upstream tcpdump ===="
+	$(Q) $(SCRIPTDIR)/extract-package $(TCPDUMP_BUILD_DIR) $(DOWNLOADDIR)/$(TCPDUMP_TARBALL)
+	$(Q) touch $@
+
+ifndef MAKE_CLEAN
+TCPDUMP_NEW_FILES = $( \
+			shell test -d $(TCPDUMP_DIR) && \
+			test -f $(TCPDUMP_BUILD_STAMP) && \
+			find -L $(TCPDUMP_DIR) -newer $(TCPDUMP_BUILD_STAMP) -type f -print -quit \
+		)
+endif
+
+tcpdump-configure: $(TCPDUMP_CONFIGURE_STAMP)
+$(TCPDUMP_CONFIGURE_STAMP): $(TCPDUMP_SOURCE_STAMP) $(LIBPCAP_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "====  Configure tcpdump-$(TCPDUMP_VERSION) ===="
+	$(Q) cd $(TCPDUMP_DIR) && PATH='$(CROSSBIN):$(PATH)'	\
+		$(TCPDUMP_DIR)/configure			\
+		--host=$(TARGET)				\
+		--prefix=/usr					\
+		CC=$(CROSSPREFIX)gcc				\
+		LDFLAGS=$(ONIE_LDFLAGS)
+	$(Q) touch $@
+
+tcpdump-build: $(TCPDUMP_BUILD_STAMP)
+$(TCPDUMP_BUILD_STAMP): $(TCPDUMP_CONFIGURE_STAMP) $(TCPDUMP_NEW_FILES) | $(DEV_SYSROOT_INIT_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "====  Building tcpdump-$(TCPDUMP_VERSION) ===="
+	$(Q) PATH='$(CROSSBIN):$(PATH)'						\
+		$(MAKE) -C $(TCPDUMP_DIR)					\
+		CC=$(CROSSPREFIX)gcc						\
+		CFLAGS="$(ONIE_CFLAGS) -I $(DEV_SYSROOT)/usr/include"
+	$(Q) PATH='$(CROSSBIN):$(PATH)'
+		$(MAKE) -C $(TCPDUMP_DIR) install DESTDIR=$(DEV_SYSROOT)	\
+		CC=$(CROSSPREFIX)gcc
+	$(Q) touch $@
+
+tcpdump-install: $(TCPDUMP_INSTALL_STAMP)
+$(TCPDUMP_INSTALL_STAMP): $(SYSROOT_INIT_STAMP) $(TCPDUMP_BUILD_STAMP)
+	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
+	$(Q) echo "==== Installing tcpdump in $(SYSROOTDIR) ===="
+	$(Q) mkdir -p $(SYSROOTDIR)/usr/bin/
+	$(Q) cp -av $(DEV_SYSROOT)/usr/bin/tcpdump $(SYSROOTDIR)/usr/bin/
+	$(Q) touch $@
+
+USER_CLEAN += tcpdump-clean
+tcpdump-clean:
+	$(Q) rm -rf $(TCPDUMP_BUILD_DIR)
+	$(Q) rm -f $(TCPDUMP_STAMP)
+	$(Q) echo "=== Finished making $@ for $(PLATFORM)"
+
+DOWNLOAD_CLEAN += tcpdump-download-clean
+tcpdump-download-clean:
+	$(Q) rm -f $(TCPDUMP_DOWNLOAD_STAMP) $(DOWNLOADDIR)/$(TCPDUMP_TARBALL)
+
+#-------------------------------------------------------------------------------
+#
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/upstream/libpcap-1.10.4.tar.gz.sha1
+++ b/upstream/libpcap-1.10.4.tar.gz.sha1
@@ -1,0 +1,1 @@
+818cbe70179c73eebfe1038854665f33aac64245  libpcap-1.10.4.tar.gz

--- a/upstream/tcpdump-4.99.4.tar.gz.sha1
+++ b/upstream/tcpdump-4.99.4.tar.gz.sha1
@@ -1,0 +1,1 @@
+cc005539296900ce6a90c61f4099bd0f3ef3dd26  tcpdump-4.99.4.tar.gz


### PR DESCRIPTION
How did I test this Pull Request?

1. Add the configurations to the machine name accton_as4630
```
opencomputeproject-onie$ git diff
diff --git a/machine/accton/accton_as4630/machine.make b/machine/accton/accton_as4630/machine.make
index 4294ae97..5031ff02 100644
--- a/machine/accton/accton_as4630/machine.make
+++ b/machine/accton/accton_as4630/machine.make
@@ -28,6 +28,9 @@ SKIP_ETHMGMT_MACS = yes
 UEFI_ENABLE = yes
 PXE_EFI64_ENABLE = yes
 
+LIBPCAP_ENABLE = yes
+TCPDUMP_ENABLE = yes
+
 # Console parameters
 CONSOLE_DEV = 0
```
2. Make an image
```
$ cd build-config
$ make JOBS=<number of threads> MACHINEROOT=../machine/accton MACHINE=accton_as4630 all
```

3. List the output files
```
opencomputeproject-onie$ ls -1 build/accton_as4630-r0/sysroot/usr/lib/libpcap*
libpcap.so
libpcap.so.1
libpcap.so.1.10.4
opencomputeproject-onie$ ls -1 build/accton_as4630-r0/sysroot/usr/bin/tcpdump*
tcpdump
```