### PR TITLE
contrib/build-env: fix Debian stretch Docker image for EOL mirrors

### DIFF
--- a/contrib/build-env/Dockerfile
+++ b/contrib/build-env/Dockerfile
@@ -6,17 +6,33 @@
 
 FROM debian:9
 
-# Add initial development packages
-RUN apt-get update && apt-get install -y \
+# Stretch is EOL; official mirrors no longer serve it.
+# Use archive.debian.org and disable Valid-Until checks.
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
+    rm -rf /etc/apt/sources.list.d/* && \
+    printf "deb http://archive.debian.org/debian/ stretch main\n\
+deb http://archive.debian.org/debian-security stretch/updates main\n" > /etc/apt/sources.list && \
+    apt-get update && apt-get install -y \
     build-essential stgit u-boot-tools util-linux \
     gperf device-tree-compiler python-all-dev xorriso \
     autoconf automake bison flex texinfo libtool libtool-bin \
     realpath gawk libncurses5 libncurses5-dev bc \
     dosfstools mtools pkg-config git wget help2man libexpat1 \
     libexpat1-dev fakeroot python-sphinx rst2pdf \
-    libefivar-dev libnss3-tools libnss3-dev libpopt-dev \
-    libssl-dev sbsigntool uuid-runtime uuid-dev cpio \
-    bsdmainutils curl sudo unzip
+    libefivar-dev libnss3-tools libnss3-dev libpopt-dev libelf-dev \
+    libssl-dev sbsigntool uuid-runtime uuid-dev cpio gnu-efi \
+    bsdmainutils curl sudo unzip gettext autopoint locales \
+    gnupg2 monkeysphere libfile-slurp-perl && \
+    sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
+    git clone --depth 1 --branch v1.9.2 https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git /tmp/efitools && \
+    make -C /tmp/efitools && \
+    cp /tmp/efitools/cert-to-efi-sig-list /tmp/efitools/sign-efi-sig-list \
+       /tmp/efitools/sig-list-to-certs /tmp/efitools/efi-readvar /tmp/efitools/efi-updatevar \
+       /usr/local/bin/ && \
+    mkdir -p /usr/share/efitools/efi && \
+    cp /tmp/efitools/efi/*.efi /usr/share/efitools/efi/ 2>/dev/null || true && \
+    rm -rf /tmp/efitools
 
 # Create build user
 RUN useradd -m -s /bin/bash build && \
@@ -25,8 +41,10 @@ RUN useradd -m -s /bin/bash build && \
 
 WORKDIR /home/build
 
-# Add /sbin and /usr/sbin to build user's path
-RUN echo export PATH="/sbin:/usr/sbin:\$PATH" >> .bashrc
+# Add /sbin and /usr/sbin to build user's path; uClibc needs UTF-8 locale
+RUN echo export PATH="/sbin:/usr/sbin:\$PATH" >> .bashrc && \
+    echo export LANG=en_US.UTF-8 >> .bashrc && \
+    echo export LC_ALL=en_US.UTF-8 >> .bashrc
 
 # Add common files, like .gitconfig
 COPY home .


### PR DESCRIPTION
## Summary
- Debian 9 (stretch) is EOL; switch apt to `archive.debian.org` and disable Valid-Until checks
- Install missing build dependencies (`gettext`, `autopoint`, `libelf-dev`, `locales`, `gnupg2`, `monkeysphere`, `gnu-efi`, `libfile-slurp-perl`)
- Build efitools v1.9.2 from source (not available via stretch apt)
- Set UTF-8 locale for the build user (required by the toolchain)

## Test plan
- [x] `docker build -t onie-build-env:pr-test .` in `contrib/build-env` succeeds
- [x] `./onie-encrypt.sh generate-all-keys` + `make shim` + `make shim-self-sign`
- [x] `make -jN MACHINE=kvm_x86_64 all recovery-iso SHIM_PREBUILT_DIR=.../safe-place`
- [x] Produces `onie-recovery-x86_64-kvm_x86_64-r0.iso`