### PR TITLE
Dockerfile: update apt sources

### DIFF
--- a/contrib/build-env/Dockerfile
+++ b/contrib/build-env/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM debian:9
 
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian stretch main non-free contrib" > /etc/apt/sources.list
+RUN echo "deb-src [trusted=yes] http://archive.debian.org/debian stretch main non-free contrib" >> /etc/apt/sources.list
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian-security stretch/updates main non-free contrib" >> /etc/apt/sources.list
+
 # Add initial development packages
 RUN apt-get update && apt-get install -y \
     build-essential stgit u-boot-tools util-linux \


### PR DESCRIPTION
Debian stretch moved to archive.debian.com, thus the old sources.list is no longer working and the source are no longer reachable. 

Update apt sources list to point to archive.debian.com that now hosts packages for stretch.

Signed-off-by: Karim Manaouil <kmanaouil.dev@gmail.com>