### PR TITLE
ci: harden the kvm_x86_64 build/boot workflow and boot harness

### DIFF
--- a/.github/onie-build/Dockerfile
+++ b/.github/onie-build/Dockerfile
@@ -87,14 +87,35 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 #       (https://github.com/moby/moby/issues/5419#issuecomment-41478290)
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -g $GID build && \
-    useradd -l -m -u $UID -g $GID -s /bin/bash build && \
-    chown -R build:build /onie
+# Reuse the host's primary group when that GID is already taken in the
+# image.  Debian fills the low GID range with system groups (30 dip, 50
+# staff, 100 users), so insisting on creating our own group makes the image
+# unbuildable for anyone whose primary group lands there -- common with
+# central/NFS accounts, and the norm on macOS hosts (GID 20 = dialout here).
+# When the group is reused, "build" no longer exists as a group name, so
+# chown by numeric id.
+RUN if getent group "$GID" >/dev/null; then \
+        echo "GID $GID is $(getent group "$GID" | cut -d: -f1); reusing it"; \
+    else \
+        groupadd -g "$GID" build; \
+    fi && \
+    useradd -l -m -u "$UID" -g "$GID" -s /bin/bash build && \
+    chown -R "$UID:$GID" /onie
+
+# /sbin and /usr/sbin hold tools the build invokes.  Set this in two places
+# so it holds however the image is invoked:
+#   ENV        -- non-login shells (docker run <cmd>, bash -c)
+#   profile.d  -- login shells.  Debian's /etc/profile *replaces* PATH for
+#                 non-root users with one that omits both sbin dirs, and it
+#                 does so before sourcing profile.d, so the snippet wins.
+# ~/.bashrc, which this used to use, works for neither: Debian's default
+# .bashrc returns early when the shell is not interactive, so under the
+# workflow's "bash -lc" the PATH line was never reached.
+ENV PATH="/sbin:/usr/sbin:${PATH}"
+RUN printf '%s\n' 'export PATH="/sbin:/usr/sbin:$PATH"' \
+        > /etc/profile.d/00-onie-sbin.sh
 
 USER build
-
-# /sbin and /usr/sbin hold tools the build invokes.
-RUN echo 'export PATH="/sbin:/usr/sbin:$PATH"' >> ~/.bashrc
 
 # The build runs git commands; give it a default identity.
 RUN git config --global user.email "build@example.com" && \

--- a/.github/workflows/build-onie.yml
+++ b/.github/workflows/build-onie.yml
@@ -10,21 +10,96 @@ name: Build ONIE (kvm_x86_64)
 # confirm the change still builds, and the kvm_x86_64 image depends on far
 # more than the build files (installer/, rootconf/, patches/, ...), so path
 # filtering would risk skipping validation on build-affecting changes.
+#
+# A push to a branch that already has an open pull request IN THIS repository
+# fires both events and ran the whole pipeline twice; the concurrency group
+# below cannot collapse them, because the two events carry different refs
+# (refs/heads/<branch> vs refs/pull/<n>/merge).  The "gate" job below drops the
+# duplicate push run.  See the comment there for why this is a query rather
+# than a branch filter on "push:".
 on:
   workflow_dispatch:
   push:
   pull_request:
 
-# Cancel an in-progress run when a newer commit is pushed to the same ref,
-# so stacked pushes don't pile up concurrent builds.
+# Cancel an in-progress run when a newer commit is pushed to the same ref, so
+# stacked pushes don't pile up concurrent builds.  Runs on the long-lived
+# branches are never cancelled -- those results are the integration signal.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/master'
+    && github.ref != 'refs/heads/onie-modernization-2026' }}
+
+# Nothing here writes to the repository; without this the workflow inherits
+# the repository default token scope, which is read/write in many repos.
+permissions:
+  contents: read
 
 jobs:
+  # Skip a push-triggered run when an open pull request in this repository
+  # already covers the commit -- the pull_request run is the one that reports
+  # on the PR, so the push run is pure duplicate cost.
+  #
+  # Deliberately a query rather than restricting "push:" to the long-lived
+  # branches.  A branch filter also removes CI from every topic branch in a
+  # FORK, and that is where this workflow does most of its pre-submit work: a
+  # fork's pull requests are opened against the upstream repository, so they
+  # raise no pull_request event in the fork, and workflow_dispatch is not
+  # available there either unless the workflow is also on the fork's default
+  # branch.  A branch filter would leave such a branch with no CI at all.  The
+  # query has no such blind spot: in a fork it simply finds no pull request and
+  # the push run proceeds.
+  #
+  # Only "build" needs to depend on this -- the other jobs chain from it, and a
+  # skipped job skips its dependents.
+  gate:
+    name: Check for a duplicate run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Job-level permissions replace the workflow-level block rather than adding
+    # to it; this job reads pull requests and checks out nothing.
+    permissions:
+      pull-requests: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Decide whether this run is needed
+        id: check
+        # Everything from the event context is passed via env rather than
+        # interpolated into the script body, so a branch name can never be
+        # parsed as shell.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [ "$EVENT" != push ]; then
+            echo "$EVENT is not a push; running."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          open="$(gh api --method GET "repos/$REPO/pulls" \
+                    -f state=open -f head="$OWNER:$BRANCH" --jq 'length')"
+          if [ "${open:-0}" -gt 0 ]; then
+            echo "An open pull request in $REPO already covers $BRANCH;" \
+                 "its pull_request run reports on it.  Skipping the push run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open pull request in $REPO for $BRANCH; running."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build kvm_x86_64
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
+    # A cold build (toolchain + full image) is roughly 45-60 min; cap it so a
+    # wedged build fails here instead of burning the 6-hour GitHub default.
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -71,6 +146,17 @@ jobs:
       # environment the toolchain is built in.  No loose restore-keys: any
       # input change forces a clean rebuild rather than restoring a
       # mismatched toolchain.
+      #
+      # kernel-download.make and the arch/machine makefiles are hashed because
+      # xtools.make derives
+      #   XTOOLS_VERSION = $(ONIE_ARCH)-g$(GCC_VERSION)-lnx$(LINUX_RELEASE)-...
+      # (and seds CT_LINUX_VERSION into the generated toolchain .config), while
+      # LINUX_RELEASE lives in kernel-download.make and ONIE_ARCH in
+      # machine/kvm_x86_64/machine.make.  With those omitted a kernel bump kept
+      # HITTING this key while the build/x-tools/<XTOOLS_VERSION> directory name
+      # changed underneath it: the restored toolchain was the wrong one, "make
+      # xtools" rebuilt from scratch, and the save step -- gated on a cache miss
+      # -- skipped it, so every later run paid the same rebuild forever.
       - name: Restore cross-toolchain cache
         id: xtools-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -82,7 +168,17 @@ jobs:
             build/x-tools/*/stamp
             build/x-tools/*/install
             build/x-tools/*/build/.config
-          key: onie-xtools-kvm_x86_64-${{ hashFiles('build-config/make/xtools.make', 'build-config/make/crosstool-ng.make', 'build-config/make/compiler.make', 'build-config/conf/crosstool/**', 'patches/crosstool-NG/**', '.github/onie-build/Dockerfile') }}
+          key: >-
+            onie-xtools-kvm_x86_64-${{ hashFiles(
+            'build-config/make/xtools.make',
+            'build-config/make/crosstool-ng.make',
+            'build-config/make/compiler.make',
+            'build-config/make/kernel-download.make',
+            'build-config/arch/x86_64.make',
+            'machine/kvm_x86_64/machine.make',
+            'build-config/conf/crosstool/**',
+            'patches/crosstool-NG/**',
+            '.github/onie-build/Dockerfile') }}
 
       # ONIE drives its build with stamp files compared by mtime.  A fresh
       # checkout gives every repo source file a current mtime, which is newer
@@ -122,14 +218,52 @@ jobs:
                build/x-tools/*/build/.config \
                -type f -exec touch -t "$ts" {} +
 
+      # Record which toolchains the cache restored, so the check after the
+      # build can tell whether "make xtools" had to build one the cache did not
+      # contain -- the symptom of a key that is still missing an input.
+      - name: Record restored toolchain set
+        id: xtools-before
+        if: steps.xtools-cache.outputs.cache-hit == 'true'
+        run: |
+          echo "dirs=$(ls -d build/x-tools/*/install 2>/dev/null | sort | tr '\n' ' ')" \
+            >> "$GITHUB_OUTPUT"
+
+      # No --privileged: the Dockerfile ends with "USER build", so the build
+      # runs unprivileged and cannot use any capability --privileged grants.
+      # It was ineffective as well as an unnecessary escalation -- the
+      # documented flow (contrib/build-env) builds unprivileged with fakeroot,
+      # and the image build uses mtools/fakeroot rather than loop mounts.
       - name: Build cross toolchain
         run: |
-          docker run --rm --privileged \
+          docker run --rm \
             -v "${PWD}:/onie" \
             onie-build-env \
             bash -lc 'cd build-config && make -j"$(nproc)" \
               MACHINE=kvm_x86_64 \
               xtools'
+
+      # A cache hit that nonetheless had to build a new toolchain means the key
+      # did not cover something that changed XTOOLS_VERSION.  The save step
+      # cannot rescue that run -- the primary key already exists and GitHub
+      # will not overwrite it -- so warn instead of rebuilding silently forever.
+      - name: Check whether the cached toolchain was actually reused
+        if: steps.xtools-cache.outputs.cache-hit == 'true'
+        # Passed via env rather than interpolated into the script body, so the
+        # step output can never be parsed as shell.
+        env:
+          RESTORED_DIRS: ${{ steps.xtools-before.outputs.dirs }}
+        run: |
+          now="$(ls -d build/x-tools/*/install 2>/dev/null | sort | tr '\n' ' ')"
+          if [ "$now" != "$RESTORED_DIRS" ]; then
+            echo "::warning title=Stale cross-toolchain cache key::" \
+                 "Cache key hit but 'make xtools' built a toolchain the cache" \
+                 "did not contain (restored: [$RESTORED_DIRS], now: [$now])." \
+                 "XTOOLS_VERSION changed without changing the cache key, so this" \
+                 "toolchain cannot be saved and every run will rebuild it." \
+                 "Add the changed input to the 'Restore cross-toolchain cache' key."
+          else
+            echo "Cached toolchain reused as-is: $now"
+          fi
 
       # Save only on a cache miss, and only after the toolchain build above
       # succeeded (default if: success()), so a broken toolchain is never
@@ -148,9 +282,10 @@ jobs:
             build/x-tools/*/build/.config
           key: ${{ steps.xtools-cache.outputs.cache-primary-key }}
 
+      # No --privileged, as above.
       - name: Build ONIE
         run: |
-          docker run --rm --privileged \
+          docker run --rm \
             -v "${PWD}:/onie" \
             onie-build-env \
             bash -lc 'cd build-config && \
@@ -204,6 +339,9 @@ jobs:
     name: Boot test kvm_x86_64
     needs: build
     runs-on: ubuntu-latest
+    # Three boots at up to 300s each plus package install and artifact
+    # download; this catches a QEMU that outlives the harness's own TIMEOUT.
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -268,6 +406,9 @@ jobs:
     # time, keeping CI resource use low.
     needs: boot-test
     runs-on: ubuntu-latest
+    # Three boot stages at up to 600s each, plus the embed and install work in
+    # between.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/emulation/ci-boot-test.sh
+++ b/emulation/ci-boot-test.sh
@@ -20,13 +20,20 @@
 #               enrolled.  shim still chainloads grub->kernel, so it validates
 #               "does it boot" independent of the SB signature chain.  Boots on
 #               the default 'pc' machine (ONIE's onie-vm.sh reference machine).
+#               Also asserts the guest does NOT report secure boot as active.
 #   secureboot  Secure-Boot-ENFORCED: enrolls the demonstration PK/KEK/db from
 #               KEYS_DIR into an OVMF varstore (virt-fw-vars), boots the secboot
 #               OVMF firmware on 'q35,smm=on' with the flash secure flag, and
 #               asserts ONIE boots -- i.e. the shim/grub/kernel signing chain
-#               verifies under enforcement.  Also runs a NEGATIVE control with
-#               the db omitted, which MUST be rejected (proves SB is enforcing,
-#               not merely permissive).
+#               verifies under enforcement.  Enforcement itself is asserted from
+#               inside the guest ("Info: Secure Boot: Active."), so a varstore
+#               that failed to enroll cannot pass merely by booting unverified.
+#               Also runs a NEGATIVE control with the db omitted, which MUST be
+#               rejected (proves SB is enforcing, not merely permissive).
+#
+# Each boot writes three logs beside <serial_log>: the serial console itself,
+# -firmware.log (the OVMF debug console, empty unless the host has a debug OVMF
+# build) and -qemu-stderr.log.
 #
 # Usage:  ci-boot-test.sh <recovery.iso> [timeout_secs]
 # Env:    SERIAL_LOG=<path>   serial log path (default ./onie-boot-serial.log)
@@ -52,6 +59,21 @@ BOOT_MODE="${BOOT_MODE:-relaxed}"
 #               or, unexpectedly, reached GRUB/ONIE (caught by the assertions).
 READY_BOOT='Please press Enter to activate this console|discover: (ONIE|Rescue)|Starting ONIE Service Discovery'
 READY_NEG='Security Violation|Access Denied|verification failed|GNU GRUB|ONIE: (OS Install|Rescue) Mode'
+
+# A milestone only ONIE userspace can produce.  The strings this check used to
+# match -- "ONIE: Rescue Mode ..." and "Version   :" -- are echoed by GRUB
+# itself, from the menuentry and onie_entry_end in
+# build-config/recovery/grub-iso.cfg, so both appear before the kernel is even
+# loaded: the check duplicated "GRUB reached" and proved nothing about
+# userspace.  "Info: BIOS mode:" is printed unconditionally during sysinit by
+# rootconf/grub-arch/sysroot-lib-onie/init-arch and cannot come from GRUB.
+USERSPACE_UP='Info: BIOS mode:'
+
+# The same init-arch reports the firmware's Secure Boot state, read from the
+# SecureBoot EFI variable via efivar.  Asserting it in the guest is direct
+# evidence the firmware is enforcing, rather than inferring enforcement from
+# the negative control's silence.
+SB_ACTIVE='Info: Secure Boot: Active\.'
 
 [ -r "$ISO" ] || { echo "ERROR: ISO not readable: $ISO" >&2; exit 2; }
 
@@ -79,6 +101,34 @@ done
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+# vCPU count: two with hardware acceleration, one on TCG.  Pure emulation
+# starves the guest badly enough that an SB-enforced boot with two vCPUs never
+# reaches userspace -- it dies in "rcu: INFO: rcu_sched detected stalls" and
+# burns the whole timeout.  With identical firmware, varstore and ISO the same
+# boot completes in ~31s at -smp 1.  CI has /dev/kvm and still gets two; this
+# only affects the accel=kvm:tcg fallback used by local runs.
+if [ -w /dev/kvm ]; then SMP=2; else SMP=1; fi
+
+# Firmware (OVMF debug console) log that pairs with a given serial log.
+fw_log_for() { echo "${1%.log}-firmware.log"; }
+
+# Capture the OVMF debug console as a second evidence channel for why the
+# firmware stopped.  A release OVMF -- what Ubuntu ships, so what CI uses --
+# emits nothing here, and its rejection line does reach ttyS0 anyway
+# ("BdsDxe: failed to load Boot0001 ...: Access Denied"), so this is
+# belt-and-braces for a debug OVMF build rather than the only place a rejection
+# can appear.  0x402 is the I/O port edk2 debug builds log to.  Probe for the
+# device so this stays strictly additive: on a QEMU without it we lose the
+# extra channel instead of failing every boot.  Bounded, with stdin closed, so
+# a QEMU that fails to exit cannot wedge the harness before any boot starts.
+if timeout 10 qemu-system-x86_64 -device help </dev/null 2>/dev/null \
+        | grep -q '"isa-debugcon"'; then
+    HAVE_DEBUGCON=yes
+else
+    HAVE_DEBUGCON=no
+    echo "   NOTE  QEMU has no usable isa-debugcon; firmware console not captured"
+fi
+
 # --- boot QEMU headless, serial(ttyS0) -> file, -no-reboot so a panic doesn't
 #     loop.  Polls the serial log and stops QEMU as soon as the boot reaches a
 #     terminal state (the <ready-regex>, e.g. the console prompt) or panics --
@@ -88,16 +138,41 @@ trap 'rm -rf "$WORK"' EXIT
 #     Args:  <ready-regex> <code.fd> <vars.fd> <serial_log> [extra qemu args...]
 run_qemu() {
     local ready_re="$1" code="$2" vars="$3" log="$4"; shift 4
-    : >"$log"
+    local fw_log qerr
+    fw_log="$(fw_log_for "$log")"; qerr="${log%.log}-qemu-stderr.log"
+    : >"$log"; : >"$fw_log"; : >"$qerr"
+    local -a DEBUGCON_ARGS=()
+    [ "$HAVE_DEBUGCON" = yes ] && \
+        DEBUGCON_ARGS=(-debugcon "file:$fw_log" -global isa-debugcon.iobase=0x402)
+    # Keep QEMU's stderr rather than discarding it, so a QEMU that never ran can
+    # be told apart from a firmware that refused the image -- previously both
+    # left an empty serial log, which is what let a broken harness score as a
+    # successful secure-boot rejection.  It also surfaces "Could not access KVM
+    # kernel module ... falling back to tcg", otherwise invisible.
     qemu-system-x86_64 \
-        -m 2048 -smp 2 \
+        -m 2048 -smp "$SMP" \
         -drive if=pflash,format=raw,readonly=on,file="$code" \
         -drive if=pflash,format=raw,file="$vars" \
         -cdrom "$ISO" -boot d \
         -netdev user,id=onienet -device virtio-net,netdev=onienet \
         -display none -serial "file:$log" -no-reboot \
-        "$@" >/dev/null 2>&1 &
-    local qpid=$! t=0
+        "${DEBUGCON_ARGS[@]}" \
+        "$@" >/dev/null 2>"$qerr" &
+    local qpid=$! t=0 rc=0
+    # A QEMU that dies this early never ran the firmware: bad arguments, a
+    # malformed varstore, a missing device model.  That is a harness error, not
+    # a verdict about the image, so fail loudly instead of letting a silent
+    # serial log be scored as a pass (relaxed) or a rejection (negative
+    # control).  Any early exit counts, including a successful one: rc=0 still
+    # means no boot happened.
+    sleep 2
+    if ! kill -0 "$qpid" 2>/dev/null ; then
+        wait "$qpid" 2>/dev/null
+        rc=$?
+        echo "ERROR: QEMU exited immediately (rc=$rc) -- harness error, not a boot result" >&2
+        sed 's/^/   /' "$qerr" >&2
+        exit 2
+    fi
     while kill -0 "$qpid" 2>/dev/null; do
         if grep -Eaq "$ready_re" "$log" || grep -aq 'Kernel panic' "$log"; then break; fi
         [ "$t" -ge "$TIMEOUT" ] && break
@@ -115,16 +190,38 @@ chk() {  # <logfile> <label> <extended-regex>
     if grep -Eaq "$3" "$1"; then echo "   PASS  $2"
     else echo "   FAIL  $2   (/$3/)"; fail=1; fi
 }
-assert_booted() {  # <logfile>
-    local log="$1"
+assert_booted() {  # <logfile> [expected secure boot state: active|inactive]
+    local log="$1" want_sb="${2:-}"
     [ -s "$log" ] || { echo "   FAIL  no serial output captured"; fail=1; return; }
     chk "$log" "GRUB reached"   'GNU GRUB|Booting .ONIE'
-    chk "$log" "ONIE userspace" 'ONIE: (OS Install|Rescue) Mode|^Version   :'
-    chk "$log" "console up"     'Please press Enter to activate this console|discover: (ONIE|Rescue)|Starting ONIE Service Discovery'
+    # The GRUB echoes this check used to match are still covered -- by "GRUB
+    # reached" above, where they belong.
+    chk "$log" "ONIE userspace" "$USERSPACE_UP"
+    chk "$log" "console up"     "$READY_BOOT"
     if grep -aq 'Kernel panic' "$log"; then
         echo "   FAIL  kernel panicked:"; grep -a 'Kernel panic' "$log" | sed 's/^/         /'
         fail=1
     fi
+    # Have the guest confirm the firmware's Secure Boot state.  In enforced mode
+    # this is the assertion that makes the run meaningful: without it a varstore
+    # that failed to enroll simply booted with secure boot off and the "must
+    # boot" check passed for the wrong reason.
+    case "$want_sb" in
+        active)
+            chk "$log" "secure boot ENFORCED (guest reports Active)" "$SB_ACTIVE"
+            ;;
+        inactive)
+            # Assert the absence of enforcement rather than the exact
+            # "Disabled." line: a firmware exposing no SecureBoot variable at
+            # all prints neither, and that is still a valid relaxed boot.
+            if grep -Eaq "$SB_ACTIVE" "$log"; then
+                echo "   FAIL  guest reports secure boot Active in the relaxed run"
+                fail=1
+            else
+                echo "   PASS  secure boot not enforced (as expected when relaxed)"
+            fi
+            ;;
+    esac
 }
 dump_tail() {  # <logfile>
     echo "---- serial tail ($1) ----"
@@ -132,19 +229,41 @@ dump_tail() {  # <logfile>
         | grep -avE '^\s*$' | tail -25
 }
 
+# --- build an OVMF varstore with keys enrolled, failing if enrollment fails ---
+# The previous inline invocation piped virt-fw-vars through "| sed | grep ...
+# || true", which discarded its exit status twice over (the pipeline reported
+# grep's status, and "|| true" swallowed even that).  A failed enrollment
+# therefore produced an un-enrolled varstore and the run continued, so the
+# "must boot" assertion passed with secure boot simply off.
+# Args:  <output varstore> <virt-fw-vars key args...>
+enroll_varstore() {
+    local out="$1"; shift
+    local elog="$out.enroll.log"
+    if ! virt-fw-vars --input "$OVMF_VARS_SRC" --output "$out" \
+            "$@" --secure-boot >"$elog" 2>&1 ; then
+        echo "ERROR: virt-fw-vars failed to build $out:" >&2
+        sed 's/^/   /' "$elog" >&2
+        exit 2
+    fi
+    [ -s "$out" ] || { echo "ERROR: virt-fw-vars produced an empty varstore: $out" >&2; exit 2; }
+    grep -Ei 'error|fail|set pk|add (kek|db)|secure' "$elog" | sed 's/^/   /' || true
+}
+
 echo "== ONIE boot-test =="
 echo "   ISO        : $ISO"
 echo "   mode       : $BOOT_MODE"
 echo "   serial log : $SERIAL_LOG"
 echo "   timeout    : ${TIMEOUT}s"
-echo "   accel      : kvm:tcg ($([ -w /dev/kvm ] && echo 'KVM' || echo 'TCG (no /dev/kvm)'))"
+echo "   accel      : kvm:tcg ($([ -w /dev/kvm ] && echo 'KVM' || echo 'TCG (no /dev/kvm)')), ${SMP} vcpu"
 
 if [ "$BOOT_MODE" = "relaxed" ]; then
     echo "   OVMF code  : $OVMF_CODE (SB-relaxed)"
     cp "$OVMF_VARS_SRC" "$WORK/vars.fd"   # writable per-run varstore copy
     run_qemu "$READY_BOOT" "$OVMF_CODE" "$WORK/vars.fd" "$SERIAL_LOG" -machine accel=kvm:tcg
     echo "== milestones =="
-    assert_booted "$SERIAL_LOG"
+    # This mode uses the non-secboot OVMF build, so secure boot is absent rather
+    # than merely permissive -- assert the guest agrees.
+    assert_booted "$SERIAL_LOG" inactive
 
 elif [ "$BOOT_MODE" = "secureboot" ]; then
     # --- Secure-Boot-ENFORCED validation ---
@@ -168,16 +287,18 @@ elif [ "$BOOT_MODE" = "secureboot" ]; then
 
     # Positive: PK + KEK + db (incl. the SW-database key that signs shim).
     echo "== [secureboot] enrolling PK/KEK/db (positive) =="
-    virt-fw-vars --input "$OVMF_VARS_SRC" --output "$WORK/vars.pos.fd" \
+    enroll_varstore "$WORK/vars.pos.fd" \
         --set-pk  "$SB_OWNER_GUID" "$PK" \
         --add-kek "$SB_OWNER_GUID" "$KEK_SW" --add-kek "$SB_OWNER_GUID" "$KEK_HW" \
-        --add-db  "$SB_OWNER_GUID" "$DB_SW"  --add-db  "$SB_OWNER_GUID" "$DB_HW" \
-        --secure-boot 2>&1 | sed 's/^/   /' | grep -Ei 'error|fail|add (pk|kek|db)|secure' || true
+        --add-db  "$SB_OWNER_GUID" "$DB_SW"  --add-db  "$SB_OWNER_GUID" "$DB_HW"
 
     echo "== [secureboot] booting SB-ENFORCED (must boot) =="
     run_qemu "$READY_BOOT" "$OVMF_CODE_SB" "$WORK/vars.pos.fd" "$SERIAL_LOG" "${SB_QEMU_ARGS[@]}"
     echo "== milestones =="
-    assert_booted "$SERIAL_LOG"
+    # Requiring "Info: Secure Boot: Active." here is what upgrades the negative
+    # control below from "nothing appeared" to real evidence: we know the
+    # firmware was enforcing when it refused the image it had no db for.
+    assert_booted "$SERIAL_LOG" active
     # An SB rejection of our own signed chain is a hard fail (chain broke).
     if grep -Eaiq 'Security Violation|Access Denied|verification failed|image (failed|did not pass)' "$SERIAL_LOG"; then
         echo "   FAIL  secure-boot rejected the signed image (chain broken):"
@@ -190,14 +311,17 @@ elif [ "$BOOT_MODE" = "secureboot" ]; then
     # boots anyway, SB is not actually being enforced -> the positive result
     # is meaningless, so this is a hard fail.
     NEG_LOG="${SERIAL_LOG%.log}-negative.log"; [ "$NEG_LOG" = "$SERIAL_LOG" ] && NEG_LOG="$SERIAL_LOG.negative"
+    NEG_FW_LOG="$(fw_log_for "$NEG_LOG")"
     echo "== [secureboot] enrolling PK/KEK, NO db (negative control) =="
-    virt-fw-vars --input "$OVMF_VARS_SRC" --output "$WORK/vars.neg.fd" \
+    enroll_varstore "$WORK/vars.neg.fd" \
         --set-pk  "$SB_OWNER_GUID" "$PK" \
-        --add-kek "$SB_OWNER_GUID" "$KEK_SW" \
-        --secure-boot 2>&1 | sed 's/^/   /' | grep -Ei 'error|fail|secure' || true
+        --add-kek "$SB_OWNER_GUID" "$KEK_SW"
     echo "== [secureboot] booting NEGATIVE (must be REJECTED) =="
-    # Negative boot rejects fast; cap its wait so it doesn't burn the full timeout.
-    ( TIMEOUT=$(( TIMEOUT < 90 ? TIMEOUT : 90 )); run_qemu "$READY_NEG" "$OVMF_CODE_SB" "$WORK/vars.neg.fd" "$NEG_LOG" "${SB_QEMU_ARGS[@]}" )
+    # Negative boot rejects fast; cap its wait so it doesn't burn the full
+    # timeout.  The "|| exit" matters: run_qemu now aborts on a harness error,
+    # and inside a subshell that would otherwise end only the subshell and let
+    # the negative assertions score a broken QEMU as a rejection.
+    ( TIMEOUT=$(( TIMEOUT < 90 ? TIMEOUT : 90 )); run_qemu "$READY_NEG" "$OVMF_CODE_SB" "$WORK/vars.neg.fd" "$NEG_LOG" "${SB_QEMU_ARGS[@]}" ) || exit $?
     echo "== negative assertions =="
     if grep -Eaq 'GNU GRUB|ONIE: (OS Install|Rescue) Mode|Please press Enter to activate this console' "$NEG_LOG"; then
         echo "   FAIL  ONIE booted with db absent -> secure boot is NOT being enforced"
@@ -205,12 +329,26 @@ elif [ "$BOOT_MODE" = "secureboot" ]; then
     else
         echo "   PASS  ONIE did not boot without db (as required)"
     fi
-    if grep -Eaiq 'Security Violation|Access Denied|verification failed|image (failed|did not pass)' "$NEG_LOG"; then
+    # Search the firmware console as well as the serial log, and say plainly
+    # which kind of evidence we ended up with.  A release OVMF does put its
+    # BdsDxe "Access Denied" line on ttyS0, so the serial search is normally the
+    # one that matches; the firmware log adds detail only on a debug build.
+    REJECT_RE='Security Violation|Access Denied|verification failed|image (failed|did not pass)'
+    if grep -Eaiq "$REJECT_RE" "$NEG_LOG" "$NEG_FW_LOG" 2>/dev/null; then
         echo "   PASS  firmware rejected the untrusted image:"
-        grep -Eai 'Security Violation|Access Denied|verification failed' "$NEG_LOG" | sed 's/^/         /' | head -3
+        grep -Eai "$REJECT_RE" "$NEG_LOG" "$NEG_FW_LOG" 2>/dev/null | sed 's/^/         /' | head -3
+    elif [ -s "$NEG_FW_LOG" ]; then
+        # The firmware talked to us but never said why it stopped.  Combined
+        # with the enforced positive run above (which proved SecureBoot was
+        # Active), absence-of-boot is sound evidence.
+        echo "   NOTE  no explicit rejection string on the firmware console;"
+        echo "         relying on absence-of-boot plus the enforced positive run"
     else
-        # No explicit rejection string AND it didn't boot -- acceptable, but note it.
-        echo "   NOTE  no explicit rejection string; relying on absence-of-boot above"
+        # No serial output, no firmware output: expected on a release OVMF
+        # build, but it means the only evidence is silence, so say so rather
+        # than implying a verified rejection.
+        echo "   NOTE  firmware console was empty (release OVMF build?);"
+        echo "         rejection inferred from absence-of-boot only"
     fi
     [ -f "$NEG_LOG" ] && [ "$fail" -ne 0 ] && dump_tail "$NEG_LOG"
 


### PR DESCRIPTION
Follow-up fixes to the CI added in `1a24708f`, all found in review by @mshych on #1126. They are here rather than in that PR because they fix already-merged code, which is how he asked for them to be split.

Every item was re-verified against the tree before being applied; the notes are his numbering.

**Workflow**

1. **Cross-toolchain cache key omitted inputs that change the toolchain.** `xtools.make:25` derives `XTOOLS_VERSION = $(ONIE_ARCH)-g$(GCC_VERSION)-lnx$(LINUX_RELEASE)-...`, but `LINUX_RELEASE` is defined in `build-config/make/kernel-download.make:22` and `ONIE_ARCH` in `machine/kvm_x86_64/machine.make:10` — neither was hashed. A kernel bump therefore keeps *hitting* the key while the `build/x-tools/<XTOOLS_VERSION>` directory name changes underneath it: the restored toolchain is the wrong one, `make xtools` rebuilds from scratch, and the save step (gated on a cache miss) skips it, so every later run pays the same rebuild. Silent and self-perpetuating. `GCC_VERSION`/`XTOOLS_LIBC` default in `crosstool-ng.make`, which is already hashed, so those two were the only gaps. Also adds his guard: a `::warning` when a cache hit still had to build a toolchain.

   This is the one worth landing before the kernel PR (#1130) does exactly this bump.

2. **`push:` and `pull_request:` both unfiltered** ran the pipeline twice for every push to a branch with an open PR; the concurrency group can't collapse them because the refs differ. Fixed, but **not** with the branch filter that was suggested — see the note at the bottom. A small `gate` job now skips the push run when an open PR in the same repository already covers the commit.

3. **`--privileged` dropped** from both `docker run` invocations. The Dockerfile ends with `USER build`, so the build is unprivileged and can't use anything `--privileged` grants. Confirmed the build needs no loop mounts — it goes through `fakeroot` and `mtools`, and `onie-mk-iso.sh` hardcodes `/sbin/mkdosfs`.

4. **`permissions: contents: read`** at workflow level plus `timeout-minutes` on each job (180/45/60).

**Dockerfile**

5. **`groupadd -g $GID` failed when the host GID already exists.** Confirmed in `debian:11`: `groupadd -g 30 build` → `rc=4, GID '30' already exists`. The low range is full of system groups (30 dip, 50 staff, 100 users), which is common with central/NFS accounts and the norm on macOS (GID 20 = dialout there). CI never sees it because the runner's GID is free. Reuses the group when the GID is taken, and chowns by numeric id since `build` then isn't a group name. Test-built at GID 30 and GID 1001 — both work now.

10. **The `/sbin:/usr/sbin` PATH line never took effect.** It was appended to `~/.bashrc`, and Debian's default `.bashrc` returns early for non-interactive shells, so `bash -lc` never reaches it. As he noted, `ENV` alone isn't enough either: `/etc/profile` lines 5–9 *replace* PATH for non-root users with one that omits both sbin dirs. Verified in the image — `bash -lc` as non-root gets `/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games` and `blkid` is off PATH. Fixed with `ENV` plus an `/etc/profile.d` snippet (profile.d is sourced at line 27, after the reset). Verified both login and non-login shells now resolve `/sbin/blkid`.

**emulation/ci-boot-test.sh**

9. **The "ONIE userspace" milestone was matched by GRUB output.** `build-config/recovery/grub-iso.cfg:32` echoes `"ONIE: Rescue Mode ..."` and `:24` echoes `"Version   : ..."`, both before the kernel loads — so the check duplicated "GRUB reached". Now asserts `Info: BIOS mode:`, printed unconditionally from `rootconf/grub-arch/sysroot-lib-onie/init-arch:130`.

6. **secureboot mode never checked that Secure Boot was enforced.** Now asserts the guest's own `Info: Secure Boot: Active.` (`init-arch:121`, read from the SecureBoot EFI variable via efivar), and asserts its absence on the relaxed run.

7. **A failed `virt-fw-vars` was silently ignored** — piped through `| sed | grep ... || true`, which dropped its status twice over. Enrolment moved into a helper that fails the run.

8. **A QEMU that never started could be scored as a successful SB rejection.** QEMU's stderr is kept and an immediate exit is now a hard error. Verified with a stub QEMU that exits 1: the harness prints the stderr and exits 2, where before it reported `FAIL no serial output captured` / `PASS ONIE did not boot without db`. Also captures the OVMF debug console when `isa-debugcon` is present — belt-and-braces, since as he corrected himself the release OVMF does put its `BdsDxe: ... Access Denied` line on ttyS0.

11. **One vCPU when `/dev/kvm` is unusable**, so the documented `accel=kvm:tcg` fallback works for local runs. CI has `/dev/kvm` and still gets two.

Smoke-tested locally against real OVMF: logs are written as expected, the firmware console is empty on Ubuntu's release OVMF (as he predicted), and the milestone assertions behave correctly on a non-ONIE ISO.


---

### Note on the duplicate-run fix

@mshych suggested restricting `push:` to the long-lived branches, which is the usual answer. I took a different route because the filter has a blind spot that bites this exact patch series.

A fork's pull requests are opened against the *upstream* repository, so they raise no `pull_request` event in the fork; the fork's only trigger is `push`. Filtering `push` by branch name therefore leaves every topic branch in a fork with **no CI at all**, and `workflow_dispatch` cannot fill the gap unless the workflow also exists on the fork's default branch (it does not — this workflow lives on `onie-modernization-2026`, and forks default to `master`).

That is not hypothetical: with the branch filter applied, pushing this very branch to my fork produced zero runs, which is how I noticed.

The `gate` job targets the actual condition instead — "an open PR here already covers this commit" — so it drops the duplicate upstream while a fork, where the query finds nothing, keeps full push CI. Verified on the fork: `No open pull request in bhouse-nexthop/onie for bhouse.ci-review-fixes; running.` Only `build` depends on the gate; the other jobs chain from it and skip automatically.

If you would rather have the simple branch filter, say so and I will switch it — the tradeoff is that fork-based development loses pre-submit CI.