### PR TITLE
Handle missing management MAC address in syseeprom

### DIFF
--- a/rootconf/default/etc/init.d/networking.sh
+++ b/rootconf/default/etc/init.d/networking.sh
@@ -198,6 +198,10 @@ if [ "$1" = "start" ] ; then
 
     # Set MAC addr for all interfaces, but leave the interfaces down.
     base_mac=$(onie-sysinfo -e)
+    if [ "$base_mac" = "ERROR:" ] ; then
+        log_warning_msg "Unable to retrieve management Ethernet MAC address"
+        onie_skip_ethmgmt_macs=yes
+    fi
     for intf in $intf_list ; do
         if [ "$onie_skip_ethmgmt_macs" = "no" ] ; then
             mac="$(mac_add $base_mac $intf_counter)"


### PR DESCRIPTION
When the management MAC address was missing from the syseeprom, /etc/init.d/networking.sh would attempt to parse the error message as a MAC address. This would result in a fairly cryptic error message:
```
/etc/rcS.d/S30networking.sh: line 1: arithmetic syntax error
```

This change explicitly handles that case by showing the user a warning and skipping steps that rely on this value.