### PR TITLE
build: migrate environment and scripts to python 3

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -594,11 +594,11 @@ machine-prefix:
 # The onie/build-config/scripts/onie-build-targets.json file lists
 #  platforms and known working build environments.
 DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools util-linux \
-				  gperf device-tree-compiler python-all-dev xorriso \
+				  gperf device-tree-compiler python3-dev xorriso \
 				  autoconf automake bison flex texinfo libtool libtool-bin \
 				  gawk libncurses5 libncurses5-dev bc \
 				  dosfstools mtools pkg-config git wget help2man libexpat1 \
-				  libexpat1-dev fakeroot python-sphinx rst2pdf \
+				  libexpat1-dev fakeroot python3-sphinx rst2pdf \
 				  libefivar-dev libnss3-tools libnss3-dev libpopt-dev \
 				  libssl-dev sbsigntool uuid-runtime uuid-dev cpio \
 				  bsdmainutils unzip

--- a/build-config/scripts/mk-part-table.py
+++ b/build-config/scripts/mk-part-table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 from struct import pack
 import sys

--- a/contrib/build-env/Dockerfile
+++ b/contrib/build-env/Dockerfile
@@ -9,11 +9,11 @@ FROM debian:9
 # Add initial development packages
 RUN apt-get update && apt-get install -y \
     build-essential stgit u-boot-tools util-linux \
-    gperf device-tree-compiler python-all-dev xorriso \
+    gperf device-tree-compiler python3-dev xorriso \
     autoconf automake bison flex texinfo libtool libtool-bin \
     realpath gawk libncurses5 libncurses5-dev bc \
     dosfstools mtools pkg-config git wget help2man libexpat1 \
-    libexpat1-dev fakeroot python-sphinx rst2pdf \
+    libexpat1-dev fakeroot python3-sphinx rst2pdf \
     libefivar-dev libnss3-tools libnss3-dev libpopt-dev \
     libssl-dev sbsigntool uuid-runtime uuid-dev cpio \
     bsdmainutils curl sudo unzip

--- a/contrib/git-stats/gitdm/findoldfiles
+++ b/contrib/git-stats/gitdm/findoldfiles
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Another quick hack of a script to find files unchanged
 # since a given commit.

--- a/contrib/git-stats/gitdm/logparser.py
+++ b/contrib/git-stats/gitdm/logparser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #-*- coding:utf-8 -*-
 #
 # Copyright © 2009 Germán Póo-Caamaño <gpoo@gnome.org>

--- a/contrib/git-stats/gitdm/tests/gitdm-tests.py
+++ b/contrib/git-stats/gitdm/tests/gitdm-tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 
 #

--- a/contrib/git-stats/gitdm/treeplot
+++ b/contrib/git-stats/gitdm/treeplot
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Create a graph of patch flow into the mainline.
 #

--- a/contrib/oce/build-onie.py
+++ b/contrib/oce/build-onie.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # -----------------------------------------------------------------------------
 # Copyright (C) 2014-2015 Carlos Cardenas <carlos@cumulusnetworks.com>

--- a/contrib/oce/eyes.py
+++ b/contrib/oce/eyes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # -----------------------------------------------------------------------------
 # Copyright (C) 2015-2016 Carlos Cardenas <carlos@cumulusnetworks.com>

--- a/contrib/oce/test-onie.py
+++ b/contrib/oce/test-onie.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # -----------------------------------------------------------------------------
 # Copyright (C) 2014-2016 Carlos Cardenas <carlos@cumulusnetworks.com>


### PR DESCRIPTION
Debian 12 and other modern host operating systems have removed Python 2. This commit updates the host preparation dependencies to use modern python3 equivalents and updates legacy python shebangs across the build and contrib scripts to ensure compatibility.

Fixes build-host preparation failures related to python-all-dev and python-sphinx.

Tested by: Successfully running 'make debian-prepare-build-host' and verifying the toolchain extraction phase completes on WSL Ubuntu 22.04.