### PR TITLE
ci: add GitHub Action to build and boot-test the kvm_x86_64 ONIE image

### DIFF
--- a/.github/onie-build/Dockerfile
+++ b/.github/onie-build/Dockerfile
@@ -1,0 +1,103 @@
+# ONIE build environment for CI.
+#
+# Debian 11 is required: onie/build-config/Makefile still pulls in
+# python2-era tooling (python-all-dev) that is unavailable on newer
+# Debian releases.
+#
+# This image builds the generic kvm_x86_64 target with secure boot
+# enabled.  It includes the secure-boot key-generation and EFI signing
+# tooling (gnupg2, efitools, sbsigntool), the NSS command-line tools the
+# shim signing step shells out to (libnss3-tools: pk12util/certutil), and
+# the build dependencies for the pesign that ONIE compiles from source
+# (NSS/NSPR dev packages).
+FROM debian:11
+WORKDIR /onie
+
+# Tolerate transient Debian mirror hiccups (connection resets mid-fetch).
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
+# Build dependencies for crosstool-NG and the ONIE image.
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    autoconf-archive \
+    automake \
+    autopoint \
+    bc \
+    bison \
+    bsdmainutils \
+    build-essential \
+    coreutils \
+    cpio \
+    curl \
+    device-tree-compiler \
+    dosfstools \
+    efitools \
+    fakeroot \
+    flex \
+    gawk \
+    git \
+    gnupg2 \
+    gperf \
+    help2man \
+    libefivar-dev \
+    libelf-dev \
+    libexpat1 \
+    libexpat1-dev \
+    libncurses5 \
+    libncurses5-dev \
+    libnspr4-dev \
+    libnss3-dev \
+    libnss3-tools \
+    libpopt-dev \
+    libssl-dev \
+    libtool \
+    libtool-bin \
+    locales \
+    mtools \
+    pkgconf \
+    python-all-dev \
+    python3-all-dev \
+    python3-sphinx \
+    python3-venv \
+    rst2pdf \
+    rsync \
+    sbsigntool \
+    stgit \
+    texinfo \
+    tree \
+    u-boot-tools \
+    unzip \
+    util-linux \
+    uuid-dev \
+    uuid-runtime \
+    wget \
+    zip \
+    xorriso \
+    && rm -rf /var/lib/apt/lists/*
+
+# Generate UTF-8 locale (needed for the uclibc / crosstool-NG build).
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+
+# Create the build user with the same UID/GID as the host invoker so
+# build artifacts are not left owned by root.  Override at build time
+# with --build-arg UID=$(id -u) --build-arg GID=$(id -g).
+#
+# NOTE: -l avoids docker layer-export hangs for large UIDs.
+#       (https://github.com/moby/moby/issues/5419#issuecomment-41478290)
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID build && \
+    useradd -l -m -u $UID -g $GID -s /bin/bash build && \
+    chown -R build:build /onie
+
+USER build
+
+# /sbin and /usr/sbin hold tools the build invokes.
+RUN echo 'export PATH="/sbin:/usr/sbin:$PATH"' >> ~/.bashrc
+
+# The build runs git commands; give it a default identity.
+RUN git config --global user.email "build@example.com" && \
+    git config --global user.name "Build User"
+
+CMD ["/bin/bash", "--login"]

--- a/.github/workflows/build-onie.yml
+++ b/.github/workflows/build-onie.yml
@@ -1,0 +1,302 @@
+name: Build ONIE (kvm_x86_64)
+
+# Builds the generic amd64 ONIE image for the kvm_x86_64 target, intended
+# to run as a VM under KVM/QEMU.  The build follows the upstream-recommended
+# containerized flow (see contrib/build-env and machine/kvm_x86_64/INSTALL),
+# with secure boot enabled: the workflow generates demonstration signing
+# keys and self-signs the shim before building.
+
+# Run on every push and pull request: the point of this workflow is to
+# confirm the change still builds, and the kvm_x86_64 image depends on far
+# more than the build files (installer/, rootconf/, patches/, ...), so path
+# filtering would risk skipping validation on build-affecting changes.
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+# Cancel an in-progress run when a newer commit is pushed to the same ref,
+# so stacked pushes don't pile up concurrent builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build kvm_x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Determine host UID/GID
+        id: ids
+        run: |
+          echo "uid=$(id -u)" >> "$GITHUB_OUTPUT"
+          echo "gid=$(id -g)" >> "$GITHUB_OUTPUT"
+
+      - name: Build the ONIE build-environment image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .github/onie-build
+          tags: onie-build-env:latest
+          build-args: |
+            UID=${{ steps.ids.outputs.uid }}
+            GID=${{ steps.ids.outputs.gid }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Cache the crosstool-NG cross toolchain -- the long pole of a cold
+      # build.  We cache the whole stamp chain (so make does not rebuild on a
+      # missing root stamp) but only the parts the warm, no-op path actually
+      # needs -- NOT the multi-GB crosstool-NG build scratch or ct-ng source
+      # tree, which are only used while building the toolchain.  On a cache
+      # hit "make xtools" is a no-op and the real build only uses the
+      # installed toolchain, so dropping the scratch keeps the cache blob
+      # small and fast/reliable to restore.
+      #
+      #   build/stamp-project          -- top-of-chain project stamp
+      #   build/download               -- toolchain tarballs + download stamps
+      #   build/crosstool-ng/stamp     -- crosstool-NG build stamps
+      #   build/x-tools/*/stamp        -- xtools build stamps
+      #   build/x-tools/*/install      -- the installed cross toolchain
+      #   build/x-tools/*/build/.config -- xtools config (an xtools-build prereq)
+      #
+      # The key is tied to every input that can change the toolchain --
+      # including the Dockerfile, since it defines the compiler/host
+      # environment the toolchain is built in.  No loose restore-keys: any
+      # input change forces a clean rebuild rather than restoring a
+      # mismatched toolchain.
+      - name: Restore cross-toolchain cache
+        id: xtools-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            build/stamp-project
+            build/download
+            build/crosstool-ng/stamp
+            build/x-tools/*/stamp
+            build/x-tools/*/install
+            build/x-tools/*/build/.config
+          key: onie-xtools-kvm_x86_64-${{ hashFiles('build-config/make/xtools.make', 'build-config/make/crosstool-ng.make', 'build-config/make/compiler.make', 'build-config/conf/crosstool/**', 'patches/crosstool-NG/**', '.github/onie-build/Dockerfile') }}
+
+      # ONIE drives its build with stamp files compared by mtime.  A fresh
+      # checkout gives every repo source file a current mtime, which is newer
+      # than the restored stamps -- so make would consider the toolchain
+      # stale and rebuild it (e.g. build/.../.config depends on the
+      # checked-out conf/crosstool config).  A cache hit means the key
+      # matched, i.e. every toolchain input is unchanged and the restored
+      # toolchain is valid, so bump the restored artifacts ahead of the
+      # checkout to make "make xtools" a genuine no-op.
+      - name: Mark restored toolchain up to date
+        if: steps.xtools-cache.outputs.cache-hit == 'true'
+        # Restoring build/stamp-project makes make skip the project-stamp
+        # recipe, which is what normally creates the project output dirs --
+        # so recreate them (build/images is an output, not part of the
+        # cache, and the kernel install copies vmlinuz into it).
+        #
+        # Then touch only the files make compares -- the stamp files and the
+        # toolchain .config.  Do NOT touch the toolchain tree itself: it
+        # contains read-only binaries and symlinks to host tools (bash,
+        # make, ...) that touch would follow and fail to update.
+        #
+        # Touch them all to ONE identical timestamp (-t), not "now" per file.
+        # The xtools build stamp depends on .config (xtools.make), and a bare
+        # `find -exec touch {} +` batches files across calls that can straddle a
+        # one-second boundary -- leaving .config (touched last) newer than the
+        # build stamp.  make then re-runs `ct-ng build`, which fails because the
+        # ct-ng binary is intentionally not in the cache.  Equal mtimes mean no
+        # cached target is ever "newer-than" a cached prerequisite, so `make
+        # xtools` is a reliable no-op; the timestamp is "now" (after checkout),
+        # so it's also newer than the just-checked-out toolchain config sources.
+        run: |
+          mkdir -p build build/images build/download
+          ts="$(date +%Y%m%d%H%M.%S)"
+          find build/stamp-project build/download \
+               build/crosstool-ng/stamp \
+               build/x-tools/*/stamp \
+               build/x-tools/*/build/.config \
+               -type f -exec touch -t "$ts" {} +
+
+      - name: Build cross toolchain
+        run: |
+          docker run --rm --privileged \
+            -v "${PWD}:/onie" \
+            onie-build-env \
+            bash -lc 'cd build-config && make -j"$(nproc)" \
+              MACHINE=kvm_x86_64 \
+              xtools'
+
+      # Save only on a cache miss, and only after the toolchain build above
+      # succeeded (default if: success()), so a broken toolchain is never
+      # cached.  Running before the full build means a later-stage failure
+      # still preserves the toolchain for the next run.
+      - name: Save cross-toolchain cache
+        if: steps.xtools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            build/stamp-project
+            build/download
+            build/crosstool-ng/stamp
+            build/x-tools/*/stamp
+            build/x-tools/*/install
+            build/x-tools/*/build/.config
+          key: ${{ steps.xtools-cache.outputs.cache-primary-key }}
+
+      - name: Build ONIE
+        run: |
+          docker run --rm --privileged \
+            -v "${PWD}:/onie" \
+            onie-build-env \
+            bash -lc 'cd build-config && \
+              make MACHINE=kvm_x86_64 signing-keys-generate && \
+              make MACHINE=kvm_x86_64 shim-self-sign && \
+              make -j"$(nproc)" MACHINE=kvm_x86_64 all recovery-iso demo'
+
+      - name: Upload kvm recovery image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: onie-kvm-recovery-iso
+          path: build/images/onie-recovery-x86_64-kvm_x86_64-r0.iso
+          retention-days: 7
+
+      # The demonstration PK/KEK/db that signed this build's shim/grub/kernel.
+      # The boot-test job enrolls them into an OVMF varstore to validate the
+      # secure-boot signature chain.  These are the SAME keys this run signed
+      # with, so the enrolled db matches the shipped image (regenerating would
+      # not).  Demo keys only -- non-sensitive (see machine-security.make).
+      - name: Upload secure-boot demo keys
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: onie-kvm-sb-keys
+          # Exclude the gpg-agent sockets that signing-keys-generate leaves in
+          # the gpg-keys dirs -- upload-artifact can't zip sockets and warns
+          # ENTRYNOTSUPPORTED; only the .pem/.der key material is needed.
+          path: |
+            encryption/machines/kvm_x86_64/keys
+            !encryption/machines/kvm_x86_64/keys/**/S.gpg-agent*
+          retention-days: 7
+
+      # Artifacts for the install-test job: the recovery kernel/initrd (booted
+      # directly in install mode), the ONIE updater (to embed ONIE on a blank
+      # disk first), and the demo OS installer (the NOS discovery installs).
+      - name: Upload install-test images
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: onie-kvm-install-images
+          path: |
+            build/images/kvm_x86_64-r0.vmlinuz
+            build/images/kvm_x86_64-r0.initrd
+            build/images/onie-updater-x86_64-kvm_x86_64-r0
+            build/images/demo-installer-x86_64-kvm_x86_64-r0.bin
+          retention-days: 7
+
+  # Boot the built recovery ISO headlessly under QEMU+OVMF and assert ONIE gets
+  # past GRUB into the OS (serial-console milestones, no kernel panic).  ONIE is
+  # serial end-to-end (GRUB+kernel+userspace on ttyS0) so a serial capture
+  # suffices -- no screen scraping/OCR.  See emulation/ci-boot-test.sh.
+  boot-test:
+    name: Boot test kvm_x86_64
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Enable KVM (grant /dev/kvm access)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Install QEMU + OVMF
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils ovmf python3-virt-firmware
+      - name: Download kvm recovery image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: onie-kvm-recovery-iso
+          path: build/images
+      - name: Download secure-boot demo keys
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: onie-kvm-sb-keys
+          path: encryption/machines/kvm_x86_64/keys
+      # SB-relaxed smoke: plain OVMF on the default 'pc' machine -- proves the
+      # image boots past GRUB into the OS independent of the SB signature chain.
+      - name: Boot ONIE (SB-relaxed) and assert it reaches the OS
+        run: |
+          SERIAL_LOG="$PWD/onie-boot-serial.log" BOOT_MODE=relaxed \
+            emulation/ci-boot-test.sh \
+              build/images/onie-recovery-x86_64-kvm_x86_64-r0.iso 300
+      # SB-enforced: enroll the demo PK/KEK/db, boot the secboot OVMF on
+      # q35,smm=on, and assert the shim/grub/kernel chain verifies (plus a
+      # negative control with db omitted that MUST be rejected).  This is the
+      # signal that catches a broken signing chain in the grub/shim/kernel
+      # modernization PRs even when the image otherwise builds and boots.
+      - name: Boot ONIE (SB-enforced) and assert the signing chain verifies
+        run: |
+          SERIAL_LOG="$PWD/onie-boot-serial-secureboot.log" BOOT_MODE=secureboot \
+          KEYS_DIR="$PWD/encryption/machines/kvm_x86_64/keys" \
+            emulation/ci-boot-test.sh \
+              build/images/onie-recovery-x86_64-kvm_x86_64-r0.iso 300
+      - name: Upload serial logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: onie-boot-serial-log
+          path: onie-boot-serial*.log
+          retention-days: 7
+
+  # Functional discovery-install: prove ONIE actually installs an OS and boots
+  # it, not just that it reaches rescue.  Embed ONIE onto a blank disk, then in
+  # install mode point discovery (install_url=) at the locally-served demo
+  # installer, install it, and boot the resulting demo OS -- all headless via
+  # the serial console.  This exercises the real installer path (download,
+  # exec_installer, the NOS writing GRUB + the OS to disk, the OS booting) that
+  # the boot-smoke jobs do not.  Runs Secure-Boot-relaxed (legacy BIOS) -- the
+  # signing chain is covered by boot-test.  See emulation/ci-install-test.sh.
+  install-test:
+    name: Install test kvm_x86_64
+    # Chained after boot-test (not parallel) so only one VM-heavy job runs at a
+    # time, keeping CI resource use low.
+    needs: boot-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Enable KVM (grant /dev/kvm access)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils
+      - name: Download install-test images
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: onie-kvm-install-images
+          path: build/images
+      - name: Install demo OS via discovery and boot it
+        run: |
+          SERIAL_PREFIX="$PWD/onie-install" \
+            emulation/ci-install-test.sh \
+              build/images/kvm_x86_64-r0.vmlinuz \
+              build/images/kvm_x86_64-r0.initrd \
+              build/images/demo-installer-x86_64-kvm_x86_64-r0.bin 600
+      - name: Upload install serial logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: onie-install-serial-log
+          path: onie-install-*.log
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 local.make
 onie-installer
+encryption/machines/

--- a/emulation/ci-boot-test.sh
+++ b/emulation/ci-boot-test.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+#  Copyright (C) 2026 Brad House <bhouse@nexthop.ai>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+#
+# CI boot-validation harness for the kvm_x86_64 ONIE recovery image.
+#
+# Boots the recovery ISO headlessly under QEMU + OVMF (UEFI), captures the
+# serial console, and asserts that ONIE boots PAST GRUB INTO THE OS.  ONIE
+# routes GRUB, the kernel and userspace all to ttyS0, so a serial capture is
+# sufficient -- no graphical/OCR interaction is needed.
+#
+# PASS  = all boot milestones observed AND no kernel panic.
+# FAIL  = a milestone is missing or the kernel panicked (e.g. init died).
+#
+# Two modes (BOOT_MODE):
+#   relaxed     (default) Secure-Boot-RELAXED: plain OVMF varstore, no keys
+#               enrolled.  shim still chainloads grub->kernel, so it validates
+#               "does it boot" independent of the SB signature chain.  Boots on
+#               the default 'pc' machine (ONIE's onie-vm.sh reference machine).
+#   secureboot  Secure-Boot-ENFORCED: enrolls the demonstration PK/KEK/db from
+#               KEYS_DIR into an OVMF varstore (virt-fw-vars), boots the secboot
+#               OVMF firmware on 'q35,smm=on' with the flash secure flag, and
+#               asserts ONIE boots -- i.e. the shim/grub/kernel signing chain
+#               verifies under enforcement.  Also runs a NEGATIVE control with
+#               the db omitted, which MUST be rejected (proves SB is enforcing,
+#               not merely permissive).
+#
+# Usage:  ci-boot-test.sh <recovery.iso> [timeout_secs]
+# Env:    SERIAL_LOG=<path>   serial log path (default ./onie-boot-serial.log)
+#         BOOT_MODE=relaxed|secureboot     (default relaxed)
+#         KEYS_DIR=<dir>      encryption/machines/kvm_x86_64/keys (secureboot)
+#
+# Requires on the host: qemu-system-x86_64, ovmf (apt: qemu-system-x86 ovmf).
+# secureboot mode additionally needs virt-fw-vars (apt: python3-virt-firmware).
+# On GitHub Actions, add the kvm udev rule first so /dev/kvm is usable; QEMU
+# falls back to TCG automatically via accel=kvm:tcg if KVM is unavailable.
+
+set -uo pipefail
+
+ISO="${1:?usage: ci-boot-test.sh <recovery.iso> [timeout_secs]}"
+TIMEOUT="${2:-300}"
+SERIAL_LOG="${SERIAL_LOG:-onie-boot-serial.log}"
+BOOT_MODE="${BOOT_MODE:-relaxed}"
+
+# Terminal-state markers run_qemu polls for (to stop QEMU as soon as the outcome
+# is decided instead of waiting out the timeout):
+#  READY_BOOT - a successful boot has reached the ONIE console/discovery prompt.
+#  READY_NEG  - the SB negative control has resolved: either rejected (expected)
+#               or, unexpectedly, reached GRUB/ONIE (caught by the assertions).
+READY_BOOT='Please press Enter to activate this console|discover: (ONIE|Rescue)|Starting ONIE Service Discovery'
+READY_NEG='Security Violation|Access Denied|verification failed|GNU GRUB|ONIE: (OS Install|Rescue) Mode'
+
+[ -r "$ISO" ] || { echo "ERROR: ISO not readable: $ISO" >&2; exit 2; }
+
+# A fixed owner GUID for the enrolled demo keys -- deterministic on purpose so
+# runs are reproducible; the value is immaterial for boot verification.
+SB_OWNER_GUID="a9b1c2d3-0011-4caf-8bad-f00d0c1e0001"
+
+# --- locate OVMF firmware (Ubuntu 24.04 dropped the 2MB files -> probe _4M first) ---
+OVMF_CODE=""; OVMF_CODE_SB=""; OVMF_VARS_SRC=""
+for c in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd \
+         /usr/share/edk2/ovmf/OVMF_CODE.fd; do
+    [ -f "$c" ] && OVMF_CODE="$c" && break
+done
+for c in /usr/share/OVMF/OVMF_CODE_4M.secboot.fd /usr/share/OVMF/OVMF_CODE.secboot.fd \
+         /usr/share/edk2/ovmf/OVMF_CODE.secboot.fd; do
+    [ -f "$c" ] && OVMF_CODE_SB="$c" && break
+done
+for v in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd \
+         /usr/share/edk2/ovmf/OVMF_VARS.fd; do
+    [ -f "$v" ] && OVMF_VARS_SRC="$v" && break
+done
+[ -n "$OVMF_CODE" ] && [ -n "$OVMF_VARS_SRC" ] || {
+    echo "ERROR: OVMF firmware not found (apt install ovmf)" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- boot QEMU headless, serial(ttyS0) -> file, -no-reboot so a panic doesn't
+#     loop.  Polls the serial log and stops QEMU as soon as the boot reaches a
+#     terminal state (the <ready-regex>, e.g. the console prompt) or panics --
+#     ONIE boots to an idle console and never exits, so without this we would
+#     dead-wait the full timeout on every (successful) boot.  The timeout is now
+#     only hit by a genuinely stuck boot.
+#     Args:  <ready-regex> <code.fd> <vars.fd> <serial_log> [extra qemu args...]
+run_qemu() {
+    local ready_re="$1" code="$2" vars="$3" log="$4"; shift 4
+    : >"$log"
+    qemu-system-x86_64 \
+        -m 2048 -smp 2 \
+        -drive if=pflash,format=raw,readonly=on,file="$code" \
+        -drive if=pflash,format=raw,file="$vars" \
+        -cdrom "$ISO" -boot d \
+        -netdev user,id=onienet -device virtio-net,netdev=onienet \
+        -display none -serial "file:$log" -no-reboot \
+        "$@" >/dev/null 2>&1 &
+    local qpid=$! t=0
+    while kill -0 "$qpid" 2>/dev/null; do
+        if grep -Eaq "$ready_re" "$log" || grep -aq 'Kernel panic' "$log"; then break; fi
+        [ "$t" -ge "$TIMEOUT" ] && break
+        sleep 1; t=$((t + 1))
+    done
+    kill "$qpid" 2>/dev/null; sleep 1; kill -9 "$qpid" 2>/dev/null; wait "$qpid" 2>/dev/null
+    if grep -aq 'Kernel panic' "$log"; then        echo "   (stopped at ${t}s: kernel panic)"
+    elif grep -Eaq "$ready_re" "$log"; then         echo "   (stopped at ${t}s: reached terminal state)"
+    else                                            echo "   (stopped at ${t}s: TIMEOUT, no terminal marker)"; fi
+}
+
+# --- assert the ONIE boot milestones in a captured serial log.  Sets `fail`. ---
+fail=0
+chk() {  # <logfile> <label> <extended-regex>
+    if grep -Eaq "$3" "$1"; then echo "   PASS  $2"
+    else echo "   FAIL  $2   (/$3/)"; fail=1; fi
+}
+assert_booted() {  # <logfile>
+    local log="$1"
+    [ -s "$log" ] || { echo "   FAIL  no serial output captured"; fail=1; return; }
+    chk "$log" "GRUB reached"   'GNU GRUB|Booting .ONIE'
+    chk "$log" "ONIE userspace" 'ONIE: (OS Install|Rescue) Mode|^Version   :'
+    chk "$log" "console up"     'Please press Enter to activate this console|discover: (ONIE|Rescue)|Starting ONIE Service Discovery'
+    if grep -aq 'Kernel panic' "$log"; then
+        echo "   FAIL  kernel panicked:"; grep -a 'Kernel panic' "$log" | sed 's/^/         /'
+        fail=1
+    fi
+}
+dump_tail() {  # <logfile>
+    echo "---- serial tail ($1) ----"
+    sed 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b[=>]//g; s/\r/\n/g' "$1" \
+        | grep -avE '^\s*$' | tail -25
+}
+
+echo "== ONIE boot-test =="
+echo "   ISO        : $ISO"
+echo "   mode       : $BOOT_MODE"
+echo "   serial log : $SERIAL_LOG"
+echo "   timeout    : ${TIMEOUT}s"
+echo "   accel      : kvm:tcg ($([ -w /dev/kvm ] && echo 'KVM' || echo 'TCG (no /dev/kvm)'))"
+
+if [ "$BOOT_MODE" = "relaxed" ]; then
+    echo "   OVMF code  : $OVMF_CODE (SB-relaxed)"
+    cp "$OVMF_VARS_SRC" "$WORK/vars.fd"   # writable per-run varstore copy
+    run_qemu "$READY_BOOT" "$OVMF_CODE" "$WORK/vars.fd" "$SERIAL_LOG" -machine accel=kvm:tcg
+    echo "== milestones =="
+    assert_booted "$SERIAL_LOG"
+
+elif [ "$BOOT_MODE" = "secureboot" ]; then
+    # --- Secure-Boot-ENFORCED validation ---
+    KEYS_DIR="${KEYS_DIR:?secureboot mode requires KEYS_DIR=.../keys}"
+    [ -d "$KEYS_DIR" ] || { echo "ERROR: KEYS_DIR not a directory: $KEYS_DIR" >&2; exit 2; }
+    [ -n "$OVMF_CODE_SB" ] || { echo "ERROR: secboot OVMF not found (OVMF_CODE_4M.secboot.fd)" >&2; exit 2; }
+    command -v virt-fw-vars >/dev/null || { echo "ERROR: virt-fw-vars missing (apt install python3-virt-firmware)" >&2; exit 2; }
+
+    PK="$KEYS_DIR/HW/efi-keys/HW-platform-key-cert.pem"
+    KEK_SW="$KEYS_DIR/SW/efi-keys/SW-key-exchange-key-cert.pem"
+    KEK_HW="$KEYS_DIR/HW/efi-keys/HW-key-exchange-key-cert.pem"
+    DB_SW="$KEYS_DIR/SW/efi-keys/SW-database-key-cert.pem"   # this verifies shim
+    DB_HW="$KEYS_DIR/HW/efi-keys/HW-database-key-cert.pem"
+    for f in "$PK" "$KEK_SW" "$KEK_HW" "$DB_SW" "$DB_HW"; do
+        [ -r "$f" ] || { echo "ERROR: missing demo key: $f" >&2; exit 2; }
+    done
+
+    SB_QEMU_ARGS=(-machine q35,smm=on,accel=kvm:tcg
+                  -global driver=cfi.pflash01,property=secure,value=on)
+    echo "   OVMF code  : $OVMF_CODE_SB (SB-enforced, q35,smm=on)"
+
+    # Positive: PK + KEK + db (incl. the SW-database key that signs shim).
+    echo "== [secureboot] enrolling PK/KEK/db (positive) =="
+    virt-fw-vars --input "$OVMF_VARS_SRC" --output "$WORK/vars.pos.fd" \
+        --set-pk  "$SB_OWNER_GUID" "$PK" \
+        --add-kek "$SB_OWNER_GUID" "$KEK_SW" --add-kek "$SB_OWNER_GUID" "$KEK_HW" \
+        --add-db  "$SB_OWNER_GUID" "$DB_SW"  --add-db  "$SB_OWNER_GUID" "$DB_HW" \
+        --secure-boot 2>&1 | sed 's/^/   /' | grep -Ei 'error|fail|add (pk|kek|db)|secure' || true
+
+    echo "== [secureboot] booting SB-ENFORCED (must boot) =="
+    run_qemu "$READY_BOOT" "$OVMF_CODE_SB" "$WORK/vars.pos.fd" "$SERIAL_LOG" "${SB_QEMU_ARGS[@]}"
+    echo "== milestones =="
+    assert_booted "$SERIAL_LOG"
+    # An SB rejection of our own signed chain is a hard fail (chain broke).
+    if grep -Eaiq 'Security Violation|Access Denied|verification failed|image (failed|did not pass)' "$SERIAL_LOG"; then
+        echo "   FAIL  secure-boot rejected the signed image (chain broken):"
+        grep -Eai 'Security Violation|Access Denied|verification failed' "$SERIAL_LOG" | sed 's/^/         /' | head
+        fail=1
+    fi
+
+    # Negative control: enroll PK + KEK but OMIT db.  The ONIE shim is now
+    # untrusted, so an *enforcing* firmware MUST refuse to load it.  If ONIE
+    # boots anyway, SB is not actually being enforced -> the positive result
+    # is meaningless, so this is a hard fail.
+    NEG_LOG="${SERIAL_LOG%.log}-negative.log"; [ "$NEG_LOG" = "$SERIAL_LOG" ] && NEG_LOG="$SERIAL_LOG.negative"
+    echo "== [secureboot] enrolling PK/KEK, NO db (negative control) =="
+    virt-fw-vars --input "$OVMF_VARS_SRC" --output "$WORK/vars.neg.fd" \
+        --set-pk  "$SB_OWNER_GUID" "$PK" \
+        --add-kek "$SB_OWNER_GUID" "$KEK_SW" \
+        --secure-boot 2>&1 | sed 's/^/   /' | grep -Ei 'error|fail|secure' || true
+    echo "== [secureboot] booting NEGATIVE (must be REJECTED) =="
+    # Negative boot rejects fast; cap its wait so it doesn't burn the full timeout.
+    ( TIMEOUT=$(( TIMEOUT < 90 ? TIMEOUT : 90 )); run_qemu "$READY_NEG" "$OVMF_CODE_SB" "$WORK/vars.neg.fd" "$NEG_LOG" "${SB_QEMU_ARGS[@]}" )
+    echo "== negative assertions =="
+    if grep -Eaq 'GNU GRUB|ONIE: (OS Install|Rescue) Mode|Please press Enter to activate this console' "$NEG_LOG"; then
+        echo "   FAIL  ONIE booted with db absent -> secure boot is NOT being enforced"
+        fail=1
+    else
+        echo "   PASS  ONIE did not boot without db (as required)"
+    fi
+    if grep -Eaiq 'Security Violation|Access Denied|verification failed|image (failed|did not pass)' "$NEG_LOG"; then
+        echo "   PASS  firmware rejected the untrusted image:"
+        grep -Eai 'Security Violation|Access Denied|verification failed' "$NEG_LOG" | sed 's/^/         /' | head -3
+    else
+        # No explicit rejection string AND it didn't boot -- acceptable, but note it.
+        echo "   NOTE  no explicit rejection string; relying on absence-of-boot above"
+    fi
+    [ -f "$NEG_LOG" ] && [ "$fail" -ne 0 ] && dump_tail "$NEG_LOG"
+
+else
+    echo "ERROR: unknown BOOT_MODE '$BOOT_MODE' (expected relaxed|secureboot)" >&2
+    exit 2
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "RESULT: PASS ($BOOT_MODE -- ONIE booted past GRUB into the OS)"; exit 0
+else
+    echo "RESULT: FAIL ($BOOT_MODE)"
+    dump_tail "$SERIAL_LOG"
+    exit 1
+fi

--- a/emulation/ci-install-test.sh
+++ b/emulation/ci-install-test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+#  Copyright (C) 2026 Brad House <bhouse@nexthop.ai>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+#
+# CI harness: functional discovery-install of the demo OS.
+#
+# Drives a full ONIE OS-install end to end, headlessly under QEMU:
+#   Stage A (install): boot ONIE in OS-install mode pointing discovery at a
+#     locally-served demo installer (install_url= on the kernel cmdline; ONIE's
+#     sd_static() short-circuits discovery straight to it), install onto a blank
+#     virtio disk, and assert "NOS install successful".
+#   Stage B (boot NOS): boot the now-installed disk and assert the demo OS
+#     comes up ("Welcome to ... DEMO ... platform").
+#
+# This validates the real installer path -- download, exec_installer, the demo
+# installer writing GRUB + the demo OS to disk, and the demo OS booting -- which
+# the build/boot-smoke gates do not exercise.
+#
+# Usage:  ci-install-test.sh <vmlinuz> <initrd> <demo-installer.bin> [timeout]
+# Env:    WORKDIR=<dir>  (default mktemp)   SERIAL_PREFIX=<path-prefix>
+#
+# Requires: qemu-system-x86_64, qemu-img, python3 (http.server).  Bypasses
+# GRUB/shim (direct -kernel boot) on purpose -- this phase tests the INSTALLER,
+# not the boot chain (the boot chain is covered by ci-boot-test.sh).
+
+set -uo pipefail
+
+VMLINUZ="${1:?usage: ci-install-test.sh <vmlinuz> <initrd> <demo-installer.bin> [timeout]}"
+INITRD="${2:?need initrd}"
+INSTALLER="${3:?need demo-installer.bin}"
+TIMEOUT="${4:-600}"
+for f in "$VMLINUZ" "$INITRD" "$INSTALLER"; do
+    [ -r "$f" ] || { echo "ERROR: not readable: $f" >&2; exit 2; }
+done
+
+WORKDIR="${WORKDIR:-$(mktemp -d)}"; mkdir -p "$WORKDIR"
+SERIAL_PREFIX="${SERIAL_PREFIX:-$WORKDIR/install}"
+mkdir -p "$(dirname "$SERIAL_PREFIX")"
+INSTALL_LOG="${SERIAL_PREFIX}-install.log"
+NOS_LOG="${SERIAL_PREFIX}-nos.log"
+DISK="$WORKDIR/nos-disk.qcow2"
+HTTP_PORT=8919
+ACCEL="accel=kvm:tcg"
+CONSOLE="console=tty0 console=ttyS0,115200n8"
+INSTALLER_NAME="$(basename "$INSTALLER")"
+
+echo "== ONIE install-test =="
+echo "   vmlinuz   : $VMLINUZ"
+echo "   initrd    : $INITRD"
+echo "   installer : $INSTALLER ($INSTALLER_NAME)"
+echo "   workdir   : $WORKDIR"
+echo "   accel     : kvm:tcg ($([ -w /dev/kvm ] && echo KVM || echo TCG))"
+
+# --- serve the installer over HTTP (guest reaches host at 10.0.2.2 via SLIRP) ---
+SERVE_DIR="$(cd "$(dirname "$INSTALLER")" && pwd)"
+python3 -m http.server "$HTTP_PORT" --directory "$SERVE_DIR" >"$WORKDIR/http.log" 2>&1 &
+HTTP_PID=$!
+trap 'kill "$HTTP_PID" 2>/dev/null; [ -n "${KEEP:-}" ] || rm -rf "$WORKDIR"' EXIT
+sleep 1
+kill -0 "$HTTP_PID" 2>/dev/null || { echo "ERROR: http.server failed"; cat "$WORKDIR/http.log"; exit 2; }
+echo "   http      : serving $SERVE_DIR on :$HTTP_PORT (pid $HTTP_PID)"
+
+# --- blank install target disk ---
+qemu-img create -f qcow2 "$DISK" 4G >/dev/null 2>&1
+
+INSTALL_URL="http://10.0.2.2:${HTTP_PORT}/${INSTALLER_NAME}"
+EMBED_LOG="${SERIAL_PREFIX}-embed.log"
+
+# Boot ONIE (direct -kernel, legacy BIOS, the target disk, user-net) and stop
+# QEMU as soon as the serial log hits <ready-regex> or a panic -- ONIE idles at
+# a console and never exits, so polling avoids dead-waiting the whole timeout.
+# Args:  <serial_log> <boot_reason> <install_url> <ready-regex>
+run_onie() {
+    local log="$1" reason="$2" url="$3" ready_re="$4"
+    : > "$log"
+    qemu-system-x86_64 \
+        -machine pc,${ACCEL} -m 2048 -smp 2 \
+        -kernel "$VMLINUZ" -initrd "$INITRD" \
+        -append "quiet ${CONSOLE} boot_env=recovery boot_reason=${reason} install_url=${url}" \
+        -drive file="$DISK",if=virtio,format=qcow2 \
+        -netdev user,id=n0 -device virtio-net,netdev=n0 \
+        -display none -serial "file:$log" -no-reboot \
+        >/dev/null 2>&1 &
+    wait_serial "$log" "$ready_re"
+}
+
+# Poll <log> until <ready-regex> or 'Kernel panic' appears, or TIMEOUT; then
+# stop the most recent background QEMU.  Used by every boot in this harness.
+wait_serial() {
+    local log="$1" ready_re="$2" qpid=$! t=0
+    while kill -0 "$qpid" 2>/dev/null; do
+        if grep -Eaq "$ready_re" "$log" || grep -aq 'Kernel panic' "$log"; then break; fi
+        [ "$t" -ge "$TIMEOUT" ] && break
+        sleep 1; t=$((t + 1))
+    done
+    kill "$qpid" 2>/dev/null; sleep 1; kill -9 "$qpid" 2>/dev/null; wait "$qpid" 2>/dev/null
+    echo "   (stopped at ${t}s)"
+}
+
+fail=0
+
+# ===================== Stage 0: EMBED ONIE to the disk =====================
+# The demo installer installs the NOS onto the disk that already holds ONIE
+# (uninstall-arch -> onie_get_boot_dev = `blkid | grep ONIE-BOOT`).  A direct
+# -kernel boot has no on-disk ONIE, so embed it first: ONIE's own updater
+# (file:///lib/onie/onie-updater, shipped in the recovery initrd) writes ONIE +
+# the ONIE-BOOT partition to /dev/vda.  Then the install stage can find it.
+echo
+echo "== Stage 0: embed ONIE onto the disk =="
+# The recovery ISO embeds via file:///lib/onie/onie-updater, but a direct
+# -kernel boot's initrd has no onie-updater on a local path -- so serve the
+# updater (onie-updater-<platform>, alongside the demo installer in build/images)
+# over the same HTTP server and embed from there.
+UPDATER_PATH="$(ls "$SERVE_DIR"/onie-updater-* 2>/dev/null | grep -v '\.sig$' | head -1)"
+[ -n "$UPDATER_PATH" ] || { echo "ERROR: no onie-updater-* in $SERVE_DIR (run 'make ... all')" >&2; exit 2; }
+EMBED_URL="http://10.0.2.2:${HTTP_PORT}/$(basename "$UPDATER_PATH")"
+echo "   embed via: $EMBED_URL"
+run_onie "$EMBED_LOG" embed "$EMBED_URL" 'ONIE: NOS install successful|ONIE: Rebooting'
+echo "== Stage 0 assertions =="
+s0_chk() { if grep -Eaq "$2" "$EMBED_LOG"; then echo "   PASS  $1"; else echo "   FAIL  $1  (/$2/)"; fail=1; fi; }
+s0_chk "embed ran"        'Embedding ONIE|Installing ONIE|ONIE: Executing installer'
+s0_chk "ONIE installed"   'ONIE: NOS install successful|Installed ONIE|ONIE-BOOT|Rebooting'
+if grep -aq 'Kernel panic' "$EMBED_LOG"; then echo "   FAIL  panic during embed"; fail=1; fi
+if [ "$fail" -ne 0 ]; then
+    echo "RESULT: FAIL (embed stage)"
+    echo "---- embed serial tail ----"
+    sed 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b[=>]//g; s/\r/\n/g' "$EMBED_LOG" | grep -avE '^\s*$' | tail -30
+    exit 1
+fi
+
+# ============================ Stage A: INSTALL ============================
+echo
+echo "== Stage A: install demo OS (install_url=$INSTALL_URL) =="
+run_onie "$INSTALL_LOG" install "$INSTALL_URL" 'NOS install successful|Failure: Unable to install'
+echo "== Stage A assertions =="
+sa_chk() { if grep -Eaq "$2" "$INSTALL_LOG"; then echo "   PASS  $1"; else echo "   FAIL  $1  (/$2/)"; fail=1; fi; }
+sa_chk "discovery started"   'Starting ONIE Service Discovery|ONIE: OS Install Mode'
+sa_chk "installer executed"  'Executing installer:|Demo Installer:'
+sa_chk "NOS install success"  'NOS install successful'
+if grep -aq 'Kernel panic' "$INSTALL_LOG"; then echo "   FAIL  kernel panic during install"; fail=1; fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "RESULT: FAIL (install stage)"
+    echo "---- install serial tail ----"
+    sed 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b[=>]//g; s/\r/\n/g' "$INSTALL_LOG" | grep -avE '^\s*$' | tail -40
+    exit 1
+fi
+
+# ============================ Stage B: BOOT NOS ============================
+echo
+echo "== Stage B: boot installed demo OS from disk =="
+: > "$NOS_LOG"
+qemu-system-x86_64 \
+    -machine pc,${ACCEL} -m 2048 -smp 2 \
+    -drive file="$DISK",if=virtio,format=qcow2 \
+    -netdev user,id=n0 -device virtio-net,netdev=n0 \
+    -boot c \
+    -display none -serial "file:$NOS_LOG" -no-reboot \
+    >/dev/null 2>&1 &
+wait_serial "$NOS_LOG" 'Welcome to the .*DEMO.*platform|DEMO GNU/Linux|demo login:'
+
+echo "== Stage B assertions =="
+sb_chk() { if grep -Eaq "$2" "$NOS_LOG"; then echo "   PASS  $1"; else echo "   FAIL  $1  (/$2/)"; fail=1; fi; }
+sb_chk "demo OS booted"  'Welcome to the .*DEMO.*platform|DEMO GNU/Linux|demo login:'
+if grep -aq 'Kernel panic' "$NOS_LOG"; then echo "   FAIL  kernel panic booting NOS"; fail=1; fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "RESULT: PASS (demo OS installed via discovery and booted)"; exit 0
+else
+    echo "RESULT: FAIL (NOS boot stage)"
+    echo "---- nos serial tail ----"
+    sed 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b[=>]//g; s/\r/\n/g' "$NOS_LOG" | grep -avE '^\s*$' | tail -40
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that **builds and boot-tests** the generic
amd64 ONIE target (`kvm_x86_64`, intended to run as a VM under KVM/QEMU) on
every push and pull request. The intent is to make reviewing other PRs easier:
a green check confirms the change still produces an ONIE image that **actually
boots**, so "it builds and boots" becomes part of acceptance testing rather
than something a reviewer verifies by hand.

## `build` job

Containerized build following the upstream-recommended flow (`contrib/build-env`,
`machine/kvm_x86_64/INSTALL`):
- `.github/onie-build/Dockerfile` provides a Debian 11 build environment
  (required because `build-config` still pulls in python2-era tooling), run as a
  `build` user matching the host UID/GID.
- Builds with secure boot enabled (kvm_x86_64's default): `signing-keys-generate`
  → `shim-self-sign` → `make MACHINE=kvm_x86_64 all recovery-iso`.
- The crosstool-NG cross toolchain (the ~25-min long pole) is built as a discrete
  `xtools` target and cached, keyed on every toolchain input. On a cache hit
  `make xtools` is a no-op.
- Uploads the recovery ISO as a workflow artifact for the boot-test job.

## `boot-test` job (`needs: build`)

Downloads the recovery ISO and boots it **headlessly under QEMU + OVMF (UEFI)**,
capturing the serial console and asserting ONIE gets **past GRUB into the OS** —
the GRUB menu, the ONIE banner, and the rescue console all appear, with **no
kernel panic**.
- ONIE routes GRUB, the kernel, and userspace all to `ttyS0`, so a serial
  capture is sufficient — no screen-scraping/OCR.
- GitHub's Linux runners expose `/dev/kvm` (after a udev rule grants access), so
  QEMU uses KVM acceleration, falling back to TCG otherwise.
- Secure-Boot-relaxed: it validates *does it boot*; enforcing the SB signature
  chain is left to a later change.
- Harness: `emulation/ci-boot-test.sh`.

## Notes
- apt `Acquire::Retries` so transient Debian mirror resets don't fail the build.
- Concurrency group (workflow + ref, cancel-in-progress) so a newer push cancels
  the prior run.
