### PR TITLE
ci: add OCE compliance test (DHCP VIVSO discovery + install)

### DIFF
--- a/.github/workflows/build-onie.yml
+++ b/.github/workflows/build-onie.yml
@@ -12,6 +12,17 @@ name: Build ONIE (kvm_x86_64)
 # filtering would risk skipping validation on build-affecting changes.
 on:
   workflow_dispatch:
+    inputs:
+      oce_scope:
+        description: >-
+          OCE compliance test scope: "default" (a fast representative
+          subset, also what push/PR runs) or "full" (the entire OCE
+          installer+updater sweep, tests 3-121 -- slow, many VM boots).
+        type: choice
+        default: default
+        options:
+          - default
+          - full
   push:
   pull_request:
 
@@ -299,4 +310,78 @@ jobs:
         with:
           name: onie-install-serial-log
           path: onie-install-*.log
+          retention-days: 7
+
+  # Run ONIE's own OCE (ONIE Compliance Environment, contrib/oce) compliance
+  # suite against the image.  Where install-test hands ONIE the installer URL
+  # directly (install_url=), OCE exercises the REAL OCP discovery path: it
+  # stands up isc-dhcp-server advertising the ONIE VIVSO vendor option (DHCP
+  # option 125) plus an nginx HTTP server, and ONIE must DHCP, read the VIVSO
+  # installer URL, and fetch+install the image itself.  OCE needs L2 to the DUT
+  # (it validates the DUT shares the host interface's subnet), so the VM is on a
+  # tap interface rather than user-mode SLIRP.  contrib/oce is python3 (it was
+  # ported in the python2-to-3 PR this is stacked on).  See
+  # emulation/ci-oce-test.sh.
+  oce-test:
+    name: OCE compliance kvm_x86_64
+    # Chained after install-test (not parallel) so only one VM-heavy job runs
+    # at a time, keeping CI resource use low.
+    needs: install-test
+    runs-on: ubuntu-latest
+    # This is the longest job in the pipeline and the only one whose length
+    # depends on an input, so the cap has to track the scope.  Worst case is
+    # bounded by the harness's own caps -- a 240s embed plus PER_TEST_TIMEOUT
+    # (180s) per test:
+    #   default   25 tests -> 240s + 25*180s  ~=  80 min  -> 120 covers it
+    #   full     119 tests -> 240s + 119*180s ~= 361 min  -> over GitHub's
+    #                         6-hour job ceiling, where the platform kills the
+    #                         job and reports nothing about which test hung.
+    #                         350 keeps the kill inside the workflow, where the
+    #                         step log still shows where it stopped.
+    # Expected-case runtime is far below both; these are worst case only.  If
+    # "full" becomes a routine run rather than an occasional manual sweep,
+    # splitting it across matrix jobs is the better answer than a bigger cap.
+    timeout-minutes: ${{ inputs.oce_scope == 'full' && 350 || 120 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Enable KVM (grant /dev/kvm access)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Install QEMU + OCE service backends + python deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils isc-dhcp-server nginx-light tftpd-hpa \
+            dnsmasq dosfstools python3-venv
+          python3 -m venv /tmp/oce-venv
+          /tmp/oce-venv/bin/pip install --quiet jinja2 netifaces psutil
+      - name: Download install-test images
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: onie-kvm-install-images
+          path: build/images
+      - name: Run OCE compliance test (full install/update via OCP discovery)
+        run: |
+          # On push/PR (no dispatch input) run the fast "default" subset; a
+          # human can manually dispatch this workflow with oce_scope=full to
+          # run the entire OCE installer+updater sweep.
+          SCOPE="${{ inputs.oce_scope }}"
+          [ -z "$SCOPE" ] && SCOPE=default
+          OCE_PYTHON=/tmp/oce-venv/bin/python SERIAL_PREFIX="$PWD/onie-oce" \
+            emulation/ci-oce-test.sh \
+              build/images/kvm_x86_64-r0.vmlinuz \
+              build/images/kvm_x86_64-r0.initrd \
+              build/images/demo-installer-x86_64-kvm_x86_64-r0.bin \
+              build/images/onie-updater-x86_64-kvm_x86_64-r0 \
+              "$SCOPE"
+      - name: Upload OCE serial logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: onie-oce-serial-log
+          path: onie-oce-*.log
           retention-days: 7

--- a/emulation/ci-oce-test.sh
+++ b/emulation/ci-oce-test.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+
+#  Copyright (C) 2026 Brad House <bhouse@nexthop.ai>
+#
+#  SPDX-License-Identifier:     GPL-2.0
+
+#
+# OCE (ONIE Compliance Environment) CI harness.
+#
+# Drives ONIE's own contrib/oce/test-onie.py compliance suite against the
+# kvm_x86_64 image, headless under QEMU.  Where install-test hands ONIE the
+# installer URL directly (install_url=), this exercises the REAL OCP discovery
+# paths: for each selected OCE test, OCE generates the matching server set
+# (isc-dhcp-server with the ONIE VIVSO option, nginx, tftpd-hpa, dnsmasq) and
+# ONIE must discover + fetch the installer itself.  USB tests instead attach a
+# USB mass-storage image carrying the installer.
+#
+# Each test runs a FULL install: ONIE discovers via the method, fetches the
+# installer, and installs it -- the harness asserts "ONIE: NOS install
+# successful".  To avoid re-embedding per test, ONIE is embedded onto a base
+# disk ONCE up front; each test gets a fresh copy-on-write qcow2 overlay of that
+# base (instant reset) as its install target.
+#
+# Tests run CHAINED (one VM at a time), ordered fast->slow, and the run STOPS on
+# the first failure (fail-fast).  Each test is capped by a timeout so a method
+# that never installs fails in bounded time instead of looping ONIE's
+# retry/sleep waterfall forever.
+#
+# Usage:  ci-oce-test.sh <vmlinuz> <initrd> <demo-installer> <onie-updater> [scope]
+#   scope: "default" (broad per-method installer+updater set, the per-PR sweep),
+#          "full" (every feasible test 3-121), or an explicit space/comma list
+#          of test numbers.  Default: "default".
+# Env:    OCE_DIR=<contrib/oce>  OCE_PYTHON=<python3 w/ oce deps>
+#         SERIAL_PREFIX=<path-prefix>  WORKDIR=<dir>  TAP=<ifname>
+#         PER_TEST_TIMEOUT=<secs, default 180>
+#
+# Requires (install in the workflow): qemu-system-x86_64, qemu-utils, dosfstools,
+# isc-dhcp-server, nginx, tftpd-hpa, dnsmasq, and python3 with
+# jinja2/netifaces/psutil.  Needs sudo.  ONIE is serial end-to-end -> no OCR.
+
+set -uo pipefail
+
+VMLINUZ="${1:?usage: ci-oce-test.sh <vmlinuz> <initrd> <demo-installer> <onie-updater> [scope]}"
+INITRD="${2:?need initrd}"
+INSTALLER="${3:?need demo-installer.bin}"
+UPDATER="${4:?need onie-updater}"
+SCOPE="${5:-default}"
+for f in "$VMLINUZ" "$INITRD" "$INSTALLER" "$UPDATER"; do
+    [ -r "$f" ] || { echo "ERROR: not readable: $f" >&2; exit 2; }
+done
+VMLINUZ="$(realpath "$VMLINUZ")"; INITRD="$(realpath "$INITRD")"
+INSTALLER="$(realpath "$INSTALLER")"; UPDATER="$(realpath "$UPDATER")"
+
+OCE_DIR="${OCE_DIR:-$(cd "$(dirname "$0")/../contrib/oce" 2>/dev/null && pwd)}"
+OCE_PYTHON="${OCE_PYTHON:-python3}"
+[ -r "$OCE_DIR/test-onie.py" ] || { echo "ERROR: OCE not found at OCE_DIR=$OCE_DIR" >&2; exit 2; }
+
+WORKDIR="${WORKDIR:-$(mktemp -d)}"; mkdir -p "$WORKDIR"
+SERIAL_PREFIX="${SERIAL_PREFIX:-$WORKDIR/oce}"; mkdir -p "$(dirname "$SERIAL_PREFIX")"
+TAP="${TAP:-onie-oce0}"
+HOST_V4="192.168.1.1"; DUT_V4="192.168.1.100"; CIDR="24"; DUT_MAC="52:54:00:0c:e0:01"
+PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-180}"
+EMBED_PORT=8920
+ACCEL="accel=kvm:tcg"; CONSOLE="console=tty0 console=ttyS0,115200n8"
+BASE_DISK="$WORKDIR/onie-base.qcow2"
+
+# vCPU count: two with hardware acceleration, one on TCG, matching
+# ci-boot-test.sh.  Under pure emulation a two-vCPU guest can starve badly
+# enough to trip rcu_sched stalls and never finish -- measured on the
+# Secure-Boot OVMF boot in that harness rather than on these direct -kernel
+# boots, so this matches it rather than fixing a hang seen here.  It matters
+# because every test is capped by PER_TEST_TIMEOUT and the sweep is fail-fast:
+# a merely slow guest turns a working discovery method into a timeout and stops
+# the run.  CI runners have /dev/kvm, so this only changes local runs against
+# the accel=kvm:tcg fallback the header advertises.
+if [ -w /dev/kvm ]; then SMP=2; else SMP=1; fi
+
+# ---- test sets (ordered fast->slow: USB/DHCP-direct, then DHCP+server, then no-DHCP/fallback) ----
+DEFAULT_TESTS="3 9 10 69 70 11 12 13 14 20 26 32 71 72 73 74 80 86 92 44 50 56 104 110 116"
+FULL_TESTS="$(seq 3 121)"
+case "$SCOPE" in
+    default) TESTS="$DEFAULT_TESTS" ;;
+    full)    TESTS="$FULL_TESTS" ;;
+    *)       TESTS="$(echo "$SCOPE" | tr ',' ' ')" ;;
+esac
+
+echo "== ONIE OCE compliance sweep (full install) =="
+echo "   scope     : $SCOPE  ($(echo $TESTS | wc -w) tests)"
+echo "   tap iface : $TAP ($HOST_V4/$CIDR, DUT $DUT_V4 mac $DUT_MAC)"
+echo "   accel     : kvm:tcg ($([ -w /dev/kvm ] && echo KVM || echo TCG)), ${SMP} vcpu"
+echo "   per-test  : ${PER_TEST_TIMEOUT}s cap"
+
+stop_services() {
+    sudo pkill -f "dhcpd.leases.oce" 2>/dev/null
+    sudo pkill -f "nginx.*$WORKDIR" 2>/dev/null
+    sudo pkill -x in.tftpd 2>/dev/null
+    sudo pkill -f "dnsmasq.*$WORKDIR" 2>/dev/null
+    true
+}
+cleanup() {
+    stop_services
+    # The embed step's temporary HTTP server, if we exited before killing it.
+    [ -n "${EHP:-}" ] && kill "$EHP" 2>/dev/null
+    sudo ip link del "$TAP" 2>/dev/null
+    [ -n "${KEEP:-}" ] || rm -rf "$WORKDIR"
+    true
+}
+trap cleanup EXIT
+
+# ---- fail loudly when QEMU never ran ----
+# Both launches used to send stderr to /dev/null, so a QEMU that dies on
+# startup (bad args, a missing device model, a tap it cannot open) left an
+# empty serial log -- indistinguishable from "ONIE booted but never installed",
+# and reported as the latter.  Keeping stderr also surfaces "Could not access
+# KVM kernel module ... falling back to tcg", which is otherwise invisible and
+# would explain an inexplicably slow sweep.
+#
+# This has to run at the call site rather than inside wait_marker: wait_marker
+# is invoked in a command substitution, so an exit there would end only the
+# subshell and let the caller continue with a bogus elapsed time.
+qemu_started_or_die() {  # <qemu-pid> <stderr-log>
+    sleep 2
+    kill -0 "$1" 2>/dev/null && return 0
+    local rc=0
+    wait "$1" 2>/dev/null
+    rc=$?
+    echo "ERROR: QEMU exited immediately (rc=$rc) -- harness error, not a test result" >&2
+    sed 's/^/   /' "$2" >&2
+    exit 2
+}
+
+# ---- poll a serial log until a marker (regex) or panic or timeout; kill QEMU; echo elapsed ----
+# The QEMU pid is an explicit argument.  It used to be read from $! inside the
+# function -- "the shell's most recent background job" -- which is correct at
+# both call sites today only because QEMU happens to be started last, even
+# though run_one backgrounds four service processes (dhcpd, nginx, tftpd,
+# dnsmasq) immediately before it.  Any reordering there would silently make the
+# harness poll, and then kill, the wrong process.
+wait_marker() {  # <log> <success-regex> <timeout> <qemu-pid>
+    local log="$1" ok_re="$2" tmo="$3" qpid="$4" t=0
+    while kill -0 "$qpid" 2>/dev/null; do
+        grep -Eaq "$ok_re" "$log" && break
+        grep -aq 'Kernel panic' "$log" && break
+        [ "$t" -ge "$tmo" ] && break
+        sleep 1; t=$((t + 1))
+    done
+    kill "$qpid" 2>/dev/null; sleep 1; kill -9 "$qpid" 2>/dev/null; wait "$qpid" 2>/dev/null
+    echo "$t"
+}
+
+# ---- one-time setup: stop conflicting services, set up the tap ----
+echo "== setup =="
+sudo systemctl stop nginx isc-dhcp-server dnsmasq tftpd-hpa 2>/dev/null
+sudo pkill -x nginx 2>/dev/null; sudo pkill -x dnsmasq 2>/dev/null; sudo pkill -x dhcpd 2>/dev/null
+sudo ip link del "$TAP" 2>/dev/null
+sudo ip tuntap add dev "$TAP" mode tap user "$(id -un)"
+sudo ip addr add "$HOST_V4/$CIDR" dev "$TAP"
+sudo ip -6 addr add fd00:ce::1/64 dev "$TAP" 2>/dev/null
+sudo ip link set "$TAP" up
+
+# ---- embed ONIE onto the base disk ONCE (reused via overlays); via SLIRP + a temp HTTP updater ----
+echo "== embed ONIE onto base disk (one-time) =="
+qemu-img create -f qcow2 "$BASE_DISK" 4G >/dev/null 2>&1
+python3 -m http.server "$EMBED_PORT" --directory "$(dirname "$UPDATER")" >"$WORKDIR/embed-http.log" 2>&1 &
+EHP=$!; sleep 1
+: > "$WORKDIR/embed.log"
+qemu-system-x86_64 \
+    -machine pc,${ACCEL} -m 2048 -smp "$SMP" \
+    -kernel "$VMLINUZ" -initrd "$INITRD" \
+    -append "quiet ${CONSOLE} boot_env=recovery boot_reason=embed install_url=http://10.0.2.2:${EMBED_PORT}/$(basename "$UPDATER")" \
+    -drive file="$BASE_DISK",if=virtio,format=qcow2 \
+    -netdev user,id=n0 -device virtio-net,netdev=n0 \
+    -display none -serial "file:$WORKDIR/embed.log" -no-reboot \
+    >/dev/null 2>"$WORKDIR/embed-qemu-stderr.log" &
+EMBED_QPID=$!
+qemu_started_or_die "$EMBED_QPID" "$WORKDIR/embed-qemu-stderr.log"
+esecs="$(wait_marker "$WORKDIR/embed.log" 'ONIE: NOS install successful|ONIE: Rebooting' 240 "$EMBED_QPID")"
+kill "$EHP" 2>/dev/null
+if ! grep -aqE 'ONIE: NOS install successful|ONIE: Rebooting|Installing ONIE on' "$WORKDIR/embed.log"; then
+    echo "ERROR: embed failed (${esecs}s) -- cannot run install tests"
+    sed 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\r/\n/g' "$WORKDIR/embed.log" | grep -avE '^\s*$' | tail -20
+    exit 1
+fi
+echo "   embedded in ${esecs}s -> $BASE_DISK (cached; tests overlay this)"
+
+# ---- build a vfat USB image carrying the installer under ONIE's default names ----
+build_usb_image() {  # <out.img>
+    local img="$1"
+    # The vfat must hold the installer under all 4 names below; size it to fit
+    # (installer size x4) plus slack for FAT overhead, so a >16MB installer does
+    # not overflow a fixed 64MB image partway through the copies.
+    local mb=$(( ($(stat -c%s "$INSTALLER") / 1048576 + 1) * 4 + 32 ))
+    qemu-img create -f raw "$img" "${mb}M" >/dev/null 2>&1
+    mkfs.vfat -n ONIE-USB "$img" >/dev/null 2>&1
+    local mnt; mnt="$(mktemp -d)"
+    sudo mount -o loop "$img" "$mnt"
+    for n in onie-installer-x86_64-kvm_x86_64-r0 onie-installer-kvm_x86_64 \
+             onie-installer-x86_64 onie-installer; do
+        sudo cp "$INSTALLER" "$mnt/$n"
+    done
+    sudo sync; sudo umount "$mnt"; rmdir "$mnt"
+}
+
+# ---- run one OCE test (full install); return 0 on "NOS install successful" ----
+run_one() {  # <test_num>
+    local t="$1"
+    local tdir="$WORKDIR/oce-out/test-$t"
+    local log="${SERIAL_PREFIX}-test${t}.log"
+    local disk="$WORKDIR/target-$t.qcow2"
+    rm -rf "$tdir"; : > "$log"
+    stop_services; sleep 1
+
+    # installer tests = 3-61, updater tests = 63-121 (onie-tests.json).  An
+    # updater is discovered/run only under boot_reason=update and reports a
+    # different success line than an installer.
+    local reason ok_re
+    if [ "$t" -ge 62 ]; then reason=update;  ok_re='ONIE: Success: Firmware update|Firmware update install successful'
+    else                     reason=install; ok_re='ONIE: NOS install successful'; fi
+
+    # fresh CoW overlay of the embedded base = this test's install target (instant reset)
+    qemu-img create -f qcow2 -b "$BASE_DISK" -F qcow2 "$disk" >/dev/null 2>&1
+
+    ( cd "$OCE_DIR" && "$OCE_PYTHON" test-onie.py -D \
+        -I "$TAP" -m "$DUT_MAC" -i "$DUT_V4/$CIDR" -t "$t" \
+        -o onie_installer "$INSTALLER" onie_updater "$UPDATER" \
+           onie_arch x86_64 onie_vendor kvm onie_machine x86_64 onie_machine_rev 0 \
+           onie_switch_asic qemu \
+        -O "$WORKDIR/oce-out" ) >"$WORKDIR/oce-gen-$t.log" 2>&1
+
+    chmod -R o+rX "$WORKDIR" 2>/dev/null   # nginx/tftpd/dnsmasq workers run as nobody/tftp
+
+    local is_usb=no; local -a qemu_src
+    if [ -f "$tdir/dhcpd.conf" ] || [ -f "$tdir/nginx.conf" ] || [ -f "$tdir/tftp.sh" ] || [ -f "$tdir/dnsmasq.conf" ]; then
+        if [ -f "$tdir/dhcpd.conf" ]; then   # dhcpd is AppArmor-confined -> use allowed paths
+            sudo cp "$tdir/dhcpd.conf" /etc/dhcp/oce-ci.conf
+            sudo sh -c ': > /var/lib/dhcp/dhcpd.leases.oce'
+            sudo dhcpd -f --no-pid -cf /etc/dhcp/oce-ci.conf -lf /var/lib/dhcp/dhcpd.leases.oce "$TAP" \
+                >"$WORKDIR/dhcpd-$t.out" 2>&1 &
+        fi
+        [ -f "$tdir/nginx.conf" ]   && sudo nginx -c "$tdir/nginx.conf"        >"$WORKDIR/nginx-$t.out" 2>&1 &
+        [ -f "$tdir/tftp.sh" ]      && ( cd "$tdir" && sudo bash tftp.sh       >"$WORKDIR/tftp-$t.out" 2>&1 & )
+        [ -f "$tdir/dnsmasq.conf" ] && sudo dnsmasq -k -C "$tdir/dnsmasq.conf" >"$WORKDIR/dnsmasq-$t.out" 2>&1 &
+        sleep 3
+        qemu_src=(-netdev tap,id=n0,ifname="$TAP",script=no,downscript=no
+                  -device virtio-net,netdev=n0,mac="$DUT_MAC")
+    else
+        is_usb=yes
+        build_usb_image "$WORKDIR/usb-$t.img"
+        qemu_src=(-device qemu-xhci -device usb-storage,drive=ud
+                  -drive id=ud,if=none,format=raw,file="$WORKDIR/usb-$t.img"
+                  -netdev user,id=n0 -device virtio-net,netdev=n0)
+    fi
+
+    local qerr="$WORKDIR/qemu-stderr-$t.log"
+    qemu-system-x86_64 \
+        -machine pc,${ACCEL} -m 2048 -smp "$SMP" \
+        -kernel "$VMLINUZ" -initrd "$INITRD" \
+        -append "quiet ${CONSOLE} boot_env=recovery boot_reason=${reason}" \
+        -drive file="$disk",if=virtio,format=qcow2 \
+        "${qemu_src[@]}" \
+        -display none -serial "file:$log" -no-reboot \
+        >/dev/null 2>"$qerr" &
+    local qpid=$!
+    qemu_started_or_die "$qpid" "$qerr"
+    local secs; secs="$(wait_marker "$log" "$ok_re" "$PER_TEST_TIMEOUT" "$qpid")"
+    stop_services
+    rm -f "$disk"
+
+    local kind; kind="$([ "$is_usb" = yes ] && echo USB || echo net)"
+    if grep -Eaq "$ok_re" "$log"; then
+        printf '   PASS  test %-3s [%s/%s] %ss  ok\n' "$t" "$kind" "$reason" "$secs"
+        return 0
+    fi
+    printf '   FAIL  test %-3s [%s/%s] %ss  did NOT reach "%s"\n' "$t" "$kind" "$reason" "$secs" "$ok_re"
+    # QEMU's stderr lives in the work dir, which is removed on exit, so dump it
+    # here -- it is where "Could not access KVM kernel module ... falling back
+    # to tcg" shows up, which would explain an unexpectedly slow test.
+    if [ -s "$qerr" ]; then
+        echo "---- qemu stderr (test $t) ----"
+        grep -v 'terminating on signal' "$qerr" | sed 's/^/   /' | head -10
+    fi
+    echo "---- serial tail (test $t) ----"
+    sed 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b[=>]//g; s/\r/\n/g' "$log" 2>/dev/null | grep -avE '^\s*$' | tail -25
+    return 1
+}
+
+# ---- chained, fail-fast ----
+echo "== running '$SCOPE' sweep ($(echo $TESTS | wc -w) tests), full install, fail-fast =="
+pass=0
+for t in $TESTS; do
+    if run_one "$t"; then pass=$((pass + 1)); else
+        echo "RESULT: FAIL (OCE sweep stopped at test $t; $pass passed before it)"; exit 1
+    fi
+done
+echo "RESULT: PASS (OCE sweep: all $pass tests installed via discovery)"
+exit 0


### PR DESCRIPTION
## What this adds
`ci: add OCE compliance test (DHCP VIVSO discovery + install)` — a new CI gate that runs ONIE's own OCE (ONIE Compliance Environment, `contrib/oce`) against the freshly built `kvm_x86_64` image, exercising the real OCP discovery path end-to-end:

- New `oce-test` job chained after `install-test` (`build → boot-test → install-test → oce-test`), so it runs against the same validated image.
- Boots ONIE headless with an L2 tap (not user-mode SLIRP), stands up the OCP discovery service backends (DHCP incl. **VIVSO**/opt-125, TFTP, HTTP), and has OCE drive discovery → fetch → **full install** (and updater mode for the relevant tests), asserting success over the serial console.
- `workflow_dispatch` gains an `oce_scope` input: `default` (a fast representative subset, also what push/PR runs) or `full` (the entire OCE installer+updater sweep).
- Harness: `emulation/ci-oce-test.sh`.


