### PR TITLE
Automatically select libpcap & libopenssl if tcpdump is enabled

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -502,10 +502,6 @@ ifeq ($(SHIM_ENABLE),yes)
   include make/shim.make
 endif
 
-ifeq ($(LIBPCAP_ENABLE),yes)
-  include make/libpcap.make
-endif
-
 ifeq ($(TCPDUMP_ENABLE),yes)
   include make/tcpdump.make
 endif

--- a/build-config/make/tcpdump.make
+++ b/build-config/make/tcpdump.make
@@ -9,6 +9,9 @@
 # This is a makefile fragment that defines the build of tcpdump
 #
 
+include make/libpcap.make
+include make/openssl.make
+
 TCPDUMP_VERSION		= 4.99.4
 TCPDUMP_TARBALL		= tcpdump-$(TCPDUMP_VERSION).tar.gz
 TCPDUMP_TARBALL_URLS	+= $(ONIE_MIRROR) \
@@ -66,15 +69,16 @@ TCPDUMP_NEW_FILES = $( \
 endif
 
 tcpdump-configure: $(TCPDUMP_CONFIGURE_STAMP)
-$(TCPDUMP_CONFIGURE_STAMP): $(TCPDUMP_SOURCE_STAMP) $(LIBPCAP_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
+$(TCPDUMP_CONFIGURE_STAMP): $(TCPDUMP_SOURCE_STAMP) $(LIBPCAP_INSTALL_STAMP) $(OPENSSL_INSTALL_STAMP) | $(DEV_SYSROOT_INIT_STAMP)
 	$(Q) rm -f $@ && eval $(PROFILE_STAMP)
 	$(Q) echo "====  Configure tcpdump-$(TCPDUMP_VERSION) ===="
-	$(Q) cd $(TCPDUMP_DIR) && PATH='$(CROSSBIN):$(PATH)'	\
-		$(TCPDUMP_DIR)/configure			\
-		--host=$(TARGET)				\
-		--prefix=/usr					\
-		CC=$(CROSSPREFIX)gcc				\
-		LDFLAGS=$(ONIE_LDFLAGS)
+	$(Q) cd $(TCPDUMP_DIR) && PATH='$(CROSSBIN):$(PATH)'		\
+		$(TCPDUMP_DIR)/configure				\
+		--host=$(TARGET)					\
+		--prefix=/usr						\
+		CC=$(CROSSPREFIX)gcc					\
+		LDFLAGS=$(ONIE_LDFLAGS)					\
+		CFLAGS="$(ONIE_CFLAGS) -I $(DEV_SYSROOT)/usr/include"
 	$(Q) touch $@
 
 tcpdump-build: $(TCPDUMP_BUILD_STAMP)


### PR DESCRIPTION
Derived to [PR#1076](https://github.com/opencomputeproject/onie/pull/1076)
------------------------------------------------------
1. Make a change to the target machine
```
onie$ git diff
diff --git a/machine/pegatron/pegatron_dm2118_b/machine.make b/machine/pegatron/pegatron_dm2118_b/machine.make
index 09f7e0c4..f19505d1 100755
--- a/machine/pegatron/pegatron_dm2118_b/machine.make
+++ b/machine/pegatron/pegatron_dm2118_b/machine.make
@@ -36,6 +36,8 @@ FDT_LOAD_ADDRESS = "0x2 0x1000000"
 LINUX_VERSION = 4.19
 LINUX_MINOR_VERSION = 143
 
+TCPDUMP_ENABLE = yes
+
 # The VENDOR_VERSION string is appended to the overal ONIE version
 # string.  HW vendors can use this to appended their own versioning
 # information to the base ONIE version string.
 ```
2. Build it under due with Debian 10
```
user@due-onie-build-debian-10: onie/build-config$ make -j<number of jobs> MACHINEROOT=../machine/pegatron MACHINE=pegatron_dm2118_b all
```
3. Depends on libopenssl (have to merge [PR#1072](https://github.com/opencomputeproject/onie/pull/1072) first)
```
With AArch64/pegatron_dm2118_b machine.
====  Configure tcpdump-4.99.4 ====
checking build system type... x86_64-pc-linux-gnu
checking host system type... aarch64-onie-linux-gnu
...
checking whether to use OpenSSL/libressl libcrypto... yes, if available
checking openssl/crypto.h usability... yes
checking openssl/crypto.h presence... no
configure: WARNING: openssl/crypto.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/crypto.h: proceeding with the compiler's result
checking for openssl/crypto.h... yes
checking for DES_cbc_encrypt in -lcrypto... yes
checking openssl/evp.h usability... yes
checking openssl/evp.h presence... no
configure: WARNING: openssl/evp.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/evp.h: proceeding with the compiler's result
checking for openssl/evp.h... yes
```

With x86_64/accton_as4630 machine.
```
====  Configure tcpdump-4.99.4 ====
checking build system type... x86_64-pc-linux-uclibc
checking host system type... x86_64-onie-linux-uclibc
...
checking whether to use OpenSSL/libressl libcrypto... yes, if available
checking openssl/crypto.h usability... yes
checking openssl/crypto.h presence... no
configure: WARNING: openssl/crypto.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/crypto.h: proceeding with the compiler's result
checking for openssl/crypto.h... yes
checking for DES_cbc_encrypt in -lcrypto... yes
checking openssl/evp.h usability... yes
checking openssl/evp.h presence... no
configure: WARNING: openssl/evp.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/evp.h: proceeding with the compiler's result
checking for openssl/evp.h... yes
```