### PR TITLE
crosstool-NG: Add upstream patch to allow building with docker

### DIFF
--- a/patches/crosstool-NG/Ignore-a-bad-id-command-to-allow-docker.patch
+++ b/patches/crosstool-NG/Ignore-a-bad-id-command-to-allow-docker.patch
@@ -1,0 +1,26 @@
+From aa6a6c3a34b3e2c5b094855e8d2b57a698457561 Mon Sep 17 00:00:00 2001
+From: Quentin Boswank <qubos@outlook.de>
+Date: Mon, 5 Feb 2024 16:20:18 +0100
+Subject: [PATCH] Ignore a bad id command to allow docker
+
+Signed-off-by: Quentin Boswank <qubos@outlook.de>
+---
+ scripts/crosstool-NG.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/crosstool-NG.sh b/scripts/crosstool-NG.sh
+index 08dbf0de..900dcb18 100644
+--- a/scripts/crosstool-NG.sh
++++ b/scripts/crosstool-NG.sh
+@@ -264,7 +264,7 @@ fi
+ 
+ # Good, now grab a bit of informations on the system we're being run on,
+ # just in case something goes awok, and it's not our fault:
+-CT_SYS_USER=$(id -un)
++CT_SYS_USER=$(id -un 2>/dev/null || echo "unknown")
+ CT_SYS_HOSTNAME=$(hostname -f 2>/dev/null || true)
+ # Hmmm. Some non-DHCP-enabled machines do not have an FQDN... Fall back to node name.
+ CT_SYS_HOSTNAME="${CT_SYS_HOSTNAME:-$(uname -n)}"
+-- 
+2.50.1
+

--- a/patches/crosstool-NG/series
+++ b/patches/crosstool-NG/series
@@ -1,4 +1,4 @@
 # Previous patches not applied on new revisions.
 #allow-patching-custom-kernel-tarballs.patch
-
+Ignore-a-bad-id-command-to-allow-docker.patch
 


### PR DESCRIPTION
crosstool-NG wants to know the username but it isn't critical. Bring in an upstream patch that allows using docker containers started with the -u option to provide a numeric UID.