### PR TITLE
Append warning message to GRUB menu "ONIE: Install OS"

### DIFF
--- a/installer/grub-arch/grub/grub-common.cfg
+++ b/installer/grub-arch/grub/grub-common.cfg
@@ -10,7 +10,7 @@ set timeout=%%GRUB_TIMEOUT%%
 
 onie_submenu="ONIE (Version: $onie_version)"
 
-onie_menu_install="ONIE: Install OS"
+onie_menu_install="ONIE: Install OS (Warning: The boot order may be changed.)"
 export onie_menu_install
 onie_menu_rescue="ONIE: Rescue"
 export onie_menu_rescue


### PR DESCRIPTION
If you go into "ONIE: Install OS" option it will screw up the boot order of the box, and automatically always boot into ONIE instead of the pre-installed NOS. This is a problem and not user friendly, and there should be a warning message in the window, that alerts you that clicking that menu option will reset the boot order. The boot order will not boot into the NOS, until you install a new OS.