### PR TITLE
Add support for Alpha Networks SNK60I0-320F r1 platform

### DIFF
--- a/build-config/scripts/onie-build-targets.json
+++ b/build-config/scripts/onie-build-targets.json
@@ -123,7 +123,7 @@
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj60d0_320f",    "BuildEnv": "Debian9",  "Release": "2021.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj61d0_320f",    "BuildEnv": "Debian10", "Release": "2022.08br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snj62d0_640f",    "BuildEnv": "Debian10", "Release": "2022.02br", "Architecture": "amd64",   "Notes": "No notes." },
-    { "Vendor": "alphanetworks", "Platform": "alphanetworks_snk60i0_320f",    "BuildEnv": "Debian10", "Release": "2025.05br", "Architecture": "amd64",   "Notes": "No notes." },
+    { "Vendor": "alphanetworks", "Platform": "alphanetworks_snk60i0_320f",    "BuildEnv": "Debian10", "Release": "2025.08br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snq6070_320f",    "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "PowerPC", "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snq60a0_320f",    "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "alphanetworks", "Platform": "alphanetworks_snx6070_486f",    "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "PowerPC", "Notes": "No notes." },

--- a/machine/alphanetworks/alphanetworks_snk60i0_320f/INSTALL
+++ b/machine/alphanetworks/alphanetworks_snk60i0_320f/INSTALL
@@ -17,23 +17,23 @@ For example:
 When complete, the ONIE binaries are located in
 ``build/images``:
 
--rw-r--r-- 1 build build 10821192 Feb 13 02:16 alphanetworks_snk60i0_320f-r0.initrd
--rw-r--r-- 1 build build  4919968 Feb  3 03:42 alphanetworks_snk60i0_320f-r0.vmlinuz
--rw-r--r-- 1 build build 37982208 Feb 13 02:17 onie-recovery-x86_64-alphanetworks_snk60i0_320f-r0.efi64.pxe
--rw-r--r-- 1 build build 35323904 Feb 13 02:17 onie-recovery-x86_64-alphanetworks_snk60i0_320f-r0.iso
--rw-r--r-- 1 build build 15689722 Feb 13 02:16 onie-updater-x86_64-alphanetworks_snk60i0_320f-r0
+-rw-r--r-- 1 build build 10825932 Aug 14 06:28 alphanetworks_snk60i0_320f-r1.initrd
+-rw-r--r-- 1 build build  4919968 Aug 14 06:27 alphanetworks_snk60i0_320f-r1.vmlinuz
+-rw-r--r-- 1 build build 37982208 Aug 14 06:29 onie-recovery-x86_64-alphanetworks_snk60i0_320f-r1.efi64.pxe
+-rw-r--r-- 1 build build 35323904 Aug 14 06:29 onie-recovery-x86_64-alphanetworks_snk60i0_320f-r1.iso
+-rw-r--r-- 1 build build 15689722 Aug 14 06:28 onie-updater-x86_64-alphanetworks_snk60i0_320f-r1
 
-alphanetworks_snk60i0_320f-r0.vmlinuz -- This is the ONIE kernel image
+alphanetworks_snk60i0_320f-r1.vmlinuz -- This is the ONIE kernel image
 
-alphanetworks_snk60i0_320f-r0.initrd  -- This is the ONIE initramfs (filesystem)
+alphanetworks_snk60i0_320f-r1.initrd  -- This is the ONIE initramfs (filesystem)
 
-onie-updater-x86_64-alphanetworks_snk60i0_320f-r0 -- This is the ONIE self-update
+onie-updater-x86_64-alphanetworks_snk60i0_320f-r1 -- This is the ONIE self-update
 image.  This image is a self-extracting archive used for installing ONIE.
 
-onie-recovery-x86_64-alphanetworks_snk60i0_320f-r0.efi64.pxe -- This is the UEFI PXE image
+onie-recovery-x86_64-alphanetworks_snk60i0_320f-r1.efi64.pxe -- This is the UEFI PXE image
 that can be installed through UEFI PXE.
 
-onie-recovery-x86_64-alphanetworks_snk60i0_320f-r0.iso -- This is a recovery ISO 
+onie-recovery-x86_64-alphanetworks_snk60i0_320f-r1.iso -- This is a recovery ISO
 image. This image can be used to create a bootable USB memory stick for 
 installing/recovery ONIE.
 
@@ -51,9 +51,9 @@ Use ``dd`` to copy the .iso image to a USB stick and boot from that:
   dd if=<machine>.iso of=/dev/sdX bs=10M
 
 For example:
-  dd if=onie-recovery-x86_64-alphanetworks_snk60i0_320f-r0.iso of=/dev/sdb bs=10M
+  dd if=onie-recovery-x86_64-alphanetworks_snk60i0_320f-r1.iso of=/dev/sdb bs=10M
 
-You can find the correct ``/dev/sdX`` by inspecing the ``dmesg``
+You can find the correct ``/dev/sdX`` by inspecting the ``dmesg``
 output after inserting the USB stick into your work station.
 
 Booting from USB stick

--- a/machine/alphanetworks/alphanetworks_snk60i0_320f/README.md
+++ b/machine/alphanetworks/alphanetworks_snk60i0_320f/README.md
@@ -19,6 +19,7 @@ Follow the instruction to identify your device's ONIE platform in order to insta
 | Platform name                        | Machine rev. | Label rev. | Build ONIE option |
 |:------------------------------------:|:------------:|:----------:|:-----------------:|
 | x86_64-alphanetworks_snk60i0_320f-r0 |  `r0`        | N/A        | VENDOR_REV=0      |
+| x86_64-alphanetworks_snk60i0_320f-r1 |  `r1`        | N/A        | VENDOR_REV=1      |
 
 > **Label rev**. is N/A which means there is no label revision for this device.
 
@@ -33,11 +34,11 @@ make -j4 MACHINEROOT=../machine/<vendor> MACHINE=<vendor>_<model> VENDOR_REV=<ve
 * \<model>: Model name.
 * \<vendor_rev>: Hardware machine revision. The default value is the latest hardware machine revision, you can specify the value to override it.
 
-For example, to build ONIE platform **x86_64-alphanetworks_snk60i0_320f-r0** for Alpha Networks SNK-60I0-320F machine revision `r0`:
+For example, to build ONIE platform **x86_64-alphanetworks_snk60i0_320f-r1** for Alpha Networks SNK-60I0-320F machine revision `r1`:
 
 ```
 $ cd build-config
-$ make -j4 MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snk60i0_320f VENDOR_REV=0 all pxe-efi64
+$ make -j4 MACHINEROOT=../machine/alphanetworks MACHINE=alphanetworks_snk60i0_320f VENDOR_REV=1 all pxe-efi64
 ```
 
 For more information, please refer to [onie/machine/alphanetworks/alphanetworks_snk60i0_320f/INSTALL](https://github.com/opencomputeproject/onie/blob/master/machine/alphanetworks/alphanetworks_snk60i0_320f/INSTALL)
@@ -45,7 +46,7 @@ For more information, please refer to [onie/machine/alphanetworks/alphanetworks_
 ## Modification history
 Alpha Networks uses vendor version to record Alpha Networks own ONIE software history. ONIE master branch always build the latest version ONIE images, and there is no option to build the previous version ONIE images.
 
-| Date       | Vendor version | Description                                  |
-|:----------:|:--------------:|:---------------------------------------------|
-| 2025/02/13 | .alpha-0.1     | Support SNK-60I0-320F machine revision `r0`. |
-
+| Date       | Vendor version | Description                                           |
+|:----------:|:--------------:|:------------------------------------------------------|
+| 2025/02/13 | .alpha-0.1     | Support SNK-60I0-320F machine revision `r0`.          |
+| 2025/08/14 | .alpha-0.2     | Support SNK-60I0-320F machine revision `r0` and `r1`. |

--- a/machine/alphanetworks/alphanetworks_snk60i0_320f/installer.conf
+++ b/machine/alphanetworks/alphanetworks_snk60i0_320f/installer.conf
@@ -12,8 +12,11 @@ install_device_platform()
     ##
 
     for _device in /sys/block/sd*/device; do
-        # Ice Lake-D LCC SATA 2 PCI Register (D:14,F:0).
-        if echo $(readlink -f $_device)|egrep -q "pci0000:00\/0000:00:0e.0"; then
+        # 1st SSD: Ice Lake-D LCC SATA 1 PCI Register (D:8,F:0)
+        #
+        # alphadiags:/# readlink -f /sys/block/sda/device
+        # /sys/devices/pci0000:00/0000:00:08.0/ata5/host4/target4:0:0/4:0:0:0
+        if echo $(readlink -f $_device)|egrep -q "pci0000:00\/0000:00:08.0"; then
             _disk=`echo $_device | cut -f4 -d/`
             echo /dev/$_disk
             return 0

--- a/machine/alphanetworks/alphanetworks_snk60i0_320f/machine.make
+++ b/machine/alphanetworks/alphanetworks_snk60i0_320f/machine.make
@@ -3,11 +3,13 @@
 ONIE_ARCH ?= x86_64
 SWITCH_ASIC_VENDOR = bcm
 
-VENDOR_REV ?= 0
+VENDOR_REV ?= 1
 
 # Translate hardware revision to ONIE hardware revision
 ifeq ($(VENDOR_REV),0)
   MACHINE_REV = 0
+else ifeq ($(VENDOR_REV),1)
+  MACHINE_REV = 1
 else
   $(warning Unknown VENDOR_REV '$(VENDOR_REV)' for MACHINE '$(MACHINE)')
   $(error Unknown VENDOR_REV)
@@ -16,7 +18,7 @@ endif
 # The VENDOR_VERSION string is appended to the overal ONIE version
 # string.  HW vendors can use this to appended their own versioning
 # information to the base ONIE version string.
-VENDOR_VERSION = .alpha-0.1
+VENDOR_VERSION = .alpha-0.2
 
 # Vendor ID -- IANA Private Enterprise Number:
 # http://www.iana.org/assignments/enterprise-numbers


### PR DESCRIPTION
 1. Add ONIE build support for x86_64-alphanetworks_snk60i0_320f-r1 platform.
 2. Fix SSD selection during installation.